### PR TITLE
Fix random maze on new start

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,11 +1,14 @@
 import { Button, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useGame } from '@/src/game/useGame';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 
 export default function TitleScreen() {
   const router = useRouter();
+  // GameProvider から新しい迷路を読み込む関数を取得
+  const { newGame } = useGame();
   return (
     <ThemedView
       /* 背景色を黒に固定。light/dark ともに同じ色を指定する */
@@ -20,7 +23,11 @@ export default function TitleScreen() {
       {/* ボタンの色も白に合わせる。onPress でゲーム画面へ遷移 */}
       <Button
         title="スタート"
-        onPress={() => router.replace('/play')}
+        onPress={() => {
+          // 毎回異なる迷路を読み込んでからプレイ画面へ
+          newGame();
+          router.replace('/play');
+        }}
         accessibilityLabel="ゲームスタート"
         color="#fff"
       />

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -3,14 +3,19 @@ import { wallSet, canMove, getHitWall, nextPosition } from './utils';
 import { loadMaze } from './loadMaze';
 import type { MazeData, Vec2, Dir } from '@/src/types/maze';
 
-// Maze データを読み込み Set 化
-const rawMaze = loadMaze();
-const maze = {
-  ...rawMaze,
-  v_walls: wallSet(rawMaze.v_walls),
-  h_walls: wallSet(rawMaze.h_walls),
-} as MazeData & { v_walls: Set<string>; h_walls: Set<string> };
+// rawMaze: JSON そのままのデータ
+type MazeSets = MazeData & { v_walls: Set<string>; h_walls: Set<string> };
 
+// MazeData から壁情報を Set 化して検索を高速にする
+function prepMaze(m: MazeData): MazeSets {
+  return {
+    ...m,
+    v_walls: wallSet(m.v_walls),
+    h_walls: wallSet(m.h_walls),
+  };
+}
+
+// ゲーム状態を表す型
 export interface GameState {
   pos: Vec2;
   steps: number;
@@ -20,27 +25,43 @@ export interface GameState {
   hitH: Set<string>;
 }
 
-const initialState: GameState = {
-  pos: { x: maze.start[0], y: maze.start[1] },
-  steps: 0,
-  bumps: 0,
-  path: [{ x: maze.start[0], y: maze.start[1] }],
-  hitV: new Set(),
-  hitH: new Set(),
-};
+// Provider が保持する全体の状態
+interface State extends GameState {
+  mazeRaw: MazeData;
+  maze: MazeSets;
+}
 
-type Action = { type: 'reset' } | { type: 'move'; dir: Dir };
+// MazeData から初期状態を作成
+function initState(m: MazeData): State {
+  const maze = prepMaze(m);
+  return {
+    mazeRaw: m,
+    maze,
+    pos: { x: m.start[0], y: m.start[1] },
+    steps: 0,
+    bumps: 0,
+    path: [{ x: m.start[0], y: m.start[1] }],
+    hitV: new Set(),
+    hitH: new Set(),
+  };
+}
 
-function reducer(state: GameState, action: Action): GameState {
+// Reducer で使うアクション型
+type Action =
+  | { type: 'reset' }
+  | { type: 'move'; dir: Dir }
+  | { type: 'newMaze'; maze: MazeData };
+
+function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'reset':
-      return {
-        ...initialState,
-        hitV: new Set(),
-        hitH: new Set(),
-      };
+      // 同じ迷路で初期化
+      return initState(state.mazeRaw);
+    case 'newMaze':
+      // 新しい迷路で初期化
+      return initState(action.maze);
     case 'move': {
-      const { pos } = state;
+      const { pos, maze } = state;
       const next = nextPosition(pos, action.dir);
       if (!canMove(pos, action.dir, maze)) {
         const hit = getHitWall(pos, action.dir, maze);
@@ -53,33 +74,42 @@ function reducer(state: GameState, action: Action): GameState {
         return { ...state, bumps: state.bumps + 1, hitV, hitH };
       }
       return {
+        ...state,
         pos: next,
         steps: state.steps + 1,
-        bumps: state.bumps,
         path: [...state.path, next],
-        hitV: state.hitV,
-        hitH: state.hitH,
       };
     }
   }
 }
 
 const GameContext = createContext<
-  | { state: GameState; move: (dir: Dir) => boolean; reset: () => void; maze: MazeData }
+  | {
+      state: GameState;
+      move: (dir: Dir) => boolean;
+      reset: () => void;
+      newGame: () => void;
+      maze: MazeData;
+    }
   | undefined
 >(undefined);
 
 export function GameProvider({ children }: { children: ReactNode }) {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  // 移動が成功したかどうかを返すように改良
+  // useReducer 第3引数を使って初期迷路を読み込む
+  const [state, dispatch] = useReducer(reducer, loadMaze(), initState);
+
+  // 移動処理: 壁に当たったかを返す
   const move = (dir: Dir): boolean => {
-    const success = canMove(state.pos, dir, maze);
+    const success = canMove(state.pos, dir, state.maze);
     dispatch({ type: 'move', dir });
     return success;
   };
+
   const reset = () => dispatch({ type: 'reset' });
+  const newGame = () => dispatch({ type: 'newMaze', maze: loadMaze() });
+
   return (
-    <GameContext.Provider value={{ state, move, reset, maze: rawMaze }}>
+    <GameContext.Provider value={{ state, move, reset, newGame, maze: state.mazeRaw }}>
       {children}
     </GameContext.Provider>
   );


### PR DESCRIPTION
## Summary
- ensure GameProvider can load new random maze
- start button initializes a new maze before game start

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685a57a5fba4832ca93df3ce733f4b75