### PR TITLE
Fix practice enemy selection

### DIFF
--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -331,7 +331,9 @@ function reducer(state: State, action: Action): State {
         action.enemyPathLength ?? state.enemyPathLength,
         action.playerPathLength ?? state.playerPathLength,
         action.wallLifetime ?? state.wallLifetime,
-        action.enemyCountsFn ?? state.enemyCountsFn,
+        // 練習モードでは前回レベルの設定を引き継がないよう
+        // 明示的に undefined を渡す
+        action.enemyCountsFn,
       );
     case 'nextStage':
       return nextStageState(state);


### PR DESCRIPTION
## Summary
- 練習モードで前回レベルの enemyCountsFn が残っていると敵数が 1 体に固定される問題を修正

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685f7f8bc7e0832c9b0ef2fc427dcb0d