### PR TITLE
壁衝突表示の追加

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -96,6 +96,8 @@ export default function PlayScreen() {
           path={state.path}
           pos={state.pos}
           showAll={debugAll}
+          hitV={state.hitV}
+          hitH={state.hitH}
           size={160}
         />
       </View>

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -144,3 +144,31 @@ export function canMove({ x, y }: Vec2, dir: Dir, maze: MazeData): boolean {
       return !v.has(`${x},${y - 1}`) && y > 0;
   }
 }
+
+/**
+ * 衝突した壁の座標を取得します。
+ * 壁が存在しない場合は null を返します。
+ */
+export function getHitWall(
+  { x, y }: Vec2,
+  dir: Dir,
+  maze: MazeData
+): { kind: 'v' | 'h'; key: string } | null {
+  const h = maze.v_walls as unknown as Set<string>;
+  const v = maze.h_walls as unknown as Set<string>;
+  switch (dir) {
+    case 'Right':
+      if (h.has(`${x},${y}`)) return { kind: 'v', key: `${x},${y}` };
+      break;
+    case 'Left':
+      if (h.has(`${x - 1},${y}`)) return { kind: 'v', key: `${x - 1},${y}` };
+      break;
+    case 'Down':
+      if (v.has(`${x},${y}`)) return { kind: 'h', key: `${x},${y}` };
+      break;
+    case 'Up':
+      if (v.has(`${x},${y - 1}`)) return { kind: 'h', key: `${x},${y - 1}` };
+      break;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- 衝突した壁の位置を記録してミニマップに表示
- MiniMap に衝突壁描画処理を追加
- PlayScreen から MiniMap へ衝突情報を渡す
- ゲーム状態に衝突壁用 Set を保持

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858c138ddf0832ca40ba79092a7a5cb