### PR TITLE
Add straight-line vision enemy type

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -13,6 +13,7 @@ export default function TitleScreen() {
   const [visible, setVisible] = React.useState('1');
   const [invisible, setInvisible] = React.useState('0');
   const [slow, setSlow] = React.useState('0');
+  const [sight, setSight] = React.useState('0');
   return (
     <ThemedView
       /* 背景色を黒に固定。light/dark ともに同じ色を指定する */
@@ -55,6 +56,16 @@ export default function TitleScreen() {
           accessibilityLabel="鈍足・視認ありの数"
         />
       </View>
+      <View style={styles.row}>
+        <ThemedText lightColor="#fff" darkColor="#fff">等速・直線視野</ThemedText>
+        <TextInput
+          style={styles.input}
+          value={sight}
+          onChangeText={setSight}
+          keyboardType="number-pad"
+          accessibilityLabel="等速・直線視野の数"
+        />
+      </View>
       {/* 迷路サイズ別のスタートボタン */}
       <Button
         title="5×5"
@@ -64,6 +75,7 @@ export default function TitleScreen() {
             visible: parseInt(visible) || 0,
             invisible: parseInt(invisible) || 0,
             slow: parseInt(slow) || 0,
+            sight: parseInt(sight) || 0,
           });
           router.replace('/play');
         }}
@@ -78,6 +90,7 @@ export default function TitleScreen() {
             visible: parseInt(visible) || 0,
             invisible: parseInt(invisible) || 0,
             slow: parseInt(slow) || 0,
+            sight: parseInt(sight) || 0,
           });
           router.replace('/play');
         }}

--- a/src/game/__tests__/enemy.test.ts
+++ b/src/game/__tests__/enemy.test.ts
@@ -26,33 +26,33 @@ const wallMaze: MazeData & { v_walls: Set<string>; h_walls: Set<string> } = {
 
 describe('moveEnemySmart', () => {
   test('プレイヤーが近いときは接近する', () => {
-    const e = pos(0, 0);
+    const e = { pos: pos(0, 0), visible: true, interval: 1, cooldown: 0, target: null };
     const visited = new Set<string>();
     const moved = moveEnemySmart(e, baseMaze, visited, pos(2, 0), () => 0);
-    expect(moved).toEqual(pos(1, 0));
+    expect(moved.pos).toEqual(pos(1, 0));
   });
 
   test('壁を避けてでも距離2以内なら接近する', () => {
-    const e = pos(0, 0);
+    const e = { pos: pos(0, 0), visible: true, interval: 1, cooldown: 0, target: null };
     const visited = new Set<string>();
     // プレイヤーは (1,1)。直線では近いが壁により回り道で2歩
     const moved = moveEnemySmart(e, wallMaze, visited, pos(1, 1), () => 0);
-    expect(moved).toEqual(pos(0, 1));
+    expect(moved.pos).toEqual(pos(0, 1));
   });
 
   test('壁で遠回りになる場合は接近しない', () => {
-    const e = pos(0, 0);
+    const e = { pos: pos(0, 0), visible: true, interval: 1, cooldown: 0, target: null };
     const visited = new Set<string>();
     // プレイヤーは (1,0) だが壁のせいで最短距離は3歩
     const moved = moveEnemySmart(e, wallMaze, visited, pos(1, 0), () => 0);
-    expect(moved).not.toEqual(pos(0, 1));
+    expect(moved.pos).not.toEqual(pos(0, 1));
   });
 
   test('未踏マスを優先して進む', () => {
-    const e = pos(1, 1);
+    const e = { pos: pos(1, 1), visible: true, interval: 1, cooldown: 0, target: null };
     const visited = new Set<string>(['2,1', '1,0', '1,2']);
     const moved = moveEnemySmart(e, baseMaze, visited, pos(9, 9), () => 0);
-    expect(moved).toEqual(pos(0, 1));
+    expect(moved.pos).toEqual(pos(0, 1));
   });
 });
 

--- a/src/game/enemy.ts
+++ b/src/game/enemy.ts
@@ -1,28 +1,31 @@
 import type { MazeData, Vec2 } from '@/src/types/maze';
-import { moveEnemyRandom, moveEnemySmart } from './utils';
+import type { Enemy } from '@/src/types/enemy';
+import { moveEnemyRandom, moveEnemySmart, moveEnemySight } from './utils';
 
 /** 敵の行動種類を表す列挙型に近い文字列 */
-export type EnemyBehavior = 'smart' | 'random';
+export type EnemyBehavior = 'smart' | 'random' | 'sight';
 
 /** 敵を1ターン移動させる関数の型 */
 export type EnemyMover = (
-  enemy: Vec2,
+  enemy: Enemy,
   maze: MazeData,
   visited: Set<string>,
   player: Vec2,
   rnd?: () => number,
-) => Vec2;
+) => Enemy;
 
 /** 行動種類から実際の移動関数を取得する */
 export function getEnemyMover(behavior: EnemyBehavior): EnemyMover {
   switch (behavior) {
     case 'smart':
       return moveEnemySmart;
+    case 'sight':
+      return moveEnemySight;
     case 'random':
     default:
       // moveEnemyRandom は追跡しない単純な移動
       return (
-        e: Vec2,
+        e: Enemy,
         maze: MazeData,
         _v: Set<string>,
         _p: Vec2,

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -32,13 +32,16 @@ function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
   const enemies: Enemy[] = [];
   const exclude = new Set<string>();
   spawnEnemies(counts.visible, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: true, interval: 1, cooldown: 0 });
+    enemies.push({ pos: p, visible: true, interval: 1, cooldown: 0, target: null });
   });
   spawnEnemies(counts.invisible, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: false, interval: 1, cooldown: 0 });
