### PR TITLE
距離計算をマンハッタン距離に更新

### DIFF
--- a/src/game/__tests__/distance.test.ts
+++ b/src/game/__tests__/distance.test.ts
@@ -1,0 +1,18 @@
+// distance 関数のテスト
+// マンハッタン距離へ変更したため、その挙動を確認します
+
+import { distance } from '../utils';
+import type { Vec2 } from '@/src/types/maze';
+
+const pos = (x: number, y: number): Vec2 => ({ x, y });
+
+describe('distance', () => {
+  test('同じ座標なら距離は0になる', () => {
+    expect(distance(pos(0, 0), pos(0, 0))).toBe(0);
+  });
+
+  test('異なる座標ではマンハッタン距離を返す', () => {
+    // 0,0 と 3,4 の距離は |3-0| + |4-0| = 7
+    expect(distance(pos(0, 0), pos(3, 4))).toBe(7);
+  });
+});

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -10,11 +10,13 @@ import type { MazeData, Vec2, Dir } from "@/src/types/maze";
 import type { Enemy } from "@/src/types/enemy";
 
 /**
- * 2点間の直線距離を求めます。
- * Math.hypot はピタゴラスの定理を使って距離を計算する関数です。
+ * 2点間のマンハッタン距離を求めます。
+ * マンハッタン距離とは |x1 - x2| + |y1 - y2| のように
+ * 各軸の差を足し合わせる単純な計算方法です。
+ * Math.abs は絶対値を求める関数を意味します。
  */
 export function distance(a: Vec2, b: Vec2): number {
-  return Math.hypot(b.x - a.x, b.y - a.y);
+  return Math.abs(b.x - a.x) + Math.abs(b.y - a.y);
 }
 
 /**
@@ -26,7 +28,7 @@ export function lerp(start: number, end: number, t: number): number {
 }
 
 export interface FeedbackOptions {
-  /** 距離の最大値。デフォルトはゴール座標から計算した距離 */
+  /** 距離の最大値。デフォルトはゴール座標から計算したマンハッタン距離 */
   maxDist?: number;
   /** 枠太さの範囲 [細いとき, 太いとき] */
   borderRange?: [number, number];
@@ -64,8 +66,8 @@ export function applyDistanceFeedback(
 ): DistanceFeedbackResult {
   // borderRange のデフォルトは [20, 200]。
   // 移動時に表示する枠線の太さが 20px から 200px の範囲で変化します。
-  const { maxDist = Math.hypot(goal.x, goal.y), borderRange = [20, 200] } =
-    opts;
+  // maxDist のデフォルトもマンハッタン距離に合わせて計算
+  const { maxDist = goal.x + goal.y, borderRange = [20, 200] } = opts;
 
   const dist = distance(pos, goal);
   // r = 0 がゴール、1 が最遠の正規化値


### PR DESCRIPTION
## Summary
- distance関数をマンハッタン距離へ変更
- 距離に基づくフィードバック計算も修正
- 距離用のユニットテストを追加

## Testing
- `pnpm lint`
- `npx jest --runTestsByPath src/game/__tests__/distance.test.ts` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ca9d3502c832cbe23fa10a31e0a34