### PR TITLE
Add debug mini map toggle

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
-import { Button, Modal, StyleSheet, View, Pressable } from 'react-native';
+import { Button, Modal, StyleSheet, View, Pressable, Switch, Text } from 'react-native';
 import { useRouter } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 import { DPad } from '@/components/DPad';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { MiniMap } from '@/src/components/MiniMap';
+import type { MazeData as MazeView } from '@/src/types/maze';
 import { useGame } from '@/game/useGame';
 
 export default function PlayScreen() {
@@ -14,6 +16,8 @@ export default function PlayScreen() {
   const [showResult, setShowResult] = useState(false);
   // メニュー表示フラグ。true のときサブメニューを表示
   const [showMenu, setShowMenu] = useState(false);
+  // デバッグ用: ミニマップで迷路全体を表示するかどうか
+  const [showAll, setShowAll] = useState(false);
 
   useEffect(() => {
     if (state.player[0] === state.maze.goal[0] && state.player[1] === state.maze.goal[1]) {
@@ -52,6 +56,13 @@ export default function PlayScreen() {
       </Pressable>
       <ThemedText>位置: {state.player[0]}, {state.player[1]}</ThemedText>
       <DPad onPress={move} />
+      {showAll && (
+        <MiniMap
+          maze={state.maze as MazeView}
+          path={state.path.map(([x, y]) => ({ x, y }))}
+          pos={{ x: state.player[0], y: state.player[1] }}
+        />
+      )}
       {/* サブメニュー本体 */}
       <Modal transparent visible={showMenu} animationType="fade">
         {/* 画面全体を押すと閉じるオーバーレイ */}
@@ -67,6 +78,14 @@ export default function PlayScreen() {
               onPress={handleExit}
               accessibilityLabel="タイトルへ戻る"
             />
+            <View style={styles.toggleRow}>
+              <Text>全てを可視化</Text>
+              <Switch
+                value={showAll}
+                onValueChange={setShowAll}
+                accessibilityLabel="ミニマップに迷路全体を表示する"
+              />
+            </View>
           </View>
         </Pressable>
       </Modal>
@@ -100,6 +119,12 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: 10,
     borderRadius: 8,
+    gap: 8,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     gap: 8,
   },
   modalWrapper: {

--- a/game/useGame.ts
+++ b/game/useGame.ts
@@ -16,6 +16,7 @@ interface GameState {
   player: [number, number];
   steps: number;
   bumps: number;
+  path: [number, number][]; // 移動履歴。MiniMap 用に保存しておく
   maze: MazeData;
 }
 
@@ -29,6 +30,7 @@ const initialState: GameState = {
   player: maze.start,
   steps: 0,
   bumps: 0,
+  path: [maze.start],
   maze,
 };
 
@@ -56,7 +58,7 @@ function hasWall(
 function reducer(state: GameState, action: GameAction): GameState {
   switch (action.type) {
     case 'reset':
-      return { ...state, player: state.maze.start, steps: 0, bumps: 0 };
+      return { ...state, player: state.maze.start, steps: 0, bumps: 0, path: [state.maze.start] };
     case 'move': {
       let next: [number, number] = state.player;
       if (action.direction === 'up') next = [state.player[0], state.player[1] - 1];
@@ -66,7 +68,12 @@ function reducer(state: GameState, action: GameAction): GameState {
       if (hasWall(state.maze, state.player, next)) {
         return { ...state, bumps: state.bumps + 1 };
       }
-      return { ...state, player: next, steps: state.steps + 1 };
+      return {
+        ...state,
+        player: next,
+        steps: state.steps + 1,
+        path: [...state.path, next],
+      };
     }
     default:
       return state;

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -102,6 +102,22 @@ export function MiniMap({ maze, path, pos, flash = 2, size = 80 }: MiniMapProps)
       <Svg width={size} height={size}>
         {renderWalls()}
         {renderPath()}
+        {/* スタート位置を緑色で表示 */}
+        <Rect
+          x={(maze.start[0] + 0.25) * cell}
+          y={(maze.start[1] + 0.25) * cell}
+          width={cell * 0.5}
+          height={cell * 0.5}
+          fill="green"
+        />
+        {/* ゴール位置を赤色で表示 */}
+        <Rect
+          x={(maze.goal[0] + 0.25) * cell}
+          y={(maze.goal[1] + 0.25) * cell}
+          width={cell * 0.5}
+          height={cell * 0.5}
+          fill="red"
+        />
         {/* 現在位置を円で表示 */}
         <Circle
           cx={(pos.x + 0.5) * cell}


### PR DESCRIPTION
## Summary
- track player path in useGame
- show start and goal on MiniMap
- add "全てを可視化" toggle in play screen that reveals the mini map

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858a6160df4832c85ef8a41c087c080