### PR TITLE
Implement new Level1 settings and dynamic enemy counts

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -23,6 +23,7 @@ export default function TitleScreen() {
       level.enemyPathLength,
       level.playerPathLength,
       level.wallLifetime,
+      level.enemyCountsFn,
     );
     router.replace('/play');
   };

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -28,6 +28,7 @@ export default function PracticeScreen() {
       pathLen,
       playerLen,
       wallLife,
+      undefined,
     );
     router.replace('/play');
   };

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -1,4 +1,5 @@
 import type { EnemyCounts } from '@/src/types/enemy';
+import { level1EnemyCounts } from '@/src/game/level1';
 
 // 各レベルの設定をまとめた型
 export interface LevelConfig {
@@ -16,6 +17,8 @@ export interface LevelConfig {
   playerPathLength: number;
   /** 壁表示を維持するターン数 */
   wallLifetime: number;
+  /** ステージ番号から敵数を決める関数。未指定なら enemies を使う */
+  enemyCountsFn?: (stage: number) => EnemyCounts;
 }
 
 /**
@@ -26,11 +29,16 @@ export const LEVELS: LevelConfig[] = [
   {
     id: 'level1',
     name: 'レベル1',
-    size: 5,
-    enemies: { random: 0, slow: 1, sight: 0, fast: 0 },
+    // 10×10 マップを使用
+    size: 10,
+    // 初回は関数から得た設定を使うため 0 で初期化
+    enemies: { random: 0, slow: 0, sight: 0, fast: 0 },
     enemyPathLength: 5,
-    playerPathLength: Infinity,
+    // 自分軌跡は 7 マス表示
+    playerPathLength: 7,
+    // 壁表示は無限大
     wallLifetime: Infinity,
+    enemyCountsFn: level1EnemyCounts,
   },
   {
     id: 'level2',

--- a/src/game/__tests__/level1EnemyCounts.test.ts
+++ b/src/game/__tests__/level1EnemyCounts.test.ts
@@ -1,0 +1,18 @@
+import { level1EnemyCounts } from '../level1';
+
+/**
+ * level1EnemyCounts の挙動確認テスト
+ */
+describe('level1EnemyCounts', () => {
+  test('ステージ1ではランダム敵1体', () => {
+    expect(level1EnemyCounts(1)).toEqual({ random: 1, slow: 0, sight: 0, fast: 0 });
+  });
+
+  test('ステージ2でもランダム敵1体', () => {
+    expect(level1EnemyCounts(2)).toEqual({ random: 1, slow: 0, sight: 0, fast: 0 });
+  });
+
+  test('ステージ3では鈍足敵1体', () => {
+    expect(level1EnemyCounts(3)).toEqual({ random: 0, slow: 1, sight: 0, fast: 0 });
+  });
+});

--- a/src/game/level1.ts
+++ b/src/game/level1.ts
@@ -1,0 +1,15 @@
+import type { EnemyCounts } from '@/src/types/enemy';
+
+/**
+ * レベル1専用の敵出現数を返す関数。
+ * stage を 1 からカウントし、3で割った余りで出現する敵を決定する。
+ * - 余り0: 鈍足・視認の敵を1体
+ * - 余り1または2: 等速・ランダムの敵を1体
+ */
+export function level1EnemyCounts(stage: number): EnemyCounts {
+  const mod = stage % 3;
+  if (mod === 0) {
+    return { random: 0, slow: 1, sight: 0, fast: 0 };
+  }
+  return { random: 1, slow: 0, sight: 0, fast: 0 };
+}


### PR DESCRIPTION
## Summary
- add stage-dependent enemy count function for Level 1
- allow LevelConfig to specify enemyCountsFn
- update useGame logic to use enemyCountsFn
- pass enemyCountsFn when starting games
- add tests for level1EnemyCounts

## Testing
- `pnpm lint`
- `npx jest` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f7ad900b8832c9dd7d244e63061f1