### PR TITLE
Fix bump feedback frame

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   Modal,
   StyleSheet,
@@ -29,7 +29,6 @@ import { useGame } from "@/src/game/useGame";
 import {
   applyBumpFeedback,
   applyDistanceFeedback,
-  distance,
   nextPosition,
 } from "@/src/game/utils";
 
@@ -59,7 +58,7 @@ export default function PlayScreen() {
   // 全てを可視化するかのフラグ。デフォルトはオフ
   const [debugAll, setDebugAll] = useState(false);
   // 枠線の色を状態として管理
-  const [borderColor, setBorderColor] = useState("white");
+  const [borderColor, setBorderColor] = useState("transparent");
   const borderW = useSharedValue(0);
   // ゴール到達時に画面左右から中央まで埋まるよう
   // 枠線の最大太さを画面幅の半分に設定する
@@ -70,22 +69,6 @@ export default function PlayScreen() {
   // applyDistanceFeedback で使う setInterval の ID を保持
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  // 現在位置からゴールまでのマンハッタン距離に応じた色を求める
-  const calcBorderColor = useCallback(
-    (p: { x: number; y: number }): string => {
-      const maxDist = (maze.size - 1) * 2;
-      const d = distance(p, { x: maze.goal[0], y: maze.goal[1] });
-      const r = Math.min(d / maxDist, 1);
-      const g = Math.round(255 * (1 - r));
-      return `rgb(${g},${g},${g})`;
-    },
-    [maze.goal, maze.size]
-  );
-
-  useEffect(() => {
-    // 移動後は常に距離に応じた色へ更新する
-    setBorderColor(calcBorderColor(state.pos));
-  }, [state.pos, calcBorderColor]);
   // 枠の太さを共通化するため縦横で別々の AnimatedStyle を用意
   const vertStyle = useAnimatedStyle(() => ({ height: borderW.value }));
   const horizStyle = useAnimatedStyle(() => ({ width: borderW.value }));
@@ -203,8 +186,8 @@ export default function PlayScreen() {
     let wait: number;
     if (!move(dir)) {
       wait = applyBumpFeedback(borderW, setBorderColor);
-      // 衝突後は元の距離色に戻す
-      setTimeout(() => setBorderColor(calcBorderColor(state.pos)), wait);
+      // 衝突表示が終わったら色を戻す
+      setTimeout(() => setBorderColor("transparent"), wait);
     } else {
       // 盤面サイズから求めた最大マンハッタン距離 (例: 10×10 なら 18)
       const maxDist = (maze.size - 1) * 2;

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -106,34 +106,40 @@ export function applyDistanceFeedback(
  * 200ms 間繰り返して振動させます。
  * setColor には枠線の色を変更する関数を渡します。
  */
+export interface BumpFeedbackOptions extends FeedbackOptions {
+  /** 枠線の太さ (px)。未指定なら 50 */
+  width?: number;
+  /** 表示時間 (ms)。未指定なら 100 */
+  showTime?: number;
+}
+
 export function applyBumpFeedback(
   borderW: SharedValue<number>,
   setColor: (color: string) => void,
-  opts: FeedbackOptions = {}
+  opts: BumpFeedbackOptions = {}
 ): number {
-  // 暫定実装として太さ 50px、表示時間 100ms に固定
-  // showTime は枠線が表示される総時間を表す
-  const width = 50;
-  const showTime = 100;
+  // 枠線の太さと表示時間。デフォルト値を用意して分かりやすくする
+  const width = opts.width ?? 50;
+  const showTime = opts.showTime ?? 100;
 
   // 枠線を赤く変更する
   setColor("red");
 
-  // 100ms だけ Heavy スタイルで振動させる
+  // 指定時間だけ Heavy スタイルで振動させる
   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
   const id = setInterval(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
   }, 50);
-  setTimeout(() => clearInterval(id), 100);
+  setTimeout(() => clearInterval(id), showTime);
 
   // 枠線を表示 → すぐ非表示とするため 50ms ずつアニメーション
   borderW.value = withSequence(
-    withTiming(width, { duration: 50 }),
-    withTiming(0, { duration: 50 })
+    withTiming(width, { duration: showTime / 2 }),
+    withTiming(0, { duration: showTime / 2 })
   );
 
   // 色のリセットは呼び出し側で行う
-  // 呼び出し元へ待ち時間を返す（ここでは100ms）
+  // 呼び出し元へ待ち時間を返す
   return showTime;
 }
 


### PR DESCRIPTION
## Summary
- show screen frame only for collision feedback
- reset frame color after bump
- expose border width and duration via `BumpFeedbackOptions`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685f6830208c832c98d89c98aff2842e