### PR TITLE
Add AdMob interstitial ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@
    pnpm lint
    ```
 
+## AdMob 広告について
+
+本リポジトリではレベルモードで一定ステージクリアごとにインタースティシャル広告を表示します。
+テスト用広告 ID と本番用広告 ID を環境変数で切り替えられる仕組みを用意しています。
+
+1. テストビルドではデフォルトのテスト ID `ca-app-pub-3940256099942544/4411468910` が利用されます。
+2. 本番ビルド時に `EXPO_PUBLIC_ADMOB_INTERSTITIAL_ID` 環境変数を設定すると、その値が広告 ID として使われます。
+
+### 本番ビルド例
+
+```bash
+EXPO_PUBLIC_ADMOB_INTERSTITIAL_ID="ca-app-pub-xxxxxxxxxxxxxxxx/nnnnnnnnnn" \
+  expo export --public-url https://example.com
+```
+
+Expo のビルドサービスを利用する場合は `eas.json` の `env` セクションに同名の変数を追加してください。
+
 ## ゲーム内容
 
 - 起動時はデフォルトで 10×10 迷路を読み込みます

--- a/app/play.tsx
+++ b/app/play.tsx
@@ -33,6 +33,8 @@ import {
   applyDistanceFeedback,
   nextPosition,
 } from "@/src/game/utils";
+// インタースティシャル広告表示用関数
+import { showInterstitial } from "@/src/ads/interstitial";
 
 // LinearGradient を Reanimated 用にラップ
 // Web 環境では setAttribute エラーを避けるためアニメーション無し
@@ -147,7 +149,9 @@ export default function PlayScreen() {
     maze.size,
   ]);
 
-  const handleOk = () => {
+  // リザルトモーダルのOKボタン処理
+  // 広告表示が必要なときはここでインタースティシャルを挿入する
+  const handleOk = async () => {
     // 結果モーダルを閉じるのみ
     setShowResult(false);
     setGameOver(false);
@@ -163,6 +167,10 @@ export default function PlayScreen() {
       router.replace("/");
     } else if (stageClear) {
       // 通常クリアで次のステージへ
+      // 9ステージごとに広告を表示してから進む
+      if (state.stage % 9 === 0) {
+        await showInterstitial();
+      }
       nextStage();
     }
   };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "react-native-svg": "15.11.2",
-    "expo-audio": "~0.4.7"
+    "expo-audio": "~0.4.7",
+    "expo-ads-admob": "~14.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/ads/interstitial.ts
+++ b/src/ads/interstitial.ts
@@ -1,0 +1,26 @@
+import { AdMobInterstitial } from 'expo-ads-admob';
+
+// テスト広告ID。AdMobが提供するサンプル用IDです
+const TEST_ID = 'ca-app-pub-3940256099942544/4411468910';
+
+// 環境変数 EXPO_PUBLIC_ADMOB_INTERSTITIAL_ID が定義されていれば本番用として使用
+// Expoのビルド時に `EXPO_PUBLIC_` プレフィックスを付けた変数を設定すると
+// process.env から参照できます
+export const AD_UNIT_ID = process.env.EXPO_PUBLIC_ADMOB_INTERSTITIAL_ID ?? TEST_ID;
+
+/**
+ * インタースティシャル広告を表示するヘルパー関数
+ * 非同期処理となるため呼び出し元で await する想定
+ */
+export async function showInterstitial() {
+  try {
+    await AdMobInterstitial.setAdUnitID(AD_UNIT_ID);
+    // パーソナライズド広告を有効にしてロード
+    await AdMobInterstitial.requestAdAsync({ servePersonalizedAds: true });
+    // 広告を表示。閉じられると Promise が解決する
+    await AdMobInterstitial.showAdAsync();
+  } catch (e) {
+    // 失敗時はコンソールに表示するだけでゲーム進行には影響させない
+    console.log('AdMob error', e);
+  }
+}


### PR DESCRIPTION
## Summary
- integrate interstitial ads using `expo-ads-admob`
- show ads every nine stages in play mode
- allow switching ad unit id via environment variable
- document how to build with production AdMob id

## Testing
- `pnpm lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cc673fbc832ca3f572d046fc75a5