### PR TITLE
敵軌跡長をレベル・練習モードで設定可能に

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,7 +16,7 @@ export default function TitleScreen() {
   const startLevel = (id: string) => {
     const level = LEVELS.find((l) => l.id === id);
     if (!level) return;
-    newGame(level.size, level.enemies);
+    newGame(level.size, level.enemies, level.pathLength);
     router.replace('/play');
   };
   return (

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -14,9 +14,11 @@ export default function PracticeScreen() {
   const [random, setRandom] = React.useState(0);
   const [slow, setSlow] = React.useState(0);
   const [sight, setSight] = React.useState(0);
+  // 敵の軌跡を残す長さ。デフォルトは通常プレイと同じ4
+  const [pathLen, setPathLen] = React.useState(4);
 
   const start = (size: number) => {
-    newGame(size, { sense, random, slow, sight, fast: 0 });
+    newGame(size, { sense, random, slow, sight, fast: 0 }, pathLen);
     router.replace('/play');
   };
 
@@ -29,6 +31,8 @@ export default function PracticeScreen() {
       <EnemyCounter label="等速・ランダム" value={random} setValue={setRandom} />
       <EnemyCounter label="鈍足・視認" value={slow} setValue={setSlow} />
       <EnemyCounter label="等速・視認" value={sight} setValue={setSight} />
+      {/* 軌跡の長さを変更するカウンター */}
+      <EnemyCounter label="軌跡長" value={pathLen} setValue={setPathLen} />
       <Button
         title="5×5"
         onPress={() => start(5)}

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -10,6 +10,8 @@ export interface LevelConfig {
   size: number;
   /** 出現させる敵の種類と数 */
   enemies: EnemyCounts;
+  /** 敵の軌跡を何マス保存するか */
+  pathLength: number;
 }
 
 /**
@@ -22,17 +24,20 @@ export const LEVELS: LevelConfig[] = [
     name: 'レベル1',
     size: 5,
     enemies: { sense: 0, random: 0, slow: 1, sight: 0, fast: 0 },
+    pathLength: 5,
   },
   {
     id: 'level2',
     name: 'レベル2',
     size: 10,
     enemies: { sense: 0, random: 0, slow: 0, sight: 1, fast: 0 },
+    pathLength: 4,
   },
   {
     id: 'level3',
     name: 'レベル3',
     size: 10,
     enemies: { sense: 0, random: 0, slow: 0, sight: 2, fast: 0 },
+    pathLength: 3,
   },
 ];

--- a/src/game/__tests__/enemy.test.ts
+++ b/src/game/__tests__/enemy.test.ts
@@ -92,7 +92,7 @@ describe('updateEnemyPaths', () => {
   test('常に最新4点だけを保持する', () => {
     const paths = [[pos(0, 0), pos(1, 0), pos(2, 0), pos(3, 0)]];
     const enemies = [pos(4, 0)];
-    const updated = updateEnemyPaths(paths, enemies);
+    const updated = updateEnemyPaths(paths, enemies, 4);
     expect(updated[0]).toEqual([pos(1, 0), pos(2, 0), pos(3, 0), pos(4, 0)]);
   });
 });

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -475,11 +475,16 @@ export function moveEnemySense(
  * enemies は移動後の座標配列です。
  * 4 点より多い場合は古い順に削除して常に最新 4 点を保ちます。
  */
-export function updateEnemyPaths(paths: Vec2[][], enemies: Vec2[]): Vec2[][] {
+export function updateEnemyPaths(
+  paths: Vec2[][],
+  enemies: Vec2[],
+  maxLen: number,
+): Vec2[][] {
   return enemies.map((e, i) => {
     const prev = paths[i] ?? [];
     const next = [...prev, e];
-    if (next.length > 4) next.shift();
+    // 配列が指定長より長くなったら先頭を捨てる
+    while (next.length > maxLen) next.shift();
     return next;
   });
 }


### PR DESCRIPTION
## Summary
- レベル設定に `pathLength` を追加し軌跡の長さを指定
- `updateEnemyPaths` が長さを引数で受け取るよう変更
- ゲーム状態に `enemyPathLength` を保持し各所で利用
- タイトル画面はレベルごとの軌跡長を渡して開始
- 練習モードで軌跡長をボタン操作で変更可能に
- テストコードを更新

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685dd09d12e4832cbdab2cb1f8b98c40