### PR TITLE
Add PlainButton component and update buttons

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { PlainButton } from '@/components/PlainButton';
 import { useRouter } from 'expo-router';
 import { useGame } from '@/src/game/useGame';
 
@@ -37,20 +38,18 @@ export default function TitleScreen() {
         Haptic Maze
       </ThemedText>
       {/* 練習モードへの遷移 */}
-      <Button
+      <PlainButton
         title="練習モード"
         onPress={() => router.push('/practice')}
         accessibilityLabel="練習モードを開く"
-        color="#fff"
       />
       {/* プリセットレベルの開始ボタン */}
       {LEVELS.map((lv) => (
-        <Button
+        <PlainButton
           key={lv.id}
           title={lv.name}
           onPress={() => startLevel(lv.id)}
           accessibilityLabel={`${lv.name}を開始`}
-          color="#fff"
         />
       ))}
     </ThemedView>

--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
-  Button,
   Modal,
   StyleSheet,
   View,
@@ -23,6 +22,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { DPad } from "@/components/DPad";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
+import { PlainButton } from "@/components/PlainButton";
 import { MiniMap } from "@/src/components/MiniMap";
 import type { MazeData as MazeView, Dir } from "@/src/types/maze";
 import { useGame } from "@/src/game/useGame";
@@ -297,12 +297,12 @@ export default function PlayScreen() {
           onPress={() => setShowMenu(false)}
         >
           <View style={[styles.menuContent, { top: insets.top + 40 }]}>
-            <Button
+            <PlainButton
               title="Reset Maze"
               onPress={handleReset}
               accessibilityLabel="迷路を最初から"
             />
-            <Button
+            <PlainButton
               title="Exit to Title"
               onPress={handleExit}
               accessibilityLabel="タイトルへ戻る"
@@ -332,7 +332,7 @@ export default function PlayScreen() {
             <ThemedText>
               Stage: {state.stage}/{totalStages}
             </ThemedText>
-            <Button
+            <PlainButton
               title="OK"
               onPress={handleOk}
               accessibilityLabel="タイトルへ戻る"

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { PlainButton } from '@/components/PlainButton';
 import { useRouter } from 'expo-router';
 import { useGame } from '@/src/game/useGame';
 import { ThemedText } from '@/components/ThemedText';
@@ -57,17 +58,15 @@ export default function PracticeScreen() {
         setValue={setWallLife}
         allowInfinity
       />
-      <Button
+      <PlainButton
         title="5×5"
         onPress={() => start(5)}
         accessibilityLabel="5マス迷路を開始"
-        color="#fff"
       />
-      <Button
+      <PlainButton
         title="10×10"
         onPress={() => start(10)}
         accessibilityLabel="10マス迷路を開始"
-        color="#fff"
       />
     </ThemedView>
   );

--- a/components/EnemyCounter.tsx
+++ b/components/EnemyCounter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { PlainButton } from '@/components/PlainButton';
 
 import { ThemedText } from '@/components/ThemedText';
 
@@ -30,7 +31,7 @@ export function EnemyCounter({
       {/* ラベル表示 */}
       <ThemedText lightColor="#fff" darkColor="#fff">{label}</ThemedText>
       {/* マイナスボタンで1減らす。最小0 */}
-      <Button
+      <PlainButton
         title="-"
         onPress={() =>
           setValue((v) => {
@@ -45,7 +46,7 @@ export function EnemyCounter({
         {display}
       </ThemedText>
       {/* プラスボタンで1増やす */}
-      <Button
+      <PlainButton
         title="+"
         onPress={() =>
           setValue((v) => {

--- a/components/PlainButton.tsx
+++ b/components/PlainButton.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet, type PressableProps } from 'react-native';
+
+interface PlainButtonProps {
+  title: string;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+  disabled?: boolean;
+  /**
+   * 外から追加のスタイルを渡したいとき用
+   */
+  style?: PressableProps['style'];
+}
+
+/**
+ * 黒背景・白文字のシンプルなボタン
+ * 初心者でも分かりやすいように Pressable と Text を組み合わせている
+ */
+export function PlainButton({
+  title,
+  onPress,
+  accessibilityLabel,
+  disabled = false,
+  style,
+}: PlainButtonProps) {
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel ?? title}
+      onPress={onPress}
+      disabled={disabled}
+      style={(state) => [
+        styles.button,
+        state.pressed && styles.pressed,
+        disabled && styles.disabled,
+        typeof style === 'function' ? style(state) : style,
+      ]}
+    >
+      <Text style={styles.text}>{title}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: '#000',
+    borderRadius: 4,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    // 最低でも 48dp の高さを確保し、指で押しやすくする
+    minHeight: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: '#fff',
+  },
+  pressed: {
+    opacity: 0.7,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});


### PR DESCRIPTION
## Summary
- implement PlainButton using Pressable and Text
- swap old `<Button>` usages to `<PlainButton>` across screens
- adjust EnemyCounter to use the new button

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685f3e3c8844832ca8269301c39de82c