### PR TITLE
サブメニューアイコンの視認性向上

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -157,7 +157,8 @@ export default function PlayScreen() {
         onPress={() => setShowMenu(true)}
         accessibilityLabel="メニューを開く"
       >
-        <MaterialIcons name="more-vert" size={24} color="black" />
+        {/* 背景が黒のためアイコンを濃いグレーにして視認性を確保 */}
+        <MaterialIcons name="more-vert" size={24} color="#555" />
       </Pressable>
       <View style={[styles.miniMapWrapper, { top: mapTop }]}>
         <MiniMap


### PR DESCRIPTION
## Summary
- サブメニューを開くアイコンが背景と同化していたため、色を濃いグレーに変更

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858f954ade0832c98214c4fff63b54c