### PR TITLE
タイトル画面の黒背景化

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -7,9 +7,23 @@ import { ThemedView } from '@/components/ThemedView';
 export default function TitleScreen() {
   const router = useRouter();
   return (
-    <ThemedView style={styles.container}>
-      <ThemedText type="title">Haptic Maze</ThemedText>
-      <Button title="スタート" onPress={() => router.replace('/play')} accessibilityLabel="ゲームスタート" />
+    <ThemedView
+      /* 背景色を黒に固定。light/dark ともに同じ色を指定する */
+      lightColor="#000"
+      darkColor="#000"
+      style={styles.container}
+    >
+      {/* アプリタイトル。文字色を白にして視認性を高める */}
+      <ThemedText type="title" lightColor="#fff" darkColor="#fff">
+        Haptic Maze
+      </ThemedText>
+      {/* ボタンの色も白に合わせる。onPress でゲーム画面へ遷移 */}
+      <Button
+        title="スタート"
+        onPress={() => router.replace('/play')}
+        accessibilityLabel="ゲームスタート"
+        color="#fff"
+      />
     </ThemedView>
   );
 }


### PR DESCRIPTION
## Summary
- タイトル画面を黒背景・白文字に変更
- ボタンの文字色も白に設定
- 初心者向けの日本語コメントを追加

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858b9110214832cbe31c23902047017