### PR TITLE
Add enemy count configuration

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,5 @@
-import { Button, StyleSheet } from 'react-native';
+import React from 'react';
+import { Button, StyleSheet, TextInput, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useGame } from '@/src/game/useGame';
 
@@ -9,6 +10,9 @@ export default function TitleScreen() {
   const router = useRouter();
   // GameProvider から新しい迷路を読み込む関数を取得
   const { newGame } = useGame();
+  const [visible, setVisible] = React.useState('1');
+  const [invisible, setInvisible] = React.useState('0');
+  const [slow, setSlow] = React.useState('0');
   return (
     <ThemedView
       /* 背景色を黒に固定。light/dark ともに同じ色を指定する */
@@ -20,12 +24,47 @@ export default function TitleScreen() {
       <ThemedText type="title" lightColor="#fff" darkColor="#fff">
         Haptic Maze
       </ThemedText>
+      {/* 敵の数設定欄 */}
+      <View style={styles.row}>
+        <ThemedText lightColor="#fff" darkColor="#fff">等速・視認あり</ThemedText>
+        <TextInput
+          style={styles.input}
+          value={visible}
+          onChangeText={setVisible}
+          keyboardType="number-pad"
+          accessibilityLabel="等速・視認ありの数"
+        />
+      </View>
+      <View style={styles.row}>
+        <ThemedText lightColor="#fff" darkColor="#fff">等速・視認なし</ThemedText>
+        <TextInput
+          style={styles.input}
+          value={invisible}
+          onChangeText={setInvisible}
+          keyboardType="number-pad"
+          accessibilityLabel="等速・視認なしの数"
+        />
+      </View>
+      <View style={styles.row}>
+        <ThemedText lightColor="#fff" darkColor="#fff">鈍足・視認あり</ThemedText>
+        <TextInput
+          style={styles.input}
+          value={slow}
+          onChangeText={setSlow}
+          keyboardType="number-pad"
+          accessibilityLabel="鈍足・視認ありの数"
+        />
+      </View>
       {/* 迷路サイズ別のスタートボタン */}
       <Button
         title="5×5"
         onPress={() => {
           // 5×5 迷路を読み込んでからプレイ画面へ遷移
-          newGame(5);
+          newGame(5, {
+            visible: parseInt(visible) || 0,
+            invisible: parseInt(invisible) || 0,
+            slow: parseInt(slow) || 0,
+          });
           router.replace('/play');
         }}
         accessibilityLabel="5マス迷路を開始"
@@ -35,7 +74,11 @@ export default function TitleScreen() {
         title="10×10"
         onPress={() => {
           // 10×10 迷路を読み込んでからプレイ画面へ遷移
-          newGame(10);
+          newGame(10, {
+            visible: parseInt(visible) || 0,
+            invisible: parseInt(invisible) || 0,
+            slow: parseInt(slow) || 0,
+          });
           router.replace('/play');
         }}
         accessibilityLabel="10マス迷路を開始"
@@ -47,4 +90,13 @@ export default function TitleScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 20 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#888',
+    color: '#fff',
+    paddingHorizontal: 4,
+    minWidth: 40,
+    textAlign: 'center',
+  },
 });

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -3,6 +3,7 @@ import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import Svg, { Line, Rect, Circle, Polygon, Defs, LinearGradient, Stop } from 'react-native-svg';
 
 import type { MazeData, Vec2 } from '@/src/types/maze';
+import type { Enemy } from '@/src/types/enemy';
 
 // 星形ポリゴンの座標文字列を生成するヘルパー
 function starPoints(cx: number, cy: number, r: number): string {
@@ -24,7 +25,7 @@ export interface MiniMapProps {
   maze: MazeData; // 迷路の壁情報
   path: Vec2[]; // 通過したマスの履歴
   pos: Vec2; // 現在の位置
-  enemies?: Vec2[]; // 敵の位置一覧
+  enemies?: Enemy[]; // 敵の位置一覧
   enemyPaths?: Vec2[][]; // 敵の移動履歴
   flash?: number | import('react-native-reanimated').SharedValue<number>; // 外枠の太さ
   size?: number; // 表示サイズ (デフォルト80px)
@@ -188,6 +189,8 @@ export function MiniMap({
   const renderEnemyPaths = () => {
     const lines = [] as React.JSX.Element[];
     enemyPaths.forEach((p, idx) => {
+      const enemy = enemies[idx];
+      if (enemy && !enemy.visible && !showAll) return;
       for (let i = 0; i < p.length - 1; i++) {
         const a = p[i];
         const b = p[i + 1];
@@ -226,13 +229,20 @@ export function MiniMap({
 
   // 敵を星形で描画
   const renderEnemies = () => {
-    return enemies.map((e, i) => (
-      <Polygon
-        key={`enemy${i}`}
-        points={starPoints((e.x + 0.5) * cell, (e.y + 0.5) * cell, cell * 0.35)}
-        fill="white"
-      />
-    ));
+    return enemies.map((e, i) => {
+      if (!e.visible && !showAll) return null;
+      return (
+        <Polygon
+          key={`enemy${i}`}
+          points={starPoints(
+            (e.pos.x + 0.5) * cell,
+            (e.pos.y + 0.5) * cell,
+            cell * 0.35,
+          )}
+          fill="white"
+        />
+      );
+    });
   };
 
   // 過去にゴールだったマスを枠線のみで描画

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -13,6 +13,7 @@ import {
 import { getEnemyMover, selectEnemyBehavior, type EnemyBehavior } from './enemy';
 import { loadMaze } from './loadMaze';
 import type { MazeData, Vec2, Dir } from '@/src/types/maze';
+import type { Enemy, EnemyCounts } from '@/src/types/enemy';
 
 // rawMaze: JSON そのままのデータ
 type MazeSets = MazeData & { v_walls: Set<string>; h_walls: Set<string> };
@@ -26,10 +27,30 @@ function prepMaze(m: MazeData): MazeSets {
   };
 }
 
+// EnemyCounts から Enemy 配列を生成するヘルパー
+function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
+  const enemies: Enemy[] = [];
+  const exclude = new Set<string>();
+  spawnEnemies(counts.visible, maze, Math.random, exclude).forEach((p) => {
+    enemies.push({ pos: p, visible: true, interval: 1, cooldown: 0 });
+  });
+  spawnEnemies(counts.invisible, maze, Math.random, exclude).forEach((p) => {
+    enemies.push({ pos: p, visible: false, interval: 1, cooldown: 0 });
+  });
+  spawnEnemies(counts.slow, maze, Math.random, exclude).forEach((p) => {
+    enemies.push({ pos: p, visible: true, interval: 2, cooldown: 0 });
+  });
+  return enemies;
+}
+
 /**
  * ランダムなスタートとゴールを含む MazeData を作成するヘルパー。
  */
-function createFirstStage(base: MazeData): State {
+function createFirstStage(base: MazeData, counts: EnemyCounts = {
+  visible: 1,
+  invisible: 0,
+  slow: 0,
+}): State {
   const visited = new Set<string>();
   const start = randomCell(base.size);
   const candidates = allCells(base.size).filter(
@@ -43,7 +64,7 @@ function createFirstStage(base: MazeData): State {
     goal: [goal.x, goal.y],
   };
   const finalStage = visited.size === base.size * base.size;
-  return initState(maze, 1, visited, finalStage);
+  return initState(maze, 1, visited, finalStage, undefined, undefined, counts);
 }
 
 /**
@@ -81,7 +102,15 @@ function nextStageState(state: State): State {
   const hitV = changeMap ? new Set<string>() : new Set(state.hitV);
   const hitH = changeMap ? new Set<string>() : new Set(state.hitH);
   // ステージ数を +1 した新しい状態を返す
-  return initState(maze, state.stage + 1, visited, finalStage, hitV, hitH);
+  return initState(
+    maze,
+    state.stage + 1,
+    visited,
+    finalStage,
+    hitV,
+    hitH,
+    state.enemyCounts,
+  );
 }
 
 /**
@@ -89,7 +118,7 @@ function nextStageState(state: State): State {
  * 同じ迷路レイアウトを使って 1 ステージ目を生成する。
  */
 function restartRun(state: State): State {
-  return createFirstStage(state.mazeRaw);
+  return createFirstStage(state.mazeRaw, state.enemyCounts);
 }
 
 // ゲーム状態を表す型
@@ -100,7 +129,7 @@ export interface GameState {
   path: Vec2[];
   hitV: Set<string>;
   hitH: Set<string>;
-  enemies: Vec2[];
+  enemies: Enemy[];
   enemyVisited: Set<string>[];
   enemyPaths: Vec2[][];
   /** 敵に捕まったとき true になる */
@@ -113,6 +142,8 @@ export interface GameState {
   finalStage: boolean;
   /** 敵の行動パターン */
   enemyBehavior: EnemyBehavior;
+  /** 敵の数設定 */
+  enemyCounts: EnemyCounts;
 }
 
 // Provider が保持する全体の状態
@@ -129,9 +160,10 @@ function initState(
   finalStage: boolean,
   hitV: Set<string> = new Set(),
   hitH: Set<string> = new Set(),
+  enemyCounts: EnemyCounts = { visible: 1, invisible: 0, slow: 0 },
 ): State {
   const maze = prepMaze(m);
-  const enemies = spawnEnemies(1, maze);
+  const enemies = createEnemies(enemyCounts, maze);
   const enemyBehavior = selectEnemyBehavior(m.size, finalStage);
   return {
     mazeRaw: m,
@@ -143,13 +175,14 @@ function initState(
     hitV,
     hitH,
     enemies,
-    enemyVisited: enemies.map((e) => new Set([`${e.x},${e.y}`])),
-    enemyPaths: enemies.map((e) => [{ ...e }]),
+    enemyVisited: enemies.map((e) => new Set([`${e.pos.x},${e.pos.y}`])),
+    enemyPaths: enemies.map((e) => [{ ...e.pos }]),
     caught: false,
     stage,
     visitedGoals,
     finalStage,
     enemyBehavior,
+    enemyCounts,
   };
 }
 
@@ -157,7 +190,7 @@ function initState(
 type Action =
   | { type: 'reset' }
   | { type: 'move'; dir: Dir }
-  | { type: 'newMaze'; maze: MazeData }
+  | { type: 'newMaze'; maze: MazeData; counts?: EnemyCounts }
   | { type: 'nextStage' }
   | { type: 'resetRun' };
 
@@ -170,10 +203,13 @@ function reducer(state: State, action: Action): State {
         state.stage,
         new Set(state.visitedGoals),
         state.finalStage,
+        undefined,
+        undefined,
+        state.enemyCounts,
       );
     case 'newMaze':
       // 新しい迷路で初期化
-      return createFirstStage(action.maze);
+      return createFirstStage(action.maze, action.counts ?? state.enemyCounts);
     case 'nextStage':
       return nextStageState(state);
     case 'resetRun':
@@ -204,18 +240,33 @@ function reducer(state: State, action: Action): State {
       const mover = getEnemyMover(state.enemyBehavior);
       const movedEnemies = enemies.map((e, i) => {
         const visited = new Set(state.enemyVisited[i]);
-        const moved = mover(e, maze, visited, newPos);
-        visited.add(`${moved.x},${moved.y}`);
+        if (e.cooldown > 0) {
+          newVisited.push(visited);
+          return { ...e, cooldown: e.cooldown - 1 };
+        }
+        const movedPos = mover(e.pos, maze, visited, newPos);
+        visited.add(`${movedPos.x},${movedPos.y}`);
         newVisited.push(visited);
-        return moved;
+        return {
+          ...e,
+          pos: movedPos,
+          cooldown: e.interval - 1,
+        };
       });
 
-      const newPaths = updateEnemyPaths(state.enemyPaths, movedEnemies);
+      const newPaths = updateEnemyPaths(
+        state.enemyPaths,
+        movedEnemies.map((e) => e.pos),
+      );
 
       const caught = movedEnemies.some((e, i) => {
-        const prev = enemies[i];
-        const cross = prev.x === newPos.x && prev.y === newPos.y && e.x === pos.x && e.y === pos.y;
-        const same = e.x === newPos.x && e.y === newPos.y;
+        const prev = enemies[i].pos;
+        const cross =
+          prev.x === newPos.x &&
+          prev.y === newPos.y &&
+          e.pos.x === pos.x &&
+          e.pos.y === pos.y;
+        const same = e.pos.x === newPos.x && e.pos.y === newPos.y;
         return same || cross;
       });
 
@@ -243,7 +294,7 @@ const GameContext = createContext<
       move: (dir: Dir) => boolean;
       reset: () => void;
       /** 新しい迷路を読み込んでゲームを開始する。size で迷路の大きさを指定 */
-      newGame: (size: number) => void;
+      newGame: (size: number, counts?: EnemyCounts) => void;
       nextStage: () => void;
       resetRun: () => void;
       maze: MazeData;
@@ -264,8 +315,8 @@ export function GameProvider({ children }: { children: ReactNode }) {
   };
 
   const reset = () => dispatch({ type: 'reset' });
-  const newGame = (size: number = 10) =>
-    dispatch({ type: 'newMaze', maze: loadMaze(size) });
+  const newGame = (size: number = 10, counts?: EnemyCounts) =>
+    dispatch({ type: 'newMaze', maze: loadMaze(size), counts });
   const nextStage = () => dispatch({ type: 'nextStage' });
   const resetRun = () => dispatch({ type: 'resetRun' });
 

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -231,16 +231,19 @@ export function spawnEnemies(
   count: number,
   maze: MazeData,
   rnd: () => number = Math.random,
+  exclude: Set<string> = new Set(),
 ): Vec2[] {
   const enemies: Vec2[] = [];
   while (enemies.length < count) {
     const x = Math.floor(rnd() * maze.size);
     const y = Math.floor(rnd() * maze.size);
-    const dup = enemies.some((e) => e.x === x && e.y === y);
+    const key = `${x},${y}`;
+    const dup = exclude.has(key) || enemies.some((e) => e.x === x && e.y === y);
     if (dup) continue;
     if (x === maze.start[0] && y === maze.start[1]) continue;
     if (x === maze.goal[0] && y === maze.goal[1]) continue;
     enemies.push({ x, y });
+    exclude.add(key);
   }
   return enemies;
 }

--- a/src/types/enemy.ts
+++ b/src/types/enemy.ts
@@ -1,0 +1,18 @@
+export interface Enemy {
+  pos: import('./maze').Vec2;
+  /** プレイヤーから見えるか */
+  visible: boolean;
+  /** 行動間隔。1なら毎ターン、2なら2ターンに1回 */
+  interval: number;
+  /** 次に行動するまでの残りターン数 */
+  cooldown: number;
+}
+
+export interface EnemyCounts {
+  /** 等速・視認なしの数 */
+  invisible: number;
+  /** 等速・視認ありの数 */
+  visible: number;
+  /** 鈍足・視認ありの数 */
+  slow: number;
+}


### PR DESCRIPTION
## Summary
- allow players to configure enemy counts on the title screen
- support invisible and slow enemies with new Enemy types
- update enemy movement logic for slower enemies
- adjust minimap to hide invisible enemies

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685c78006080832cbb7ea7e7be03197b