### PR TITLE
Update level spawn rules

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -24,6 +24,7 @@ export default function TitleScreen() {
       level.playerPathLength,
       level.wallLifetime,
       level.enemyCountsFn,
+      level.biasedSpawn,
     );
     router.replace('/play');
   };

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -29,6 +29,7 @@ export default function PracticeScreen() {
       playerLen,
       wallLife,
       undefined,
+      true,
     );
     router.replace('/play');
   };

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -19,6 +19,8 @@ export interface LevelConfig {
   wallLifetime: number;
   /** ステージ番号から敵数を決める関数。未指定なら enemies を使う */
   enemyCountsFn?: (stage: number) => EnemyCounts;
+  /** 敵スポーン位置をスタートから遠い場所に偏らせるか */
+  biasedSpawn?: boolean;
 }
 
 /**
@@ -39,15 +41,18 @@ export const LEVELS: LevelConfig[] = [
     // 壁表示は無限大
     wallLifetime: Infinity,
     enemyCountsFn: level1EnemyCounts,
+    biasedSpawn: false,
   },
   {
     id: 'level2',
     name: 'レベル2',
     size: 10,
-    enemies: { random: 0, slow: 0, sight: 1, fast: 0 },
-    enemyPathLength: 4,
-    playerPathLength: 8,
-    wallLifetime: 10,
+    enemies: { random: 0, slow: 0, sight: 0, fast: 0 },
+    enemyPathLength: 5,
+    playerPathLength: 7,
+    wallLifetime: Infinity,
+    enemyCountsFn: level1EnemyCounts,
+    biasedSpawn: true,
   },
   {
     id: 'level3',
@@ -57,6 +62,7 @@ export const LEVELS: LevelConfig[] = [
     enemyPathLength: 3,
     playerPathLength: 3,
     wallLifetime: 5,
+    biasedSpawn: true,
   },
   {
     id: 'level4',
@@ -65,5 +71,6 @@ export const LEVELS: LevelConfig[] = [
     enemies: { random: 0, slow: 1, sight: 1, fast: 0 },
     // プレイヤーの軌跡表示は 4 マス分だけ残す
     playerPathLength: 4,
+    biasedSpawn: true,
   },
 ];

--- a/src/game/__tests__/enemy.test.ts
+++ b/src/game/__tests__/enemy.test.ts
@@ -78,7 +78,7 @@ describe('moveEnemySight', () => {
 describe('spawnEnemies', () => {
   test('スタートとゴールには配置されない', () => {
     // rnd が常に 0 を返すと候補配列の先頭が選ばれる
-    const enemies = spawnEnemies(1, baseMaze, () => 0);
+    const enemies = spawnEnemies(1, baseMaze, () => 0, undefined, true);
     expect(enemies[0]).toEqual(pos(0, 1));
     expect(enemies[0]).not.toEqual(pos(0, 0));
     expect(enemies[0]).not.toEqual(pos(9, 9));

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -236,7 +236,8 @@ export function spawnEnemies(
   count: number,
   maze: MazeData,
   rnd: () => number = Math.random,
-  exclude: Set<string> = new Set()
+  exclude: Set<string> = new Set(),
+  biased: boolean = true
 ): Vec2[] {
   const enemies: Vec2[] = [];
   const start = { x: maze.start[0], y: maze.start[1] };
@@ -249,9 +250,12 @@ export function spawnEnemies(
     return true;
   });
 
-  // 候補マスから一つずつ選び、選ばれる確率はスタートから遠いほど高い
+  // 候補マスから一つずつ選ぶ。biased が true の場合はスタートから遠いほど
+  // 選ばれやすくする
   while (enemies.length < count && candidates.length > 0) {
-    const cell = biasedPickGoal(start, candidates, rnd);
+    const cell = biased
+      ? biasedPickGoal(start, candidates, rnd)
+      : candidates[Math.floor(rnd() * candidates.length)];
     const key = `${cell.x},${cell.y}`;
     enemies.push(cell);
     exclude.add(key);


### PR DESCRIPTION
## Summary
- add biasedSpawn flag in level configs and adjust existing levels
- support unbiased enemy spawn for new level1
- keep old level1 settings as level2
- pass spawn flag through game state and logic
- update tests for new spawnEnemies signature

## Testing
- `pnpm lint` *(fails: pnpm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68619c4f3280832cb682be8f8cae203f