### PR TITLE
移動時フィードバック枠の最大太さを倍に

### DIFF
--- a/APP_SPEC.md
+++ b/APP_SPEC.md
@@ -150,7 +150,7 @@ _(Set<string> で常時  O(1) 判定)_
 const maxDist = Math.hypot(9, 9);
 const dist = Math.hypot(goal.x - x, goal.y - y);
 const t = dist / maxDist; // 0–1
-const borderW = lerp(2, 20, 1 - t); // 2→20px
+const borderW = lerp(2, 80, 1 - t); // 2→80px
 ```
 
 - 振動: `Haptics.impactAsync(style)` ※ style は距離に応じて Light → Medium → Heavy を切り替え

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -54,7 +54,9 @@ export function applyDistanceFeedback(
   borderW: SharedValue<number>,
   opts: FeedbackOptions = {}
 ): number {
-  const { maxDist = Math.hypot(goal.x, goal.y), borderRange = [2, 40] } = opts;
+  // borderRange のデフォルトは [2, 80]。
+  // 移動時に表示する枠線の太さが 2px から 80px の範囲で変化します。
+  const { maxDist = Math.hypot(goal.x, goal.y), borderRange = [2, 80] } = opts;
 
   const dist = distance(pos, goal);
   // r = 0 がゴール、1 が最遠の正規化値


### PR DESCRIPTION
## Summary
- distance フィードバックの最大枠太さを 80px へ変更
- 仕様書のコード例も更新

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858ecd17e38832c89ce97b90ae05749