### PR TITLE
Implement spec updates and expo-router navigation

### DIFF
--- a/APP_SPEC.md
+++ b/APP_SPEC.md
@@ -68,25 +68,25 @@ export interface MazeData {
 
 ```
 haptic-maze/
-├─ App.tsx                    // Navigation Entrypoint
+├─ app/                       // expo-router ルート
+│   ├─ _layout.tsx            // Stack 定義
+│   ├─ index.tsx              // タイトル画面
+│   └─ play.tsx               // ゲーム画面
 ├─ app.json                   // Expo 設定
 ├─ assets/
 │  └─ mazes/maze001.json
 └─ src/
-   ├─ screens/
-   │   ├─ TitleScreen.tsx
-   │   └─ PlayScreen.tsx
    ├─ components/
    │   ├─ DPad.tsx
    │   └─ MiniMap.tsx
    ├─ game/
-   │   ├─ useGame.ts          // ゲームロジック & 状態管理 (Reducer)
+   │   ├─ useGame.tsx         // GameContext と Reducer
    │   └─ utils.ts            // 汎用関数 (canMove, distance etc.)
    └─ types/
        └─ maze.ts
 ```
 
-- **Navigation**: `react-navigation` は未使用。`useState` で `scene` 分岐。
+- **Navigation**: 画面遷移は `expo-router` を用いた Stack 構成。
 - **状態管理**: `useReducer<GameState>` を `GameContext` で共有。
 
 ---

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { GameProvider } from '@/src/game/useGame';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -19,11 +20,13 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="index" options={{ headerShown: false }} />
-        <Stack.Screen name="play" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
+      <GameProvider>
+        <Stack>
+          <Stack.Screen name="index" options={{ headerShown: false }} />
+          <Stack.Screen name="play" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+      </GameProvider>
       <StatusBar style="auto" />
     </ThemeProvider>
   );

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 // eslint-disable-next-line import/no-unresolved
 import Svg, { Line, Rect, Circle } from 'react-native-svg';
 
@@ -9,16 +9,19 @@ import type { MazeData, Vec2 } from '@/types/maze';
 // ミニマップに必要な情報をまとめて渡す
 export interface MiniMapProps {
   maze: MazeData; // 迷路の壁情報
-  path: Vec2[];   // 通過したマスの履歴
-  pos: Vec2;      // 現在の位置
-  flash?: number; // 外枠の太さ (アニメーション用)
-  size?: number;  // 表示サイズ (デフォルト80px)
+  path: Vec2[]; // 通過したマスの履歴
+  pos: Vec2; // 現在の位置
+  flash?: number | import('react-native-reanimated').SharedValue<number>; // 外枠の太さ
+  size?: number; // 表示サイズ (デフォルト80px)
 }
 
 // MiniMap コンポーネント
 // react-native-svg を使い迷路と軌跡を描画する
 export function MiniMap({ maze, path, pos, flash = 2, size = 80 }: MiniMapProps) {
   const cell = size / maze.size; // 各マスの大きさ
+  const style = useAnimatedStyle(() => ({
+    borderWidth: typeof flash === 'number' ? flash : flash.value,
+  }));
 
   // 壁の線をまとめて描画
   const renderWalls = () => {
@@ -98,7 +101,7 @@ export function MiniMap({ maze, path, pos, flash = 2, size = 80 }: MiniMapProps)
   };
 
   return (
-    <View style={{ width: size, height: size, borderWidth: flash, borderColor: 'orange' }}>
+    <Animated.View style={[{ width: size, height: size, borderColor: 'orange' }, style]}>
       <Svg width={size} height={size}>
         {renderWalls()}
         {renderPath()}
@@ -126,6 +129,6 @@ export function MiniMap({ maze, path, pos, flash = 2, size = 80 }: MiniMapProps)
           fill="blue"
         />
       </Svg>
-    </View>
+    </Animated.View>
   );
 }

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -1,5 +1,6 @@
 import * as Haptics from 'expo-haptics';
 import { withTiming, SharedValue } from 'react-native-reanimated';
+import type { MazeData, Dir } from '@/src/types/maze';
 
 export interface Vec2 {
   x: number;
@@ -54,4 +55,31 @@ export function applyDistanceFeedback(
 
   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium, vibMs);
   borderW.value = withTiming(width, { duration: 150 });
+}
+
+/**
+ * 壁配列から O(1) 検索用の Set を生成します。
+ */
+export function wallSet(walls: [number, number][]): Set<string> {
+  return new Set(walls.map(([x, y]) => `${x},${y}`));
+}
+
+/**
+ * 現在位置と進行方向から移動可能か判定します。
+ * MazeData の v_walls / h_walls は Set である前提です。
+ */
+export function canMove({ x, y }: Vec2, dir: Dir, maze: MazeData): boolean {
+  const h = maze.v_walls as unknown as Set<string>;
+  const v = maze.h_walls as unknown as Set<string>;
+  const last = maze.size - 1;
+  switch (dir) {
+    case 'Right':
+      return !h.has(`${x},${y}`) && x < last;
+    case 'Left':
+      return !h.has(`${x - 1},${y}`) && x > 0;
+    case 'Down':
+      return !v.has(`${x},${y}`) && y < last;
+    case 'Up':
+      return !v.has(`${x},${y - 1}`) && y > 0;
+  }
 }


### PR DESCRIPTION
## Summary
- update spec to describe expo-router based layout
- integrate `GameProvider` around router
- rework `useGame` with wall sets and context
- animate MiniMap border and show it always
- apply distance feedback when moving

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858a6c35280832c804ec73dbfda7b45