### PR TITLE
Add enemy type differentiation with dev colors

### DIFF
--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -40,4 +40,11 @@ export const LEVELS: LevelConfig[] = [
     enemies: { sense: 0, random: 0, slow: 0, sight: 2, fast: 0 },
     pathLength: 3,
   },
+  {
+    id: 'level4',
+    name: 'レベル4',
+    size: 10,
+    enemies: { sense: 0, random: 0, slow: 1, sight: 1, fast: 0 },
+    pathLength: 4,
+  },
 ];

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -229,8 +229,17 @@ export function MiniMap({
 
   // 敵を星形で描画
   const renderEnemies = () => {
+    // __DEV__ は React Native が提供する開発判定フラグ
+    const colorMap = {
+      random: '#999',
+      sense: '#0ff',
+      slow: '#fa0',
+      sight: '#0f0',
+      fast: '#f0f',
+    } as const;
     return enemies.map((e, i) => {
       if (!e.visible && !showAll) return null;
+      const color = __DEV__ ? colorMap[e.kind ?? 'random'] : 'white';
       return (
         <Polygon
           key={`enemy${i}`}
@@ -239,7 +248,7 @@ export function MiniMap({
             (e.pos.y + 0.5) * cell,
             cell * 0.35,
           )}
-          fill="white"
+          fill={color}
         />
       );
     });

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -40,6 +40,7 @@ function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
       cooldown: 0,
       target: null,
       behavior: 'sense',
+      kind: 'sense',
     });
   });
   spawnEnemies(counts.random, maze, Math.random, exclude).forEach((p) => {
@@ -51,6 +52,7 @@ function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
       cooldown: 0,
       target: null,
       behavior: 'random',
+      kind: 'random',
     });
   });
   spawnEnemies(counts.slow, maze, Math.random, exclude).forEach((p) => {
@@ -63,6 +65,7 @@ function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
       cooldown: 1,
       target: null,
       behavior: 'sight',
+      kind: 'slow',
     });
   });
   spawnEnemies(counts.sight, maze, Math.random, exclude).forEach((p) => {
@@ -74,6 +77,7 @@ function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
       cooldown: 0,
       target: null,
       behavior: 'sight',
+      kind: 'sight',
     });
   });
   spawnEnemies(counts.fast ?? 0, maze, Math.random, exclude).forEach((p) => {
@@ -85,6 +89,7 @@ function createEnemies(counts: EnemyCounts, maze: MazeData): Enemy[] {
       cooldown: 0,
       target: null,
       behavior: 'smart',
+      kind: 'fast',
     });
   });
   return enemies;

--- a/src/types/enemy.ts
+++ b/src/types/enemy.ts
@@ -1,6 +1,9 @@
 /** 敵の行動パターンを表す文字列型 */
 export type EnemyBehavior = 'smart' | 'random' | 'sight' | 'sense';
 
+/** 敵の種類を表す文字列型 */
+export type EnemyKind = 'random' | 'sense' | 'slow' | 'sight' | 'fast';
+
 export interface Enemy {
   pos: import('./maze').Vec2;
   /** プレイヤーから見えるかどうか */
@@ -15,6 +18,8 @@ export interface Enemy {
   target?: import('./maze').Vec2 | null;
   /** 敵固有の行動パターン */
   behavior: EnemyBehavior;
+  /** スポーン時の種別。描画色の判定に利用する */
+  kind?: EnemyKind;
 }
 
 export interface EnemyCounts {


### PR DESCRIPTION
## Summary
- add `EnemyKind` type and store kind on each enemy
- draw enemies in different colors during development
- include new level with mixed enemy types

## Testing
- `pnpm lint`
- `npx tsc -p tsconfig.json` *(fails: Cannot find name 'describe' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685dd3a13c3c832cab273fece6624af2