### PR TITLE
迷路JSON読み込みをファイル名変更に対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
+    "prestart": "node ./scripts/update-maze-import.js",
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
+    "preandroid": "node ./scripts/update-maze-import.js",
     "android": "expo start --android",
+    "preios": "node ./scripts/update-maze-import.js",
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "expo lint"

--- a/scripts/update-maze-import.js
+++ b/scripts/update-maze-import.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+const mazesDir = path.join(rootDir, 'assets', 'mazes');
+
+// assets/mazes 内の JSON ファイルを検索
+const mazeFiles = fs
+  .readdirSync(mazesDir)
+  .filter((name) => name.endsWith('.json') && fs.statSync(path.join(mazesDir, name)).isFile());
+
+if (mazeFiles.length === 0) {
+  console.error('assets/mazes に JSON ファイルがありません');
+  process.exit(1);
+}
+
+// 複数ある場合でも先頭のみ使用する (通常は 1 つのみの想定)
+const mazeFile = mazeFiles[0];
+
+const outputPath = path.join(rootDir, 'src', 'game', 'mazeAsset.ts');
+const content = `// 自動生成: assets/mazes 内の唯一の JSON を参照する\n` +
+  `// ${new Date().toISOString()}\n` +
+  `import mazeData from '@/assets/mazes/${mazeFile}';\n` +
+  `export default mazeData;\n`;
+
+fs.writeFileSync(outputPath, content);
+console.log(`mazeAsset.ts updated with ${mazeFile}`);
+

--- a/src/game/loadMaze.ts
+++ b/src/game/loadMaze.ts
@@ -1,5 +1,7 @@
 
-import mazeSet1 from '@/assets/mazes/maze_10x10_T30_L16_20250625_074204.json';
+// Maze データのパスは scripts/update-maze-import.js で自動生成された
+// mazeAsset.ts を経由して読み込む。
+import mazeSet1 from './mazeAsset';
 import type { MazeData } from '@/src/types/maze';
 
 /**

--- a/src/game/mazeAsset.ts
+++ b/src/game/mazeAsset.ts
@@ -1,0 +1,5 @@
+// 自動生成: assets/mazes 内の唯一の JSON を参照する
+// 2025-06-24T23:01:09.729Z
+import mazeData from '@/assets/mazes/maze_10x10_T30_L16_20250625_074204.json';
+export default mazeData;
+


### PR DESCRIPTION
## Summary
- 迷路JSONのパスを自動生成するスクリプトを追加
- `loadMaze` が自動生成された `mazeAsset.ts` から読み込むよう変更
- `package.json` の各起動スクリプトで自動生成スクリプトを実行
- 生成された `mazeAsset.ts` を追加

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685b2d0c2100832ca8545f488964b587