+    enemies.push({ pos: p, visible: false, interval: 1, cooldown: 0, target: null });
   });
   spawnEnemies(counts.slow, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: true, interval: 2, cooldown: 0 });
+    enemies.push({ pos: p, visible: true, interval: 2, cooldown: 0, target: null });
+  });
+  spawnEnemies(counts.sight, maze, Math.random, exclude).forEach((p) => {
+    enemies.push({ pos: p, visible: true, interval: 1, cooldown: 0, target: null });
   });
   return enemies;
 }
@@ -50,6 +53,7 @@ function createFirstStage(base: MazeData, counts: EnemyCounts = {
   visible: 1,
   invisible: 0,
   slow: 0,
+  sight: 0,
 }): State {
   const visited = new Set<string>();
   const start = randomCell(base.size);
@@ -160,7 +164,7 @@ function initState(
   finalStage: boolean,
   hitV: Set<string> = new Set(),
   hitH: Set<string> = new Set(),
-  enemyCounts: EnemyCounts = { visible: 1, invisible: 0, slow: 0 },
+  enemyCounts: EnemyCounts = { visible: 1, invisible: 0, slow: 0, sight: 0 },
 ): State {
   const maze = prepMaze(m);
   const enemies = createEnemies(enemyCounts, maze);
@@ -244,12 +248,12 @@ function reducer(state: State, action: Action): State {
           newVisited.push(visited);
           return { ...e, cooldown: e.cooldown - 1 };
         }
-        const movedPos = mover(e.pos, maze, visited, newPos);
-        visited.add(`${movedPos.x},${movedPos.y}`);
+        const moved = mover(e, maze, visited, newPos);
+        visited.add(`${moved.pos.x},${moved.pos.y}`);
         newVisited.push(visited);
         return {
           ...e,
-          pos: movedPos,
+          ...moved,
           cooldown: e.interval - 1,
         };
       });

--- a/src/types/enemy.ts
+++ b/src/types/enemy.ts
@@ -6,6 +6,8 @@ export interface Enemy {
   interval: number;
   /** 次に行動するまでの残りターン数 */
   cooldown: number;
+  /** 直線視野で見失ったときに追う座標。未使用時は null */
+  target?: import('./maze').Vec2 | null;
 }
 
 export interface EnemyCounts {
@@ -15,4 +17,6 @@ export interface EnemyCounts {
   visible: number;
   /** 鈍足・視認ありの数 */
   slow: number;
+  /** 等速・直線視野の数 */
+  sight: number;
 }


### PR DESCRIPTION
## Summary
- define new enemy count type `sight` and last-seen `target`
- implement `moveEnemySight` behaviour
- support new enemy creation and selection
- allow setting sight enemies from title screen
- adjust tests for new enemy object shape

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685c7b420f98832caa212bf4d575f6f7