### PR TITLE
Remove unused args from applyBumpFeedback

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -109,12 +109,7 @@ export default function PlayScreen() {
     // move の戻り値が false のときは壁に衝突
     let wait: number;
     if (!move(dir)) {
-      wait = applyBumpFeedback(
-        state.pos,
-        { x: maze.goal[0], y: maze.goal[1] },
-        borderW,
-        setBorderColor
-      );
+      wait = applyBumpFeedback(borderW, setBorderColor);
     } else {
       const { wait: w, id } = applyDistanceFeedback(
         next,

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -103,13 +103,11 @@ export function applyDistanceFeedback(
 
 /**
  * 壁に衝突したときのフィードバックを出します。
- * 太さ 30px の赤枠を 600ms 表示し、
+ * 太さ 50px の赤枠を 300ms 表示し、
  * 400ms の長い振動を 1 回発生させます。
  * setColor には枠線の色を変更する関数を渡します。
  */
 export function applyBumpFeedback(
-  pos: Vec2,
-  goal: Vec2,
   borderW: SharedValue<number>,
   setColor: (color: string) => void,
   opts: FeedbackOptions = {}


### PR DESCRIPTION
## Summary
- `applyBumpFeedback` から pos, goal を削除
- PlayScreen での呼び出しを更新
- コメントを実装内容に合わせて修正

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6858fdbe7b10832c94fbe09eb9ada79e