### PR TITLE
敵行動タイプの共通化

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -10,8 +10,8 @@ export default function TitleScreen() {
   const router = useRouter();
   // GameProvider から新しい迷路を読み込む関数を取得
   const { newGame } = useGame();
-  const [visible, setVisible] = React.useState('1');
-  const [invisible, setInvisible] = React.useState('0');
+  const [sense, setSense] = React.useState('1');
+  const [random, setRandom] = React.useState('0');
   const [slow, setSlow] = React.useState('0');
   const [sight, setSight] = React.useState('0');
   return (
@@ -27,43 +27,43 @@ export default function TitleScreen() {
       </ThemedText>
       {/* 敵の数設定欄 */}
       <View style={styles.row}>
-        <ThemedText lightColor="#fff" darkColor="#fff">等速・視認あり</ThemedText>
+        <ThemedText lightColor="#fff" darkColor="#fff">等速・感知</ThemedText>
         <TextInput
           style={styles.input}
-          value={visible}
-          onChangeText={setVisible}
+          value={sense}
+          onChangeText={setSense}
           keyboardType="number-pad"
-          accessibilityLabel="等速・視認ありの数"
+          accessibilityLabel="等速・感知の数"
         />
       </View>
       <View style={styles.row}>
-        <ThemedText lightColor="#fff" darkColor="#fff">等速・視認なし</ThemedText>
+        <ThemedText lightColor="#fff" darkColor="#fff">等速・ランダム</ThemedText>
         <TextInput
           style={styles.input}
-          value={invisible}
-          onChangeText={setInvisible}
+          value={random}
+          onChangeText={setRandom}
           keyboardType="number-pad"
-          accessibilityLabel="等速・視認なしの数"
+          accessibilityLabel="等速・ランダムの数"
         />
       </View>
       <View style={styles.row}>
-        <ThemedText lightColor="#fff" darkColor="#fff">鈍足・視認あり</ThemedText>
+        <ThemedText lightColor="#fff" darkColor="#fff">鈍足・視認</ThemedText>
         <TextInput
           style={styles.input}
           value={slow}
           onChangeText={setSlow}
           keyboardType="number-pad"
-          accessibilityLabel="鈍足・視認ありの数"
+          accessibilityLabel="鈍足・視認の数"
         />
       </View>
       <View style={styles.row}>
-        <ThemedText lightColor="#fff" darkColor="#fff">等速・直線視野</ThemedText>
+        <ThemedText lightColor="#fff" darkColor="#fff">等速・視認</ThemedText>
         <TextInput
           style={styles.input}
           value={sight}
           onChangeText={setSight}
           keyboardType="number-pad"
-          accessibilityLabel="等速・直線視野の数"
+          accessibilityLabel="等速・視認の数"
         />
       </View>
       {/* 迷路サイズ別のスタートボタン */}
@@ -72,10 +72,11 @@ export default function TitleScreen() {
         onPress={() => {
           // 5×5 迷路を読み込んでからプレイ画面へ遷移
           newGame(5, {
-            visible: parseInt(visible) || 0,
-            invisible: parseInt(invisible) || 0,
+            sense: parseInt(sense) || 0,
+            random: parseInt(random) || 0,
             slow: parseInt(slow) || 0,
             sight: parseInt(sight) || 0,
+            fast: 0,
           });
           router.replace('/play');
         }}
@@ -87,10 +88,11 @@ export default function TitleScreen() {
         onPress={() => {
           // 10×10 迷路を読み込んでからプレイ画面へ遷移
           newGame(10, {
-            visible: parseInt(visible) || 0,
-            invisible: parseInt(invisible) || 0,
+            sense: parseInt(sense) || 0,
+            random: parseInt(random) || 0,
             slow: parseInt(slow) || 0,
             sight: parseInt(sight) || 0,
+            fast: 0,
           });
           router.replace('/play');
         }}

--- a/src/game/__tests__/enemy.test.ts
+++ b/src/game/__tests__/enemy.test.ts
@@ -32,14 +32,14 @@ const wallMaze: MazeData & { v_walls: Set<string>; h_walls: Set<string> } = {
 
 describe('moveEnemySmart', () => {
   test('プレイヤーが近いときは接近する', () => {
-    const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null };
+    const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null, behavior: 'smart' };
     const visited = new Set<string>();
     const moved = moveEnemySmart(e, baseMaze, visited, pos(2, 0), () => 0);
     expect(moved.pos).toEqual(pos(1, 0));
   });
 
   test('壁を避けてでも距離2以内なら接近する', () => {
-    const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null };
+    const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null, behavior: 'smart' };
     const visited = new Set<string>();
     // プレイヤーは (1,1)。直線では近いが壁により回り道で2歩
     const moved = moveEnemySmart(e, wallMaze, visited, pos(1, 1), () => 0);
@@ -47,7 +47,7 @@ describe('moveEnemySmart', () => {
   });
 
   test('壁で遠回りになる場合は接近しない', () => {
-    const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null };
+    const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null, behavior: 'smart' };
     const visited = new Set<string>();
     // プレイヤーは (1,0) だが壁のせいで最短距離は3歩
     const moved = moveEnemySmart(e, wallMaze, visited, pos(1, 0), () => 0);
@@ -55,7 +55,7 @@ describe('moveEnemySmart', () => {
   });
 
   test('未踏マスを優先して進む', () => {
-    const e = { pos: pos(1, 1), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null };
+    const e = { pos: pos(1, 1), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null, behavior: 'smart' };
     const visited = new Set<string>(['2,1', '1,0', '1,2']);
     const moved = moveEnemySmart(e, baseMaze, visited, pos(9, 9), () => 0);
     expect(moved.pos).toEqual(pos(0, 1));
@@ -64,14 +64,14 @@ describe('moveEnemySmart', () => {
 
 describe('moveEnemySense', () => {
   test('感知範囲内ならプレイヤーへ近づく', () => {
-    const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0 };
+    const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, behavior: 'sense' };
     const visited = new Set<string>();
     const moved = moveEnemySense(e, baseMaze, visited, pos(2, 1), () => 0, 3);
     expect(moved.pos).toEqual(pos(0, 1));
   });
 
   test('範囲外では未踏マスを優先', () => {
-    const e = { pos: pos(1, 1), visible: true, interval: 1, repeat: 1, cooldown: 0 };
+    const e = { pos: pos(1, 1), visible: true, interval: 1, repeat: 1, cooldown: 0, behavior: 'sense' };
     const visited = new Set<string>(['2,1', '1,0', '1,2']);
     const moved = moveEnemySense(e, baseMaze, visited, pos(9, 9), () => 0, 3);
     expect(moved.pos).toEqual(pos(0, 1));

--- a/src/game/enemy.ts
+++ b/src/game/enemy.ts
@@ -1,9 +1,6 @@
 import type { MazeData, Vec2 } from '@/src/types/maze';
-import type { Enemy } from '@/src/types/enemy';
+import type { Enemy, EnemyBehavior } from '@/src/types/enemy';
 import { moveEnemyRandom, moveEnemySmart, moveEnemySight, moveEnemySense } from './utils';
-
-/** 敵の行動種類を表す列挙型に近い文字列 */
-export type EnemyBehavior = 'smart' | 'random' | 'sight' | 'sense';
 
 /** 敵を1ターン移動させる関数の型 */
 export type EnemyMover = (

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -31,23 +31,60 @@ function prepMaze(m: MazeData): MazeSets {
 function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
   const enemies: Enemy[] = [];
   const exclude = new Set<string>();
-  spawnEnemies(counts.visible, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: true, interval: 1, repeat: 1, cooldown: 0, target: null });
+  spawnEnemies(counts.sense, maze, Math.random, exclude).forEach((p) => {
+    enemies.push({
+      pos: p,
+      visible: true,
+      interval: 1,
+      repeat: 1,
+      cooldown: 0,
+      target: null,
+      behavior: 'sense',
+    });
   });
-  spawnEnemies(counts.invisible, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: false, interval: 1, repeat: 1, cooldown: 0, target: null });
+  spawnEnemies(counts.random, maze, Math.random, exclude).forEach((p) => {
+    enemies.push({
+      pos: p,
+      visible: false,
+      interval: 1,
+      repeat: 1,
+      cooldown: 0,
+      target: null,
+      behavior: 'random',
+    });
   });
   spawnEnemies(counts.slow, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: true, interval: 2, repeat: 1, cooldown: 0, target: null });
+    enemies.push({
+      pos: p,
+      visible: true,
+      interval: 2,
+      repeat: 1,
+      cooldown: 0,
+      target: null,
+      behavior: 'sight',
+    });
   });
   spawnEnemies(counts.sight, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: true, interval: 1, repeat: 1, cooldown: 0, target: null });
+    enemies.push({
+      pos: p,
+      visible: true,
+      interval: 1,
+      repeat: 1,
+      cooldown: 0,
+      target: null,
+      behavior: 'sight',
+    });
   });
   spawnEnemies(counts.fast ?? 0, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: true, interval: 1, repeat: 2, cooldown: 0, target: null });
-  });
-  spawnEnemies(counts.sense ?? 0, maze, Math.random, exclude).forEach((p) => {
-    enemies.push({ pos: p, visible: true, interval: 1, repeat: 1, cooldown: 0, target: null });
+    enemies.push({
+      pos: p,
+      visible: true,
+      interval: 1,
+      repeat: 2,
+      cooldown: 0,
+      target: null,
+      behavior: 'smart',
+    });
   });
   return enemies;
 }
@@ -56,12 +93,11 @@ function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
  * ランダムなスタートとゴールを含む MazeData を作成するヘルパー。
  */
 function createFirstStage(base: MazeData, counts: EnemyCounts = {
-  visible: 1,
-  invisible: 0,
+  sense: 1,
+  random: 0,
   slow: 0,
   sight: 0,
   fast: 0,
-  sense: 0,
 }): State {
   const visited = new Set<string>();
   const start = randomCell(base.size);
@@ -172,7 +208,7 @@ function initState(
   finalStage: boolean,
   hitV: Set<string> = new Set(),
   hitH: Set<string> = new Set(),
-  enemyCounts: EnemyCounts = { visible: 1, invisible: 0, slow: 0, sight: 0, fast: 0, sense: 0 },
+  enemyCounts: EnemyCounts = { sense: 1, random: 0, slow: 0, sight: 0, fast: 0 },
 ): State {
   const maze = prepMaze(m);
   const enemies = createEnemies(enemyCounts, maze);
@@ -249,8 +285,8 @@ function reducer(state: State, action: Action): State {
       }
 
       const newVisited: Set<string>[] = [];
-      const mover = getEnemyMover(state.enemyBehavior);
       const movedEnemies = enemies.map((e, i) => {
+        const mover = getEnemyMover(e.behavior ?? state.enemyBehavior);
         const visited = new Set(state.enemyVisited[i]);
         if (e.cooldown > 0) {
           newVisited.push(visited);

--- a/src/types/enemy.ts
+++ b/src/types/enemy.ts
@@ -1,6 +1,9 @@
+/** 敵の行動パターンを表す文字列型 */
+export type EnemyBehavior = 'smart' | 'random' | 'sight' | 'sense';
+
 export interface Enemy {
   pos: import('./maze').Vec2;
-  /** プレイヤーから見えるか */
+  /** プレイヤーから見えるかどうか */
   visible: boolean;
   /** 行動間隔。1なら毎ターン、2なら2ターンに1回 */
   interval: number;
@@ -10,19 +13,19 @@ export interface Enemy {
   cooldown: number;
   /** 直線視野で見失ったときに追う座標。未使用時は null */
   target?: import('./maze').Vec2 | null;
+  /** 敵固有の行動パターン */
+  behavior: EnemyBehavior;
 }
 
 export interface EnemyCounts {
-  /** 等速・視認なしの数 */
-  invisible: number;
-  /** 等速・視認ありの数 */
-  visible: number;
-  /** 鈍足・視認ありの数 */
-  slow: number;
-  /** 等速・直線視野の数 */
-  sight: number;
-  /** 倍速・視認ありの数 */
-  fast: number;
-  /** 感知型の数 */
+  /** 等速・ランダムの数 */
+  random: number;
+  /** 等速・感知の数 */
   sense: number;
+  /** 鈍足・視認の数 */
+  slow: number;
+  /** 等速・視認の数 */
+  sight: number;
+  /** 倍速・視認ありの数 (未使用) */
+  fast: number;
 }


### PR DESCRIPTION
## Summary
- 敵の行動種別 `EnemyBehavior` を型として定義
- `Enemy` に行動パターンを保持する `behavior` を追加
- 敵数設定をランダム/感知/鈍足視認/等速視認に整理
- タイトル画面の入力項目とラベルを更新
- 各敵ごとに行動パターンを適用するようロジックを変更

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685c82fa0174832cbd1c4400cb39d1d2