### PR TITLE
Add walking SFX and BGM

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.9",
+    "expo-av": "~15.3.0",
     "expo-web-browser": "~14.2.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
## Summary
- add expo-av to use audio playback
- play background music on loop in PlayScreen
- play walking sound when a move succeeds

## Testing
- `pnpm lint` *(fails: `expo` not found)*
- `pnpm install` *(fails: GET https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6861c298001c832c8d958bfbedd1f3da