### PR TITLE
fix: remove duplicate absolute style

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -344,25 +344,21 @@ const styles = StyleSheet.create({
     position: "absolute",
   },
   topEdge: {
-    position: "absolute",
     top: 0,
     left: 0,
     right: 0,
   },
   bottomEdge: {
-    position: "absolute",
     bottom: 0,
     left: 0,
     right: 0,
   },
   leftEdge: {
-    position: "absolute",
     left: 0,
     top: 0,
     bottom: 0,
   },
   rightEdge: {
-    position: "absolute",
     right: 0,
     top: 0,
     bottom: 0,


### PR DESCRIPTION
## Summary
- remove absolute positioning from each edge style and apply through common `edge`

## Testing
- `pnpm lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca66f8760832cacd0ca6377b2a35b