### PR TITLE
鈍足の初期クールダウンを修正

### DIFF
--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -59,7 +59,8 @@ function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
       visible: true,
       interval: 2,
       repeat: 1,
-      cooldown: 0,
+      // interval が 2 のため初期クールダウンを 1 にして偶数ターンで動くようにする
+      cooldown: 1,
       target: null,
       behavior: 'sight',
     });


### PR DESCRIPTION
## Summary
- 鈍足の敵が偶数ターンで行動するよう初期 `cooldown` を 1 に変更

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685c88e2a7f4832ca9f321f82b917500