### PR TITLE
Update border color feedback

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import {
   Button,
   Modal,
@@ -28,6 +28,7 @@ import { useGame } from "@/src/game/useGame";
 import {
   applyBumpFeedback,
   applyDistanceFeedback,
+  distance,
   nextPosition,
 } from "@/src/game/utils";
 
@@ -63,6 +64,20 @@ export default function PlayScreen() {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   // applyDistanceFeedback で使う setInterval の ID を保持
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // 現在位置からゴールまでのマンハッタン距離に応じた色を求める
+  const calcBorderColor = useCallback((p: { x: number; y: number }): string => {
+    const maxDist = (maze.size - 1) * 2;
+    const d = distance(p, { x: maze.goal[0], y: maze.goal[1] });
+    const r = Math.min(d / maxDist, 1);
+    const g = Math.round(255 * (1 - r));
+    return `rgb(${g},${g},${g})`;
+  }, [maze.goal, maze.size]);
+
+  useEffect(() => {
+    // 移動後は常に距離に応じた色へ更新する
+    setBorderColor(calcBorderColor(state.pos));
+  }, [state.pos, calcBorderColor]);
   // 枠の太さを共通化するため縦横で別々の AnimatedStyle を用意
   const vertStyle = useAnimatedStyle(() => ({ height: borderW.value }));
   const horizStyle = useAnimatedStyle(() => ({ width: borderW.value }));
@@ -174,6 +189,8 @@ export default function PlayScreen() {
     let wait: number;
     if (!move(dir)) {
       wait = applyBumpFeedback(borderW, setBorderColor);
+      // 衝突後は元の距離色に戻す
+      setTimeout(() => setBorderColor(calcBorderColor(state.pos)), wait);
     } else {
       // 盤面サイズから求めた最大マンハッタン距離 (例: 10×10 なら 18)
       const maxDist = (maze.size - 1) * 2;

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -127,8 +127,7 @@ export function applyBumpFeedback(
     withDelay(showTime, withTiming(0, { duration: 150 }))
   );
 
-  // フィードバック終了後に色を元へ戻す
-  setTimeout(() => setColor("white"), showTime + 300);
+  // 色のリセットは呼び出し側で行う
   // 次回入力まで待つ時間を返す
   return showTime + 300;
 }


### PR DESCRIPTION
## Summary
- keep border color based on Manhattan distance
- restore color after bump feedback
- stop resetting color inside `applyBumpFeedback`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685f03198f50832c9ebf1a5551ef6323