### PR TITLE
Implement 3-stage map reset

### DIFF
--- a/src/game/__tests__/stageUtils.test.ts
+++ b/src/game/__tests__/stageUtils.test.ts
@@ -1,4 +1,4 @@
-import { randomCell, biasedPickGoal } from '../utils';
+import { randomCell, biasedPickGoal, shouldChangeMap } from '../utils';
 import type { Vec2 } from '@/src/types/maze';
 
 describe('randomCell', () => {
@@ -23,5 +23,17 @@ describe('biasedPickGoal', () => {
   test('大きな乱数では遠い方が選ばれる', () => {
     const rnd = jest.fn().mockReturnValue(0.9); // 0.9*12 = 10.8 >2
     expect(biasedPickGoal(start, cells, rnd)).toEqual(cells[1]);
+  });
+});
+
+describe('shouldChangeMap', () => {
+  test('3 の倍数ステージで迷路を変更する', () => {
+    expect(shouldChangeMap(3)).toBe(true);
+    expect(shouldChangeMap(6)).toBe(true);
+  });
+
+  test('それ以外のステージでは迷路を維持する', () => {
+    expect(shouldChangeMap(1)).toBe(false);
+    expect(shouldChangeMap(2)).toBe(false);
   });
 });

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -11,6 +11,7 @@ import {
   randomCell,
   biasedPickGoal,
   allCells,
+  shouldChangeMap,
 } from './utils';
 import { getEnemyMover, selectEnemyBehavior, type EnemyBehavior } from './enemy';
 import { loadMaze } from './loadMaze';
@@ -148,8 +149,8 @@ function createFirstStage(
  */
 function nextStageState(state: State): State {
   const size = state.mazeRaw.size;
-  // size の倍数ステージクリアごとに迷路を変更する
-  const changeMap = state.stage % size === 0;
+  // STAGE_PER_MAP の倍数ステージクリアごとに迷路を変更する
+  const changeMap = shouldChangeMap(state.stage);
   // 迷路を継続する場合は同じレイアウトを使う
   const base = changeMap ? loadMaze(size) : state.mazeRaw;
   // 次のスタート地点は前回ゴールしたマス

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -555,3 +555,17 @@ export function allCells(size: number): Vec2[] {
   }
   return cells;
 }
+
+/**
+ * 何ステージごとに新しい迷路を読み込むかを示す定数。
+ * 現在は 3 ステージごとにリセットする仕様です。
+ */
+export const STAGE_PER_MAP = 3;
+
+/**
+ * 現在のステージ番号から迷路を変更すべきか判定します。
+ * stage が STAGE_PER_MAP の倍数なら true を返します。
+ */
+export function shouldChangeMap(stage: number): boolean {
+  return stage % STAGE_PER_MAP === 0;
+}


### PR DESCRIPTION
## Summary
- decide map reset timing with `shouldChangeMap`
- update `nextStageState` to use the helper
- test the new logic

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685f5a0dda9c832c88b52b524b1d1394