### PR TITLE
Implement outer wall hit display

### DIFF
--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -47,6 +47,7 @@ export function MiniMap({
     const lines = [] as React.JSX.Element[];
 
     // 外周の壁
+    // 通常モードでは表示しないが、デバッグ時のみ全体を確認するため描画
     lines.push(
       <Rect
         key="border"
@@ -101,6 +102,7 @@ export function MiniMap({
   };
 
   // 衝突した壁を黄色で描画
+  // 外周との衝突も同じ座標形式で渡される
   const renderHitWalls = () => {
     const lines = [] as React.JSX.Element[];
     hitV?.forEach((k) => {

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -167,18 +167,28 @@ export function getHitWall(
 ): { kind: 'v' | 'h'; key: string } | null {
   const h = maze.v_walls as unknown as Set<string>;
   const v = maze.h_walls as unknown as Set<string>;
+  // 迷路の端は last 番のマスの外側にあると考える
+  const last = maze.size - 1;
   switch (dir) {
     case 'Right':
       if (h.has(`${x},${y}`)) return { kind: 'v', key: `${x},${y}` };
+      // 右端にぶつかった場合
+      if (x >= last) return { kind: 'v', key: `${last},${y}` };
       break;
     case 'Left':
       if (h.has(`${x - 1},${y}`)) return { kind: 'v', key: `${x - 1},${y}` };
+      // 左端にぶつかった場合
+      if (x <= 0) return { kind: 'v', key: `-1,${y}` };
       break;
     case 'Down':
       if (v.has(`${x},${y}`)) return { kind: 'h', key: `${x},${y}` };
+      // 下端にぶつかった場合
+      if (y >= last) return { kind: 'h', key: `${x},${last}` };
       break;
     case 'Up':
       if (v.has(`${x},${y - 1}`)) return { kind: 'h', key: `${x},${y - 1}` };
+      // 上端にぶつかった場合
+      if (y <= 0) return { kind: 'h', key: `${x},-1` };
       break;
   }
   return null;


### PR DESCRIPTION
## Summary
- add border collision support in `getHitWall`
- document outer wall debug lines in MiniMap

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858e05f867c832c9d6fc452ec83dc7b