### PR TITLE
プレイヤー軌跡の線幅を1pxに統一

### DIFF
--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -241,7 +241,7 @@ export function MiniMap({
             x2={(b.x + 0.5) * cell}
             y2={(b.y + 0.5) * cell}
             stroke="white"
-            strokeWidth={2}
+            strokeWidth={1}
           />
         );
       } else {
@@ -270,7 +270,7 @@ export function MiniMap({
               x2={(b.x + 0.5) * cell}
               y2={(b.y + 0.5) * cell}
               stroke={`url(#${id})`}
-              strokeWidth={2}
+              strokeWidth={1}
             />
           </React.Fragment>
         );


### PR DESCRIPTION
## Summary
- プレイヤーの軌跡を描画する `MiniMap` の線幅を 1px に変更
- これにより敵の軌跡と同じ太さになる

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685f785f8bac832cb7494e23f2b5d12b