### PR TITLE
敵探索ロジックを訪問回数で選択

### DIFF
--- a/src/game/__tests__/enemy.test.ts
+++ b/src/game/__tests__/enemy.test.ts
@@ -33,14 +33,14 @@ const wallMaze: MazeData & { v_walls: Set<string>; h_walls: Set<string> } = {
 describe('moveEnemySmart', () => {
   test('プレイヤーが近いときは接近する', () => {
     const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null, behavior: 'smart' };
-    const visited = new Set<string>();
+    const visited = new Map<string, number>();
     const moved = moveEnemySmart(e, baseMaze, visited, pos(2, 0), () => 0);
     expect(moved.pos).toEqual(pos(1, 0));
   });
 
   test('壁を避けてでも距離2以内なら接近する', () => {
     const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null, behavior: 'smart' };
-    const visited = new Set<string>();
+    const visited = new Map<string, number>();
     // プレイヤーは (1,1)。直線では近いが壁により回り道で2歩
     const moved = moveEnemySmart(e, wallMaze, visited, pos(1, 1), () => 0);
     expect(moved.pos).toEqual(pos(0, 1));
@@ -48,7 +48,7 @@ describe('moveEnemySmart', () => {
 
   test('壁で遠回りになる場合は接近しない', () => {
     const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null, behavior: 'smart' };
-    const visited = new Set<string>();
+    const visited = new Map<string, number>();
     // プレイヤーは (1,0) だが壁のせいで最短距離は3歩
     const moved = moveEnemySmart(e, wallMaze, visited, pos(1, 0), () => 0);
     expect(moved.pos).not.toEqual(pos(0, 1));
@@ -56,7 +56,11 @@ describe('moveEnemySmart', () => {
 
   test('未踏マスを優先して進む', () => {
     const e = { pos: pos(1, 1), visible: true, interval: 1, repeat: 1, cooldown: 0, target: null, behavior: 'smart' };
-    const visited = new Set<string>(['2,1', '1,0', '1,2']);
+    const visited = new Map<string, number>([
+      ['2,1', 1],
+      ['1,0', 1],
+      ['1,2', 1],
+    ]);
     const moved = moveEnemySmart(e, baseMaze, visited, pos(9, 9), () => 0);
     expect(moved.pos).toEqual(pos(0, 1));
   });
@@ -65,14 +69,18 @@ describe('moveEnemySmart', () => {
 describe('moveEnemySense', () => {
   test('感知範囲内ならプレイヤーへ近づく', () => {
     const e = { pos: pos(0, 0), visible: true, interval: 1, repeat: 1, cooldown: 0, behavior: 'sense' };
-    const visited = new Set<string>();
+    const visited = new Map<string, number>();
     const moved = moveEnemySense(e, baseMaze, visited, pos(2, 1), () => 0, 3);
     expect(moved.pos).toEqual(pos(0, 1));
   });
 
   test('範囲外では未踏マスを優先', () => {
     const e = { pos: pos(1, 1), visible: true, interval: 1, repeat: 1, cooldown: 0, behavior: 'sense' };
-    const visited = new Set<string>(['2,1', '1,0', '1,2']);
+    const visited = new Map<string, number>([
+      ['2,1', 1],
+      ['1,0', 1],
+      ['1,2', 1],
+    ]);
     const moved = moveEnemySense(e, baseMaze, visited, pos(9, 9), () => 0, 3);
     expect(moved.pos).toEqual(pos(0, 1));
   });

--- a/src/game/enemy.ts
+++ b/src/game/enemy.ts
@@ -6,7 +6,7 @@ import { moveEnemyRandom, moveEnemySmart, moveEnemySight, moveEnemySense } from 
 export type EnemyMover = (
   enemy: Enemy,
   maze: MazeData,
-  visited: Set<string>,
+  visited: Map<string, number>,
   player: Vec2,
   rnd?: () => number,
 ) => Enemy;
@@ -26,7 +26,7 @@ export function getEnemyMover(behavior: EnemyBehavior): EnemyMover {
       return (
         e: Enemy,
         maze: MazeData,
-        _v: Set<string>,
+        _v: Map<string, number>,
         _p: Vec2,
         rnd: () => number = Math.random,
       ) => moveEnemyRandom(e, maze, _v, _p, rnd);

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -218,7 +218,8 @@ export interface GameState {
   /** 衝突した横壁と残りターン数 */
   hitH: Map<string, number>;
   enemies: Enemy[];
-  enemyVisited: Set<string>[];
+  /** 各敵が踏んだマスの回数を記録する */
+  enemyVisited: Map<string, number>[];
   enemyPaths: Vec2[][];
   /** 敵に捕まったとき true になる */
   caught: boolean;
@@ -272,7 +273,9 @@ function initState(
     hitV,
     hitH,
     enemies,
-    enemyVisited: enemies.map((e) => new Set([`${e.pos.x},${e.pos.y}`])),
+    enemyVisited: enemies.map(
+      (e) => new Map([[`${e.pos.x},${e.pos.y}`, 1]])
+    ),
     enemyPaths: enemies.map((e) => [{ ...e.pos }]),
     caught: false,
     stage,
@@ -352,10 +355,10 @@ function reducer(state: State, action: Action): State {
         steps += 1;
       }
 
-      const newVisited: Set<string>[] = [];
+      const newVisited: Map<string, number>[] = [];
       const movedEnemies = enemies.map((e, i) => {
         const mover = getEnemyMover(e.behavior ?? state.enemyBehavior);
-        const visited = new Set(state.enemyVisited[i]);
+        const visited = new Map(state.enemyVisited[i]);
         if (e.cooldown > 0) {
           newVisited.push(visited);
           return { ...e, cooldown: e.cooldown - 1 };
@@ -363,7 +366,8 @@ function reducer(state: State, action: Action): State {
         let current = e;
         for (let r = 0; r < e.repeat; r++) {
           current = mover(current, maze, visited, newPos);
-          visited.add(`${current.pos.x},${current.pos.y}`);
+          const key = `${current.pos.x},${current.pos.y}`;
+          visited.set(key, (visited.get(key) ?? 0) + 1);
         }
         newVisited.push(visited);
         return {


### PR DESCRIPTION
## Summary
- 敵共通行動 `moveEnemyBasic` を未踏回数の少ないマスへ移動する仕様に変更
- `EnemyMover` と各移動関数を訪問履歴 `Map` 型へ対応
- `useGame` の敵訪問データを回数記録に変更
- テストも新仕様に合わせて更新

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685f5987182c832cbd777143c2a06ceb