### PR TITLE
Fix DPad arrow color

### DIFF
--- a/components/DPad.tsx
+++ b/components/DPad.tsx
@@ -1,4 +1,4 @@
-import { Button, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import type { Dir } from '@/src/types/maze';
 
 /**
@@ -12,35 +12,44 @@ export function DPad({ onPress }: { onPress: (dir: Dir) => void }) {
       {/* 一段目: 上ボタンを中央に配置 */}
       <View style={styles.row}>
         <View style={styles.spacer} />
-        <Button
-          title="▲"
+        <Pressable
           onPress={() => onPress('Up')}
+          style={styles.btn}
           accessibilityLabel="上へ移動"
-        />
+        >
+          {/* \u25B2: 三角形の記号を表示 */}
+          <Text style={styles.txt}>▲</Text>
+        </Pressable>
         <View style={styles.spacer} />
       </View>
       {/* 二段目: 左右ボタン */}
       <View style={styles.row}>
-        <Button
-          title="◀"
+        <Pressable
           onPress={() => onPress('Left')}
+          style={styles.btn}
           accessibilityLabel="左へ移動"
-        />
+        >
+          <Text style={styles.txt}>◀</Text>
+        </Pressable>
         <View style={styles.spacer} />
-        <Button
-          title="▶"
+        <Pressable
           onPress={() => onPress('Right')}
+          style={styles.btn}
           accessibilityLabel="右へ移動"
-        />
+        >
+          <Text style={styles.txt}>▶</Text>
+        </Pressable>
       </View>
       {/* 三段目: 下ボタンを中央に配置 */}
       <View style={styles.row}>
         <View style={styles.spacer} />
-        <Button
-          title="▼"
+        <Pressable
           onPress={() => onPress('Down')}
+          style={styles.btn}
           accessibilityLabel="下へ移動"
-        />
+        >
+          <Text style={styles.txt}>▼</Text>
+        </Pressable>
         <View style={styles.spacer} />
       </View>
     </View>
@@ -60,5 +69,17 @@ const styles = StyleSheet.create({
   // ボタンを十字の形に配置するための空白
   spacer: {
     width: 40,
+  },
+  // 押下範囲のスタイル。幅・高さを 48 にして指が届きやすくする
+  btn: {
+    width: 48,
+    height: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // ボタン内の文字色を白に設定
+  txt: {
+    color: 'white',
+    fontSize: 24,
   },
 });

--- a/src/components/DPad.tsx
+++ b/src/components/DPad.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 // Vec2 や方角の型定義をまとめたファイルから Dir をインポート
 import type { Dir } from '@/src/types/maze';
@@ -21,33 +21,37 @@ export function DPad({ onMove }: DPadProps) {
     <View style={styles.container}>
       {/* 上ボタン。accessibilityLabel で読み上げ用の説明を指定 */}
       <View style={styles.row}>
-        <Button
-          title="▲"
-          color="white"
+        <Pressable
           onPress={() => onMove('Up')}
+          style={styles.btn}
           accessibilityLabel="上へ移動"
-        />
+        >
+          <Text style={styles.txt}>▲</Text>
+        </Pressable>
       </View>
       {/* 左・下・右ボタンを横並びに配置 */}
       <View style={styles.row}>
-        <Button
-          title="◀"
-          color="white"
+        <Pressable
           onPress={() => onMove('Left')}
+          style={styles.btn}
           accessibilityLabel="左へ移動"
-        />
-        <Button
-          title="▼"
-          color="white"
+        >
+          <Text style={styles.txt}>◀</Text>
+        </Pressable>
+        <Pressable
           onPress={() => onMove('Down')}
+          style={styles.btn}
           accessibilityLabel="下へ移動"
-        />
-        <Button
-          title="▶"
-          color="white"
+        >
+          <Text style={styles.txt}>▼</Text>
+        </Pressable>
+        <Pressable
           onPress={() => onMove('Right')}
+          style={styles.btn}
           accessibilityLabel="右へ移動"
-        />
+        >
+          <Text style={styles.txt}>▶</Text>
+        </Pressable>
       </View>
     </View>
   );
@@ -62,5 +66,17 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row', // 子要素を横並びにする設定
     gap: 10,
+  },
+  // ボタンの押下領域を確保
+  btn: {
+    width: 48,
+    height: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // テキストカラーを白に指定
+  txt: {
+    color: 'white',
+    fontSize: 24,
   },
 });


### PR DESCRIPTION
## Summary
- Pressableで方向キーを実装し直し、矢印文字の色を白に固定
- 文字サイズやボタン領域を設定して押しやすく調整

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6858d475f3ac832c8dfe326a31247f30