### PR TITLE
Add header submenu for reset and exit

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Button, Modal, StyleSheet, View } from 'react-native';
+import { Button, Modal, StyleSheet, View, Pressable } from 'react-native';
 import { useRouter } from 'expo-router';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 import { DPad } from '@/components/DPad';
 import { ThemedText } from '@/components/ThemedText';
@@ -11,6 +12,8 @@ export default function PlayScreen() {
   const router = useRouter();
   const { state, move, reset } = useGame();
   const [showResult, setShowResult] = useState(false);
+  // メニュー表示フラグ。true のときサブメニューを表示
+  const [showMenu, setShowMenu] = useState(false);
 
   useEffect(() => {
     if (state.player[0] === state.maze.goal[0] && state.player[1] === state.maze.goal[1]) {
@@ -24,10 +27,49 @@ export default function PlayScreen() {
     router.replace('/');
   };
 
+  // Reset Maze 選択時に呼ばれる
+  const handleReset = () => {
+    setShowMenu(false);
+    reset();
+  };
+
+  // Exit to Title 選択時に呼ばれる
+  const handleExit = () => {
+    setShowMenu(false);
+    reset();
+    router.replace('/');
+  };
+
   return (
     <ThemedView style={styles.container}>
+      {/* 右上のメニューアイコン */}
+      <Pressable
+        style={styles.menuBtn}
+        onPress={() => setShowMenu(true)}
+        accessibilityLabel="メニューを開く"
+      >
+        <MaterialIcons name="more-vert" size={24} color="black" />
+      </Pressable>
       <ThemedText>位置: {state.player[0]}, {state.player[1]}</ThemedText>
       <DPad onPress={move} />
+      {/* サブメニュー本体 */}
+      <Modal transparent visible={showMenu} animationType="fade">
+        {/* 画面全体を押すと閉じるオーバーレイ */}
+        <Pressable style={styles.menuOverlay} onPress={() => setShowMenu(false)}>
+          <View style={styles.menuContent}>
+            <Button
+              title="Reset Maze"
+              onPress={handleReset}
+              accessibilityLabel="迷路を最初から"
+            />
+            <Button
+              title="Exit to Title"
+              onPress={handleExit}
+              accessibilityLabel="タイトルへ戻る"
+            />
+          </View>
+        </Pressable>
+      </Modal>
       <Modal transparent visible={showResult} animationType="fade">
         <View style={styles.modalWrapper}>
           <ThemedView style={styles.modalContent}>
@@ -44,6 +86,22 @@ export default function PlayScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 20 },
+  menuBtn: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    padding: 4,
+  },
+  menuOverlay: { flex: 1 },
+  menuContent: {
+    position: 'absolute',
+    top: 40,
+    right: 10,
+    backgroundColor: '#fff',
+    padding: 10,
+    borderRadius: 8,
+    gap: 8,
+  },
   modalWrapper: {
     flex: 1,
     justifyContent: 'center',


### PR DESCRIPTION
## Summary
- add menu button with MaterialIcons
- implement submenu actions for resetting the maze and exiting to title

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6858a4ba2a6c832c9b1615ac04273a6d