### PR TITLE
Fix maze asset path

### DIFF
--- a/src/game/loadMaze.ts
+++ b/src/game/loadMaze.ts
@@ -1,4 +1,5 @@
-import mazeSet1 from '@/assets/mazes/maze_11_T30_L16_20250624-161917.json';
+// 実際に使う迷路ファイルは 10×10 サイズのこちら
+import mazeSet1 from '@/assets/mazes/maze_10x10_T30_L16_20250625_074204.json';
 import type { MazeData } from '@/src/types/maze';
 
 /**


### PR DESCRIPTION
## Summary
- correct maze JSON path in `loadMaze`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685b2b4c3b28832c8b06c54d40ca95df