### PR TITLE
Show visited goals even without debug

### DIFF
--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -246,8 +246,11 @@ export function MiniMap({
   };
 
   // 過去にゴールだったマスを枠線のみで描画
+  // これまでにゴールだったマスを常に描画する
+  // showAll フラグに関係なく表示することで
+  // プレイヤーが到達済みの地点を確認できる
   const renderVisitedGoals = () => {
-    if (!showAll || !visitedGoals) return null;
+    if (!visitedGoals) return null;
     const rects = [] as React.JSX.Element[];
     visitedGoals.forEach((k) => {
       const [x, y] = k.split(',').map(Number);


### PR DESCRIPTION
## Summary
- ゴール履歴は常にミニマップに表示するよう変更

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685c8181feb8832cb7fb0d6c7b0bf9d5