### PR TITLE
連続ステージ化対応

### DIFF
--- a/src/game/__tests__/stageUtils.test.ts
+++ b/src/game/__tests__/stageUtils.test.ts
@@ -1,0 +1,27 @@
+import { randomCell, biasedPickGoal } from '../utils';
+import type { Vec2 } from '@/src/types/maze';
+
+describe('randomCell', () => {
+  test('同じ乱数を使えば常に同じ座標になる', () => {
+    const rnd = jest.fn().mockReturnValue(0.5);
+    expect(randomCell(10, rnd)).toEqual({ x: 5, y: 5 });
+  });
+});
+
+describe('biasedPickGoal', () => {
+  const start: Vec2 = { x: 0, y: 0 };
+  const cells: Vec2[] = [
+    { x: 0, y: 1 }, // 重み2
+    { x: 0, y: 9 }, // 重み10
+  ];
+
+  test('小さな乱数では近い方が選ばれる', () => {
+    const rnd = jest.fn().mockReturnValue(0.05); // 0.05*12 = 0.6 <2
+    expect(biasedPickGoal(start, cells, rnd)).toEqual(cells[0]);
+  });
+
+  test('大きな乱数では遠い方が選ばれる', () => {
+    const rnd = jest.fn().mockReturnValue(0.9); // 0.9*12 = 10.8 >2
+    expect(biasedPickGoal(start, cells, rnd)).toEqual(cells[1]);
+  });
+});

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -343,3 +343,51 @@ export function updateEnemyPaths(paths: Vec2[][], enemies: Vec2[]): Vec2[][] {
     return next;
   });
 }
+
+/**
+ * 盤面サイズからランダムなマス座標を返す関数。
+ * rnd を渡すと任意の乱数でテストしやすくなる。
+ */
+export function randomCell(
+  size: number,
+  rnd: () => number = Math.random,
+): Vec2 {
+  return {
+    x: Math.floor(rnd() * size),
+    y: Math.floor(rnd() * size),
+  };
+}
+
+/**
+ * スタート位置と候補マス配列から、距離が遠いほど選ばれやすい形で1マス選ぶ。
+ * 重み付けにはマンハッタン距離を利用する。
+ */
+export function biasedPickGoal(
+  start: Vec2,
+  cells: Vec2[],
+  rnd: () => number = Math.random,
+): Vec2 {
+  const weights = cells.map(
+    (c) => Math.abs(c.x - start.x) + Math.abs(c.y - start.y) + 1,
+  );
+  const sum = weights.reduce((a, b) => a + b, 0);
+  let r = rnd() * sum;
+  for (let i = 0; i < cells.length; i++) {
+    r -= weights[i];
+    if (r <= 0) return cells[i];
+  }
+  return cells[cells.length - 1];
+}
+
+/**
+ * 盤面サイズから全てのマス座標を列挙する簡易ヘルパー。
+ */
+export function allCells(size: number): Vec2[] {
+  const cells: Vec2[] = [];
+  for (let x = 0; x < size; x++) {
+    for (let y = 0; y < size; y++) {
+      cells.push({ x, y });
+    }
+  }
+  return cells;
+}


### PR DESCRIPTION
## Summary
- ステージ進行用のユーティリティを追加
- useGame を連続ステージ対応に改修
- PlayScreen をゲーム進行仕様に合わせて更新
- 新規テスト `stageUtils.test.ts` を追加

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685b0d3cd2bc832ca132930712428174