### PR TITLE
Fix vibrate range option

### DIFF
--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -51,6 +51,8 @@ export function applyDistanceFeedback(
 ) {
   const {
     maxDist = Math.hypot(goal.x, goal.y),
+    // ゴールから遠いとき 120ms, 近いとき 20ms 振動させます
+    vibrateRange = [120, 20],
     borderRange = [2, 20],
     showRange = [200, 1000],
   } = opts;


### PR DESCRIPTION
## Summary
- prevent `vibrateRange` undefined error by providing a default range

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6858badb8cdc832c9b37d8ff7374a45d