### PR TITLE
迷路ファイルのランダム読み込み対応

### DIFF
--- a/src/game/loadMaze.ts
+++ b/src/game/loadMaze.ts
@@ -1,11 +1,15 @@
-import maze001 from '@/assets/mazes/maze001.json';
+import mazeSet1 from '@/assets/mazes/maze_11_T30_L16_20250624-161917.json';
 import type { MazeData } from '@/src/types/maze';
 
 /**
- * maze001.json を読み込んで MazeData 型に変換する関数
- * JSON をそのまま返すだけだが、型チェックを兼ねている
+ * assets/mazes 配下に置かれた JSON から迷路データを読み込む
+ * JSON には複数の迷路が配列で入っているため、ここでランダムに一つ選ぶ
  */
 export function loadMaze(): MazeData {
-  // JSON.parse は不要。import 時点でオブジェクト化されている
-  return maze001 as MazeData;
+  // 対象 JSON を配列として読み込み、1 次元配列にまとめる
+  const mazes: MazeData[] = [...(mazeSet1 as MazeData[])];
+  // 迷路の数から乱数でインデックスを決定
+  const idx = Math.floor(Math.random() * mazes.length);
+  return mazes[idx];
 }
+

--- a/src/types/maze.ts
+++ b/src/types/maze.ts
@@ -1,6 +1,7 @@
 export interface MazeData {
   id: string;
-  size: 10;
+  // 迷路の一辺の長さ。以前は 10 固定だったが複数サイズに対応するため number とする
+  size: number;
   start: [number, number];
   goal: [number, number];
   v_walls: [number, number][];


### PR DESCRIPTION
## Summary
- MazeData の size を number 型に変更
- 複数迷路が含まれた JSON からランダムに1つ読み込む処理を実装

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685a548f2ca0832cb8dd0e4c16b52e8e