### PR TITLE
Fix LevelConfig property typo

### DIFF
--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -55,6 +55,7 @@ export const LEVELS: LevelConfig[] = [
     name: 'レベル4',
     size: 10,
     enemies: { sense: 0, random: 0, slow: 1, sight: 1, fast: 0 },
-    pathLength: 4,
+    // プレイヤーの軌跡表示は 4 マス分だけ残す
+    playerPathLength: 4,
   },
 ];


### PR DESCRIPTION
## Summary
- fix a typo in constants/levels.ts so `playerPathLength` is used

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685f3362a378832cadad38cad33a7037