### PR TITLE
Add enemy star and game over logic

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -40,6 +40,7 @@ export default function PlayScreen() {
   const { height } = useWindowDimensions();
   const { state, move, reset, maze } = useGame();
   const [showResult, setShowResult] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
   // メニュー表示フラグ。true のときサブメニューを表示
   const [showMenu, setShowMenu] = useState(false);
   // 全てを可視化するかのフラグ。デフォルトはオフ
@@ -61,15 +62,22 @@ export default function PlayScreen() {
 
   useEffect(() => {
     if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
-      // ゴールしたら結果表示フラグを立て、迷路を全表示に切り替える
+      // ゴールしたら結果表示フラグを立てる
+      setGameOver(false);
+      setShowResult(true);
+      setDebugAll(true);
+    } else if (state.caught) {
+      // 敵に捕まったとき
+      setGameOver(true);
       setShowResult(true);
       setDebugAll(true);
     }
-  }, [state.pos, maze.goal]);
+  }, [state.pos, state.caught, maze.goal]);
 
   const handleOk = () => {
     // 結果モーダルを閉じて Title 画面へ戻る
     setShowResult(false);
+    setGameOver(false);
     // デバッグ表示も元に戻す
     setDebugAll(false);
     reset();
@@ -79,12 +87,14 @@ export default function PlayScreen() {
   // Reset Maze 選択時に呼ばれる
   const handleReset = () => {
     setShowMenu(false);
+    setGameOver(false);
     reset();
   };
 
   // Exit to Title 選択時に呼ばれる
   const handleExit = () => {
     setShowMenu(false);
+    setGameOver(false);
     reset();
     router.replace("/");
   };
@@ -180,6 +190,7 @@ export default function PlayScreen() {
           maze={maze as MazeView}
           path={state.path}
           pos={state.pos}
+          enemies={state.enemies}
           showAll={debugAll}
           hitV={state.hitV}
           hitH={state.hitH}
@@ -223,7 +234,9 @@ export default function PlayScreen() {
       <Modal transparent visible={showResult} animationType="fade">
         <View style={styles.modalWrapper}>
           <ThemedView style={[styles.modalContent, { marginTop: resultTop }]}>
-            <ThemedText type="title">ゴール！</ThemedText>
+            <ThemedText type="title">
+              {gameOver ? "ゲームオーバー" : "ゴール！"}
+            </ThemedText>
             <ThemedText>Steps: {state.steps}</ThemedText>
             <ThemedText>Bumps: {state.bumps}</ThemedText>
             <Button

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -4,12 +4,27 @@ import Svg, { Line, Rect, Circle, Polygon } from 'react-native-svg';
 
 import type { MazeData, Vec2 } from '@/src/types/maze';
 
+// 星形ポリゴンの座標文字列を生成するヘルパー
+function starPoints(cx: number, cy: number, r: number): string {
+  const points: string[] = [];
+  const step = Math.PI / 5; // 36度おきに頂点を作る
+  for (let i = 0; i < 10; i++) {
+    const rad = i * step - Math.PI / 2; // 上向きに開始
+    const len = i % 2 === 0 ? r : r * 0.5;
+    const x = cx + len * Math.cos(rad);
+    const y = cy + len * Math.sin(rad);
+    points.push(`${x},${y}`);
+  }
+  return points.join(' ');
+}
+
 // MiniMapProps インターフェース
 // ミニマップに必要な情報をまとめて渡す
 export interface MiniMapProps {
   maze: MazeData; // 迷路の壁情報
   path: Vec2[]; // 通過したマスの履歴
   pos: Vec2; // 現在の位置
+  enemies?: Vec2[]; // 敵の位置一覧
   flash?: number | import('react-native-reanimated').SharedValue<number>; // 外枠の太さ
   size?: number; // 表示サイズ (デフォルト80px)
   /**
@@ -30,6 +45,7 @@ export function MiniMap({
   maze,
   path,
   pos,
+  enemies = [],
   flash = 2,
   size = 80,
   showAll = false,
@@ -159,6 +175,17 @@ export function MiniMap({
     return segments;
   };
 
+  // 敵を星形で描画
+  const renderEnemies = () => {
+    return enemies.map((e, i) => (
+      <Polygon
+        key={`enemy${i}`}
+        points={starPoints((e.x + 0.5) * cell, (e.y + 0.5) * cell, cell * 0.35)}
+        fill="white"
+      />
+    ));
+  };
+
   return (
     // showAll が true のときだけ外枠をオレンジ色で表示する
     // false の場合は transparent を指定して枠線を隠す
@@ -198,6 +225,7 @@ export function MiniMap({
           r={cell * 0.3}
           fill="white"
         />
+        {renderEnemies()}
       </Svg>
     </Animated.View>
   );

--- a/src/game/__tests__/enemy.test.ts
+++ b/src/game/__tests__/enemy.test.ts
@@ -1,0 +1,52 @@
+// spawnEnemies と moveEnemyRandom のテスト
+// 初心者向けに分かりやすく記述
+
+import { spawnEnemies, moveEnemyRandom, wallSet } from '../utils';
+import type { MazeData, Vec2 } from '@/src/types/maze';
+
+// 基本となる迷路データ（壁なし）
+const baseMaze: MazeData & { v_walls: Set<string>; h_walls: Set<string> } = {
+  id: 'test',
+  size: 10,
+  start: [0, 0],
+  goal: [9, 9],
+  v_walls: wallSet([]),
+  h_walls: wallSet([]),
+};
+
+const pos = (x: number, y: number): Vec2 => ({ x, y });
+
+describe('moveEnemyRandom', () => {
+  test('進める方向が一つだけなら必ずそこへ移動する', () => {
+    const maze = {
+      ...baseMaze,
+      // 下方向のみ開けている状態を作る
+      v_walls: wallSet([]),
+      h_walls: wallSet([]),
+    };
+    const e = pos(0, 0);
+    const moved = moveEnemyRandom(e, maze, () => 0);
+    expect(moved).toEqual(pos(0, 1));
+  });
+
+  test('乱数によって方向が決まる', () => {
+    const e = pos(0, 0);
+    const moved = moveEnemyRandom(e, baseMaze, () => 0.6); // Right を選ぶ
+    expect(moved).toEqual(pos(1, 0));
+  });
+});
+
+describe('spawnEnemies', () => {
+  test('スタートとゴールには配置されない', () => {
+    const rnd = jest
+      .fn()
+      // 最初はスタート座標を返す → 無視される
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      // 次に有効な座標 (1,2)
+      .mockReturnValueOnce(0.1)
+      .mockReturnValueOnce(0.2);
+    const enemies = spawnEnemies(1, baseMaze, rnd);
+    expect(enemies[0]).toEqual(pos(1, 2));
+  });
+});

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -221,3 +221,43 @@ export function getHitWall(
   }
   return null;
 }
+
+/**
+ * 敵をランダムな位置に生成します。
+ * count には生成したい数、rnd は乱数関数を指定します。
+ * 同じマスを避け、スタート地点とゴール地点も除外します。
+ */
+export function spawnEnemies(
+  count: number,
+  maze: MazeData,
+  rnd: () => number = Math.random,
+): Vec2[] {
+  const enemies: Vec2[] = [];
+  while (enemies.length < count) {
+    const x = Math.floor(rnd() * maze.size);
+    const y = Math.floor(rnd() * maze.size);
+    const dup = enemies.some((e) => e.x === x && e.y === y);
+    if (dup) continue;
+    if (x === maze.start[0] && y === maze.start[1]) continue;
+    if (x === maze.goal[0] && y === maze.goal[1]) continue;
+    enemies.push({ x, y });
+  }
+  return enemies;
+}
+
+/**
+ * 敵をランダムに一マス移動させます。
+ * rnd を渡すとテストで動きを固定できます。
+ */
+export function moveEnemyRandom(
+  enemy: Vec2,
+  maze: MazeData,
+  rnd: () => number = Math.random,
+): Vec2 {
+  const dirs: Dir[] = ['Up', 'Down', 'Left', 'Right'].filter((d) =>
+    canMove(enemy, d, maze),
+  );
+  if (dirs.length === 0) return enemy;
+  const idx = Math.floor(rnd() * dirs.length);
+  return nextPosition(enemy, dirs[idx]);
+}


### PR DESCRIPTION
## Summary
- generate a random enemy in the maze
- move the enemy after each player move
- end the game when touching the enemy
- display the enemy as a white star on the mini map
- add unit tests for enemy logic

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685a6bae2084832c991bec4460be5310