### PR TITLE
Add debug visibility toggle

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Modal, StyleSheet, View, Pressable } from 'react-native';
+import { Button, Modal, StyleSheet, View, Pressable, Switch } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
@@ -21,6 +21,8 @@ export default function PlayScreen() {
   const [showResult, setShowResult] = useState(false);
   // メニュー表示フラグ。true のときサブメニューを表示
   const [showMenu, setShowMenu] = useState(false);
+  // 全てを可視化するかのフラグ。デフォルトはオフ
+  const [debugAll, setDebugAll] = useState(false);
   const borderW = useSharedValue(2);
 
   useEffect(() => {
@@ -62,7 +64,13 @@ export default function PlayScreen() {
       </Pressable>
       <ThemedText>位置: {state.pos.x}, {state.pos.y}</ThemedText>
       <DPad onPress={move} />
-      <MiniMap maze={maze as MazeView} path={state.path} pos={state.pos} flash={borderW} />
+      <MiniMap
+        maze={maze as MazeView}
+        path={state.path}
+        pos={state.pos}
+        flash={borderW}
+        showAll={debugAll}
+      />
       {/* サブメニュー本体 */}
       <Modal transparent visible={showMenu} animationType="fade">
         {/* 画面全体を押すと閉じるオーバーレイ */}
@@ -79,6 +87,15 @@ export default function PlayScreen() {
               onPress={handleExit}
               accessibilityLabel="タイトルへ戻る"
             />
+            {/* デバッグ用スイッチ */}
+            <View style={styles.switchRow}>
+              <ThemedText>全てを可視化</ThemedText>
+              <Switch
+                value={debugAll}
+                onValueChange={setDebugAll}
+                accessibilityLabel="迷路を全て表示"
+              />
+            </View>
           </View>
         </Pressable>
       </Modal>
@@ -113,6 +130,11 @@ const styles = StyleSheet.create({
     padding: 10,
     borderRadius: 8,
     gap: 8,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
   modalWrapper: {
     flex: 1,

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
-// eslint-disable-next-line import/no-unresolved
 import Svg, { Line, Rect, Circle } from 'react-native-svg';
 
 import type { MazeData, Vec2 } from '@/types/maze';
@@ -13,11 +12,16 @@ export interface MiniMapProps {
   pos: Vec2; // 現在の位置
   flash?: number | import('react-native-reanimated').SharedValue<number>; // 外枠の太さ
   size?: number; // 表示サイズ (デフォルト80px)
+  /**
+   * デバッグ表示フラグ
+   * true のとき壁とゴールを含む全情報を描画
+   */
+  showAll?: boolean;
 }
 
 // MiniMap コンポーネント
 // react-native-svg を使い迷路と軌跡を描画する
-export function MiniMap({ maze, path, pos, flash = 2, size = 80 }: MiniMapProps) {
+export function MiniMap({ maze, path, pos, flash = 2, size = 80, showAll = false }: MiniMapProps) {
   const cell = size / maze.size; // 各マスの大きさ
   const style = useAnimatedStyle(() => ({
     borderWidth: typeof flash === 'number' ? flash : flash.value,
@@ -25,6 +29,8 @@ export function MiniMap({ maze, path, pos, flash = 2, size = 80 }: MiniMapProps)
 
   // 壁の線をまとめて描画
   const renderWalls = () => {
+    // デバッグオフなら壁を描かない
+    if (!showAll) return null;
     const lines = [] as JSX.Element[];
 
     // 外周の壁
@@ -113,14 +119,16 @@ export function MiniMap({ maze, path, pos, flash = 2, size = 80 }: MiniMapProps)
           height={cell * 0.5}
           fill="green"
         />
-        {/* ゴール位置を赤色で表示 */}
-        <Rect
-          x={(maze.goal[0] + 0.25) * cell}
-          y={(maze.goal[1] + 0.25) * cell}
-          width={cell * 0.5}
-          height={cell * 0.5}
-          fill="red"
-        />
+        {showAll && (
+          // ゴール位置はデバッグ時のみ表示
+          <Rect
+            x={(maze.goal[0] + 0.25) * cell}
+            y={(maze.goal[1] + 0.25) * cell}
+            width={cell * 0.5}
+            height={cell * 0.5}
+            fill="red"
+          />
+        )}
         {/* 現在位置を円で表示 */}
         <Circle
           cx={(pos.x + 0.5) * cell}


### PR DESCRIPTION
## Summary
- add debug toggle in submenu
- show goal and walls when toggle is on
- hide walls and goal by default in MiniMap

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858ad26fe4c832c97a83135a1f7e15b