### PR TITLE
敵AIの行動改善

### DIFF
--- a/src/game/__tests__/enemy.test.ts
+++ b/src/game/__tests__/enemy.test.ts
@@ -1,7 +1,7 @@
-// spawnEnemies と moveEnemyRandom のテスト
+// spawnEnemies と moveEnemySmart のテスト
 // 初心者向けに分かりやすく記述
 
-import { spawnEnemies, moveEnemyRandom, wallSet } from '../utils';
+import { spawnEnemies, moveEnemySmart, wallSet } from '../utils';
 import type { MazeData, Vec2 } from '@/src/types/maze';
 
 // 基本となる迷路データ（壁なし）
@@ -16,23 +16,19 @@ const baseMaze: MazeData & { v_walls: Set<string>; h_walls: Set<string> } = {
 
 const pos = (x: number, y: number): Vec2 => ({ x, y });
 
-describe('moveEnemyRandom', () => {
-  test('進める方向が一つだけなら必ずそこへ移動する', () => {
-    const maze = {
-      ...baseMaze,
-      // 下方向のみ開けている状態を作る
-      v_walls: wallSet([]),
-      h_walls: wallSet([]),
-    };
+describe('moveEnemySmart', () => {
+  test('プレイヤーが近いときは接近する', () => {
     const e = pos(0, 0);
-    const moved = moveEnemyRandom(e, maze, () => 0);
-    expect(moved).toEqual(pos(0, 1));
+    const visited = new Set<string>();
+    const moved = moveEnemySmart(e, baseMaze, visited, pos(2, 0), () => 0);
+    expect(moved).toEqual(pos(1, 0));
   });
 
-  test('乱数によって方向が決まる', () => {
-    const e = pos(0, 0);
-    const moved = moveEnemyRandom(e, baseMaze, () => 0.6); // Right を選ぶ
-    expect(moved).toEqual(pos(1, 0));
+  test('未踏マスを優先して進む', () => {
+    const e = pos(1, 1);
+    const visited = new Set<string>(['2,1', '1,0', '1,2']);
+    const moved = moveEnemySmart(e, baseMaze, visited, pos(9, 9), () => 0);
+    expect(moved).toEqual(pos(0, 1));
   });
 });
 

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -261,3 +261,42 @@ export function moveEnemyRandom(
   const idx = Math.floor(rnd() * dirs.length);
   return nextPosition(enemy, dirs[idx]);
 }
+
+/**
+ * プレイヤーとの距離が 2 マス以内なら接近し、
+ * それ以外では未踏のマスを優先して移動する敵 AI。
+ * visited にはその敵がこれまでに踏んだマスの集合を渡します。
+ */
+export function moveEnemySmart(
+  enemy: Vec2,
+  maze: MazeData,
+  visited: Set<string>,
+  player: Vec2,
+  rnd: () => number = Math.random,
+): Vec2 {
+  const dirs: Dir[] = ['Up', 'Down', 'Left', 'Right'].filter((d) =>
+    canMove(enemy, d, maze),
+  );
+  if (dirs.length === 0) return enemy;
+
+  // マンハッタン距離を求める関数。縦横の差を足し合わせるだけ。
+  const dist = (p: Vec2) => Math.abs(p.x - player.x) + Math.abs(p.y - player.y);
+
+  // 距離が 2 以下ならプレイヤーに近づく方向を選ぶ
+  if (dist(enemy) <= 2) {
+    const chase = dirs.filter((d) => dist(nextPosition(enemy, d)) < dist(enemy));
+    if (chase.length > 0) {
+      const idx = Math.floor(rnd() * chase.length);
+      return nextPosition(enemy, chase[idx]);
+    }
+  }
+
+  const unvisited = dirs.filter((d) => {
+    const next = nextPosition(enemy, d);
+    return !visited.has(`${next.x},${next.y}`);
+  });
+
+  const choices = unvisited.length > 0 ? unvisited : dirs;
+  const idx = Math.floor(rnd() * choices.length);
+  return nextPosition(enemy, choices[idx]);
+}


### PR DESCRIPTION
## Summary
- 敵の移動ロジックを `moveEnemySmart` として実装
- `useGame` で敵の訪問マスを管理しプレイヤーとの交錯を判定
- テストを `moveEnemySmart` 用に更新

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685a8b8dfad4832cb0587fd3ad08dc42