### PR TITLE
fix: スタート表示を枠線のみ描画

### DIFF
--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -384,24 +384,26 @@ export function MiniMap({
         {renderPath()}
         {renderEnemyPaths()}
         {renderVisitedGoals()}
-        {/* スタート位置は showAll 時のみ描画 */}
+        {/* スタート位置は枠線のみで表示する */}
         {showAll && (
           <Rect
             x={(maze.start[0] + 0.25) * cell}
             y={(maze.start[1] + 0.25) * cell}
             width={cell * 0.5}
             height={cell * 0.5}
-            fill="white"
+            stroke="white" // 枠線の色
+            strokeWidth={1} // 枠線の太さ
+            fill="none" // 塗りつぶさず透明にする
           />
         )}
         {showAll && (
-          // ゴール位置はデバッグ時のみ表示
+          // ゴール位置は塗りつぶし四角で表示する
           <Rect
             x={(maze.goal[0] + 0.25) * cell}
             y={(maze.goal[1] + 0.25) * cell}
             width={cell * 0.5}
             height={cell * 0.5}
-            fill="white"
+            fill="white" // 塗りつぶし
           />
         )}
         {/* 現在位置を円で表示 */}


### PR DESCRIPTION
## Summary
- ミニマップでスタート位置を塗りつぶさず枠線のみ描画するよう修正
- ゴール位置は従来通り白い塗りつぶし四角で表示

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68619fc4e360832c93230e079acc6dd3