### PR TITLE
fix: use expo-audio instead of deprecated expo-av

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -18,7 +18,8 @@ import Animated, {
   useDerivedValue,
 } from "react-native-reanimated";
 import { LinearGradient } from "expo-linear-gradient";
-import { Audio } from "expo-av";
+// expo-av が SDK54 で廃止されるため expo-audio を利用
+import { Audio } from "expo-audio";
 
 import { DPad } from "@/components/DPad";
 import { ThemedText } from "@/components/ThemedText";

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
         "expo": "~53.0.12",
-        "expo-av": "~15.1.6",
+        "expo-audio": "~0.4.6",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.6",
         "expo-font": "~13.3.1",
@@ -6379,10 +6379,10 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-av": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.1.6.tgz",
-      "integrity": "sha512-5ZbeXdCmdckZHwtEV+8tRZqLlUWR96gkkUIxpyZAEvK0L+aI/BnyhDCpjnSKWwZo4ZA6lx8/su9kyFNV/mQ/sQ==",
+    "node_modules/expo-audio": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-0.4.6.tgz",
+      "integrity": "",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "react-native-svg": "15.11.2",
-    "expo-av": "~15.1.6"
+    "expo-audio": "~0.4.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- remove deprecated expo-av
- add expo-audio
- update import in `PlayScreen`

## Testing
- `pnpm lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cb3005c4832cbe6f43b64fca4481