### PR TITLE
フィードバック枠を画面全体で表示

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -3,7 +3,7 @@ import { Button, Modal, StyleSheet, View, Pressable, Switch, useWindowDimensions
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { useSharedValue } from 'react-native-reanimated';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
 
 import { DPad } from '@/components/DPad';
 import { ThemedText } from '@/components/ThemedText';
@@ -25,7 +25,8 @@ export default function PlayScreen() {
   const [showMenu, setShowMenu] = useState(false);
   // 全てを可視化するかのフラグ。デフォルトはオフ
   const [debugAll, setDebugAll] = useState(false);
-  const borderW = useSharedValue(2);
+  const borderW = useSharedValue(0);
+  const flashStyle = useAnimatedStyle(() => ({ borderWidth: borderW.value }));
 
   useEffect(() => {
     if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
@@ -57,7 +58,8 @@ export default function PlayScreen() {
   const mapTop = height / 3;
 
   return (
-    <ThemedView style={[styles.container, { paddingTop: insets.top }]}
+    <Animated.View
+      style={[styles.container, flashStyle, { paddingTop: insets.top }]}
     >
       {/* 右上のメニューアイコン */}
       <Pressable
@@ -73,7 +75,6 @@ export default function PlayScreen() {
           maze={maze as MazeView}
           path={state.path}
           pos={state.pos}
-          flash={borderW}
           showAll={debugAll}
           size={160}
         />
@@ -120,13 +121,15 @@ export default function PlayScreen() {
           </ThemedView>
         </View>
       </Modal>
-    </ThemedView>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: 'black',
+    borderColor: 'white',
   },
   menuBtn: {
     position: 'absolute',

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -1,5 +1,5 @@
 import * as Haptics from 'expo-haptics';
-import { withTiming, SharedValue } from 'react-native-reanimated';
+import { withTiming, withDelay, SharedValue } from 'react-native-reanimated';
 import type { MazeData, Dir } from '@/src/types/maze';
 
 export interface Vec2 {
@@ -30,6 +30,8 @@ export interface FeedbackOptions {
   vibrateRange?: [number, number];
   /** 枠太さの範囲 [最小, 最大] */
   borderRange?: [number, number];
+  /** 枠を表示する時間 (ミリ秒) */
+  showTime?: number;
 }
 
 /**
@@ -46,6 +48,7 @@ export function applyDistanceFeedback(
     maxDist = Math.hypot(goal.x, goal.y),
     vibrateRange = [120, 20],
     borderRange = [2, 8],
+    showTime = 1000,
   } = opts;
 
   const dist = distance(pos, goal);
@@ -55,6 +58,7 @@ export function applyDistanceFeedback(
 
   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium, vibMs);
   borderW.value = withTiming(width, { duration: 150 });
+  borderW.value = withDelay(showTime, withTiming(0, { duration: 150 }));
 }
 
 /**


### PR DESCRIPTION
## Summary
- 画面全体が黒背景で白枠を点滅させるよう変更
- MiniMap での枠表示を廃止
- 距離フィードバック関数に枠表示時間を追加

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858b06837cc832c80b3fef769d1ec66