### PR TITLE
Add practice mode screen with level presets

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -23,6 +23,7 @@ export default function RootLayout() {
       <GameProvider>
         <Stack>
           <Stack.Screen name="index" options={{ headerShown: false }} />
+          <Stack.Screen name="practice" options={{ headerShown: false }} />
           <Stack.Screen name="play" options={{ headerShown: false }} />
           <Stack.Screen name="+not-found" />
         </Stack>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,17 +5,20 @@ import { useGame } from '@/src/game/useGame';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { EnemyCounter } from '@/components/EnemyCounter';
+import { LEVELS } from '@/constants/levels';
 
 export default function TitleScreen() {
   const router = useRouter();
   // GameProvider から新しい迷路を読み込む関数を取得
   const { newGame } = useGame();
-  // 敵の数は数値として扱う。初期値はすべて0
-  const [sense, setSense] = React.useState(0);
-  const [random, setRandom] = React.useState(0);
-  const [slow, setSlow] = React.useState(0);
-  const [sight, setSight] = React.useState(0);
+
+  // 定義済みレベルの設定を使ってゲームを開始する
+  const startLevel = (id: string) => {
+    const level = LEVELS.find((l) => l.id === id);
+    if (!level) return;
+    newGame(level.size, level.enemies);
+    router.replace('/play');
+  };
   return (
     <ThemedView
       /* 背景色を黒に固定。light/dark ともに同じ色を指定する */
@@ -27,44 +30,23 @@ export default function TitleScreen() {
       <ThemedText type="title" lightColor="#fff" darkColor="#fff">
         Haptic Maze
       </ThemedText>
-      {/* 敵の数設定欄 */}
-      <EnemyCounter label="等速・感知" value={sense} setValue={setSense} />
-      <EnemyCounter label="等速・ランダム" value={random} setValue={setRandom} />
-      <EnemyCounter label="鈍足・視認" value={slow} setValue={setSlow} />
-      <EnemyCounter label="等速・視認" value={sight} setValue={setSight} />
-      {/* 迷路サイズ別のスタートボタン */}
+      {/* 練習モードへの遷移 */}
       <Button
-        title="5×5"
-        onPress={() => {
-          // 5×5 迷路を読み込んでからプレイ画面へ遷移
-          newGame(5, {
-            sense,
-            random,
-            slow,
-            sight,
-            fast: 0,
-          });
-          router.replace('/play');
-        }}
-        accessibilityLabel="5マス迷路を開始"
+        title="練習モード"
+        onPress={() => router.push('/practice')}
+        accessibilityLabel="練習モードを開く"
         color="#fff"
       />
-      <Button
-        title="10×10"
-        onPress={() => {
-          // 10×10 迷路を読み込んでからプレイ画面へ遷移
-          newGame(10, {
-            sense,
-            random,
-            slow,
-            sight,
-            fast: 0,
-          });
-          router.replace('/play');
-        }}
-        accessibilityLabel="10マス迷路を開始"
-        color="#fff"
-      />
+      {/* プリセットレベルの開始ボタン */}
+      {LEVELS.map((lv) => (
+        <Button
+          key={lv.id}
+          title={lv.name}
+          onPress={() => startLevel(lv.id)}
+          accessibilityLabel={`${lv.name}を開始`}
+          color="#fff"
+        />
+      ))}
     </ThemedView>
   );
 }

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useGame } from '@/src/game/useGame';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { EnemyCounter } from '@/components/EnemyCounter';
+
+export default function PracticeScreen() {
+  const router = useRouter();
+  const { newGame } = useGame();
+  // 各敵タイプの数を状態として管理
+  const [sense, setSense] = React.useState(0);
+  const [random, setRandom] = React.useState(0);
+  const [slow, setSlow] = React.useState(0);
+  const [sight, setSight] = React.useState(0);
+
+  const start = (size: number) => {
+    newGame(size, { sense, random, slow, sight, fast: 0 });
+    router.replace('/play');
+  };
+
+  return (
+    <ThemedView lightColor="#000" darkColor="#000" style={styles.container}>
+      <ThemedText type="title" lightColor="#fff" darkColor="#fff">
+        練習モード
+      </ThemedText>
+      <EnemyCounter label="等速・感知" value={sense} setValue={setSense} />
+      <EnemyCounter label="等速・ランダム" value={random} setValue={setRandom} />
+      <EnemyCounter label="鈍足・視認" value={slow} setValue={setSlow} />
+      <EnemyCounter label="等速・視認" value={sight} setValue={setSight} />
+      <Button
+        title="5×5"
+        onPress={() => start(5)}
+        accessibilityLabel="5マス迷路を開始"
+        color="#fff"
+      />
+      <Button
+        title="10×10"
+        onPress={() => start(10)}
+        accessibilityLabel="10マス迷路を開始"
+        color="#fff"
+      />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 20 },
+});

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -1,0 +1,38 @@
+import type { EnemyCounts } from '@/src/types/enemy';
+
+// 各レベルの設定をまとめた型
+export interface LevelConfig {
+  /** レベル識別子 */
+  id: string;
+  /** 画面に表示する名称 */
+  name: string;
+  /** 迷路サイズ */
+  size: number;
+  /** 出現させる敵の種類と数 */
+  enemies: EnemyCounts;
+}
+
+/**
+ * レベル定義一覧。
+ * 今後の追加や調整が容易になるよう配列で管理する。
+ */
+export const LEVELS: LevelConfig[] = [
+  {
+    id: 'level1',
+    name: 'レベル1',
+    size: 5,
+    enemies: { sense: 0, random: 0, slow: 1, sight: 0, fast: 0 },
+  },
+  {
+    id: 'level2',
+    name: 'レベル2',
+    size: 10,
+    enemies: { sense: 0, random: 0, slow: 0, sight: 1, fast: 0 },
+  },
+  {
+    id: 'level3',
+    name: 'レベル3',
+    size: 10,
+    enemies: { sense: 0, random: 0, slow: 0, sight: 2, fast: 0 },
+  },
+];


### PR DESCRIPTION
## Summary
- create `constants/levels.ts` to store preset levels
- make home screen show buttons for Practice Mode and presets
- add new `practice.tsx` for custom enemy settings
- register practice screen in router

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685dcddd7698832c88ede2cec80b6e0c