### PR TITLE
距離に応じたハプティックパルス追加

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -15,7 +15,8 @@ import { ThemedView } from '@/components/ThemedView';
 import { MiniMap } from '@/src/components/MiniMap';
 import type { MazeData as MazeView, Dir } from '@/src/types/maze';
 import { useGame } from '@/src/game/useGame';
-import { applyDistanceFeedback, applyBumpFeedback } from '@/src/game/utils';
+import { applyBumpFeedback } from '@/src/game/utils';
+import { useDistanceFeedback } from '@/hooks/useDistanceFeedback';
 
 // LinearGradient を Reanimated 用にラップ
 const AnimatedLG = Animated.createAnimatedComponent(LinearGradient);
@@ -46,8 +47,9 @@ export default function PlayScreen() {
     if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
       setShowResult(true);
     }
-    applyDistanceFeedback(state.pos, { x: maze.goal[0], y: maze.goal[1] }, borderW);
-  }, [state.pos, maze.goal, borderW]);
+  }, [state.pos, maze.goal]);
+  // ゴール距離に応じた周期でフィードバックを発火
+  useDistanceFeedback(state.pos, { x: maze.goal[0], y: maze.goal[1] }, borderW);
 
   const handleOk = () => {
     setShowResult(false);

--- a/hooks/useDistanceFeedback.ts
+++ b/hooks/useDistanceFeedback.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import type { Vec2 } from '@/src/types/maze';
+import { applyDistanceFeedback } from '@/src/game/utils';
+import type { SharedValue } from 'react-native-reanimated';
+
+/**
+ * 距離に応じたハプティックフィードバックを一定周期で発火させるフック。
+ * pos と goal が変わるたびに周期を再計算し、振動と枠表示を行います。
+ */
+export function useDistanceFeedback(
+  pos: Vec2,
+  goal: Vec2,
+  borderW: SharedValue<number>,
+) {
+  const timer = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    // 前回のタイマーを停止
+    if (timer.current) clearTimeout(timer.current);
+
+    // 一度実行後、戻り値 period に合わせて次回を予約
+    const tick = () => {
+      const wait = applyDistanceFeedback(pos, goal, borderW);
+      timer.current = setTimeout(tick, wait);
+    };
+
+    tick();
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [pos.x, pos.y, goal.x, goal.y, borderW]);
+}


### PR DESCRIPTION
## Summary
- haptic制御を周期ベースに変更し次回周期を返すよう`applyDistanceFeedback`を改修
- 距離に応じて自動発火する`useDistanceFeedback`フックを追加
- PlayScreenで新フックを利用して移動中のフィードバックを強化

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858dc8974fc832cb4727dc47b1ee32e