### PR TITLE
全画面の枠フラッシュ時間を調整

### DIFF
--- a/APP_SPEC.md
+++ b/APP_SPEC.md
@@ -151,7 +151,7 @@ const maxDist = Math.hypot(9, 9);
 const dist = Math.hypot(goal.x - x, goal.y - y);
 const t = dist / maxDist; // 0–1
 const vibMs = lerp(120, 20, 1 - t); // 120→20ms
-const borderW = lerp(2, 8, 1 - t); // 2→8px
+const borderW = lerp(2, 20, 1 - t); // 2→20px
 ```
 
 - 振動: `Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium, vibMs);`
@@ -166,7 +166,7 @@ const borderW = lerp(2, 8, 1 - t); // 2→8px
 | ミニマップ   | 80×80 px     | 固定            |
 | D‑Pad        | ボタン 56 dp | CenterBottom    |
 | ヘッダー     | H 48 dp      | rgba(0,0,0,0.6) |
-| 枠フラッシュ | Border       | 2‑8 px / 150 ms |
+| 枠フラッシュ | Border       | 2‑20 px / 150 ms |
 
 ---
 

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -28,10 +28,10 @@ export interface FeedbackOptions {
   maxDist?: number;
   /** 振動時間の範囲 [長いとき, 短いとき] */
   vibrateRange?: [number, number];
-  /** 枠太さの範囲 [最小, 最大] */
+  /** 枠太さの範囲 [細いとき, 太いとき] */
   borderRange?: [number, number];
-  /** 枠を表示する時間 (ミリ秒) */
-  showTime?: number;
+  /** 枠表示時間の範囲 [短いとき, 長いとき] */
+  showRange?: [number, number];
 }
 
 /**
@@ -47,14 +47,18 @@ export function applyDistanceFeedback(
   const {
     maxDist = Math.hypot(goal.x, goal.y),
     vibrateRange = [120, 20],
-    borderRange = [2, 8],
-    showTime = 1000,
+    borderRange = [2, 20],
+    showRange = [200, 1000],
   } = opts;
 
   const dist = distance(pos, goal);
   const t = dist / maxDist; // 0〜1 の値
   const vibMs = lerp(vibrateRange[0], vibrateRange[1], 1 - t);
   const width = lerp(borderRange[0], borderRange[1], 1 - t);
+
+  // ゴールに近いほど長く枠を表示する時間を計算
+  // showRange[1] を 1000 とすると最大 1 秒表示される
+  const showTime = lerp(showRange[0], showRange[1], 1 - t);
 
   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium, vibMs);
   borderW.value = withTiming(width, { duration: 150 });


### PR DESCRIPTION
## Summary
- `applyDistanceFeedback` オプションを更新し、距離に応じて枠表示時間を変化
- 最大太さを 20px とし、デフォルトの表示時間範囲を 200〜1000ms に設定
- APP_SPEC のフィードバック計算例と UI 寸法表を更新

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858b4ab3864832cb19726473a105fd6