### PR TITLE
プレイヤー軌跡と壁表示の設定追加

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,7 +16,13 @@ export default function TitleScreen() {
   const startLevel = (id: string) => {
     const level = LEVELS.find((l) => l.id === id);
     if (!level) return;
-    newGame(level.size, level.enemies, level.pathLength);
+    newGame(
+      level.size,
+      level.enemies,
+      level.enemyPathLength,
+      level.playerPathLength,
+      level.wallLifetime,
+    );
     router.replace('/play');
   };
   return (

--- a/app/play.tsx
+++ b/app/play.tsx
@@ -229,6 +229,8 @@ export default function PlayScreen() {
           showAll={debugAll}
           hitV={state.hitV}
           hitH={state.hitH}
+          playerPathLength={state.playerPathLength}
+          wallLifetime={state.wallLifetime}
           // ミニマップを1.5倍のサイズ（240px）で表示する
           size={240}
         />

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -16,9 +16,19 @@ export default function PracticeScreen() {
   const [sight, setSight] = React.useState(0);
   // 敵の軌跡を残す長さ。デフォルトは通常プレイと同じ4
   const [pathLen, setPathLen] = React.useState(4);
+  // プレイヤー軌跡の長さ。無限大を表すため Infinity を使用
+  const [playerLen, setPlayerLen] = React.useState<number>(Infinity);
+  // 壁表示ターン数。無限大なら永続表示
+  const [wallLife, setWallLife] = React.useState<number>(Infinity);
 
   const start = (size: number) => {
-    newGame(size, { sense, random, slow, sight, fast: 0 }, pathLen);
+    newGame(
+      size,
+      { sense, random, slow, sight, fast: 0 },
+      pathLen,
+      playerLen,
+      wallLife,
+    );
     router.replace('/play');
   };
 
@@ -31,8 +41,22 @@ export default function PracticeScreen() {
       <EnemyCounter label="等速・ランダム" value={random} setValue={setRandom} />
       <EnemyCounter label="鈍足・視認" value={slow} setValue={setSlow} />
       <EnemyCounter label="等速・視認" value={sight} setValue={setSight} />
-      {/* 軌跡の長さを変更するカウンター */}
-      <EnemyCounter label="軌跡長" value={pathLen} setValue={setPathLen} />
+      {/* 敵の軌跡長 */}
+      <EnemyCounter label="敵軌跡長" value={pathLen} setValue={setPathLen} />
+      {/* プレイヤーの軌跡長。無限大選択を許可 */}
+      <EnemyCounter
+        label="自分軌跡長"
+        value={playerLen}
+        setValue={setPlayerLen}
+        allowInfinity
+      />
+      {/* 壁表示ターン数 */}
+      <EnemyCounter
+        label="壁表示"
+        value={wallLife}
+        setValue={setWallLife}
+        allowInfinity
+      />
       <Button
         title="5×5"
         onPress={() => start(5)}

--- a/components/EnemyCounter.tsx
+++ b/components/EnemyCounter.tsx
@@ -13,11 +13,18 @@ export function EnemyCounter({
   label,
   value,
   setValue,
+  min = 0,
+  max = 10,
+  allowInfinity = false,
 }: {
   label: string;
   value: number;
   setValue: React.Dispatch<React.SetStateAction<number>>;
+  min?: number;
+  max?: number;
+  allowInfinity?: boolean;
 }) {
+  const display = allowInfinity && value === Infinity ? '∞' : value;
   return (
     <View style={styles.row}>
       {/* ラベル表示 */}
@@ -25,17 +32,28 @@ export function EnemyCounter({
       {/* マイナスボタンで1減らす。最小0 */}
       <Button
         title="-"
-        onPress={() => setValue((v) => Math.max(0, v - 1))}
+        onPress={() =>
+          setValue((v) => {
+            if (allowInfinity && v === Infinity) return max;
+            return Math.max(min, v - 1);
+          })
+        }
         accessibilityLabel={`${label}を減らす`}
       />
       {/* 現在値表示 */}
       <ThemedText lightColor="#fff" darkColor="#fff" style={styles.count}>
-        {value}
+        {display}
       </ThemedText>
       {/* プラスボタンで1増やす */}
       <Button
         title="+"
-        onPress={() => setValue((v) => v + 1)}
+        onPress={() =>
+          setValue((v) => {
+            const next = v === Infinity ? Infinity : v + 1;
+            if (allowInfinity && next > max) return Infinity;
+            return Math.min(max, next);
+          })
+        }
         accessibilityLabel={`${label}を増やす`}
       />
     </View>

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -11,7 +11,11 @@ export interface LevelConfig {
   /** 出現させる敵の種類と数 */
   enemies: EnemyCounts;
   /** 敵の軌跡を何マス保存するか */
-  pathLength: number;
+  enemyPathLength: number;
+  /** プレイヤー軌跡の長さ */
+  playerPathLength: number;
+  /** 壁表示を維持するターン数 */
+  wallLifetime: number;
 }
 
 /**
@@ -24,20 +28,26 @@ export const LEVELS: LevelConfig[] = [
     name: 'レベル1',
     size: 5,
     enemies: { sense: 0, random: 0, slow: 1, sight: 0, fast: 0 },
-    pathLength: 5,
+    enemyPathLength: 5,
+    playerPathLength: Infinity,
+    wallLifetime: Infinity,
   },
   {
     id: 'level2',
     name: 'レベル2',
     size: 10,
     enemies: { sense: 0, random: 0, slow: 0, sight: 1, fast: 0 },
-    pathLength: 4,
+    enemyPathLength: 4,
+    playerPathLength: 8,
+    wallLifetime: 10,
   },
   {
     id: 'level3',
     name: 'レベル3',
     size: 10,
     enemies: { sense: 0, random: 0, slow: 0, sight: 2, fast: 0 },
-    pathLength: 3,
+    enemyPathLength: 3,
+    playerPathLength: 3,
+    wallLifetime: 5,
   },
 ];

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -490,6 +490,34 @@ export function updateEnemyPaths(
 }
 
 /**
+ * プレイヤーの移動履歴を更新するヘルパー。
+ * maxLen が無限大 (Infinity) の場合は全て残す。
+ */
+export function updatePlayerPath(
+  path: Vec2[],
+  pos: Vec2,
+  maxLen: number,
+): Vec2[] {
+  const next = [...path, pos];
+  // 指定長より長くなったら古いものから削除
+  while (maxLen !== Infinity && next.length > maxLen) next.shift();
+  return next;
+}
+
+/**
+ * 衝突壁マップの寿命を 1 減らす。
+ * 0 以下になった要素は取り除く。
+ */
+export function decayHitMap(map: Map<string, number>): Map<string, number> {
+  const next = new Map<string, number>();
+  map.forEach((v, k) => {
+    const nv = v === Infinity ? Infinity : v - 1;
+    if (nv > 0 || nv === Infinity) next.set(k, nv);
+  });
+  return next;
+}
+
+/**
  * 盤面サイズからランダムなマス座標を返す関数。
  * rnd を渡すと任意の乱数でテストしやすくなる。
  */


### PR DESCRIPTION
## Summary
- プレイヤー軌跡長と壁表示ターンをレベル設定に追加
- MiniMap がプレイヤー軌跡と衝突壁をグラデーション表示
- EnemyCounter が無限大選択に対応
- 練習モードで軌跡長と壁表示ターンを変更可能
- GameState と useGame を拡張して各値を管理

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685dd2d19508832c90f8c35761a8f283