### PR TITLE
ミニマップサイズの拡大

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -133,7 +133,8 @@ export default function PlayScreen() {
           showAll={debugAll}
           hitV={state.hitV}
           hitH={state.hitH}
-          size={160}
+          // ミニマップを1.5倍のサイズ（240px）で表示する
+          size={240}
         />
       </View>
       <View style={[styles.dpadWrapper, { top: dpadTop }]}


### PR DESCRIPTION
## Summary
- Play 画面の `MiniMap` を 1.5 倍(240px) に拡大

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858dd2efc9c832cbdeee48c54132941