### PR TITLE
ステージ91以降の壁消失を追加

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -24,6 +24,7 @@ export default function TitleScreen() {
       level.playerPathLength,
       level.wallLifetime,
       level.enemyCountsFn,
+      level.wallLifetimeFn,
       level.biasedSpawn,
     );
     router.replace('/play');

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -29,6 +29,7 @@ export default function PracticeScreen() {
       playerLen,
       wallLife,
       undefined,
+      undefined,
       true,
     );
     router.replace('/play');

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -1,5 +1,5 @@
 import type { EnemyCounts } from '@/src/types/enemy';
-import { level1EnemyCounts } from '@/src/game/level1';
+import { level1EnemyCounts, levelWallLifetime } from '@/src/game/level1';
 
 // 各レベルの設定をまとめた型
 export interface LevelConfig {
@@ -17,6 +17,8 @@ export interface LevelConfig {
   playerPathLength: number;
   /** 壁表示を維持するターン数 */
   wallLifetime: number;
+  /** ステージ番号から壁寿命を計算する関数。未指定なら wallLifetime を使う */
+  wallLifetimeFn?: (stage: number) => number;
   /** ステージ番号から敵数を決める関数。未指定なら enemies を使う */
   enemyCountsFn?: (stage: number) => EnemyCounts;
   /** 敵スポーン位置をスタートから遠い場所に偏らせるか */
@@ -41,6 +43,7 @@ export const LEVELS: LevelConfig[] = [
     playerPathLength: 7,
     // 壁表示は無限大
     wallLifetime: Infinity,
+    wallLifetimeFn: levelWallLifetime,
     enemyCountsFn: level1EnemyCounts,
     biasedSpawn: false,
   },
@@ -52,6 +55,7 @@ export const LEVELS: LevelConfig[] = [
     enemyPathLength: 5,
     playerPathLength: 7,
     wallLifetime: Infinity,
+    wallLifetimeFn: levelWallLifetime,
     enemyCountsFn: level1EnemyCounts,
     biasedSpawn: true,
   },

--- a/src/game/__tests__/levelWallLifetime.test.ts
+++ b/src/game/__tests__/levelWallLifetime.test.ts
@@ -1,0 +1,16 @@
+import { levelWallLifetime } from '../level1';
+
+describe('levelWallLifetime', () => {
+  test('90以下ではInfinityを返す', () => {
+    expect(levelWallLifetime(90)).toBe(Infinity);
+  });
+  test('91では10を返す', () => {
+    expect(levelWallLifetime(91)).toBe(10);
+  });
+  test('100では10を返す', () => {
+    expect(levelWallLifetime(100)).toBe(10);
+  });
+  test('101以上ではInfinityを返す', () => {
+    expect(levelWallLifetime(101)).toBe(Infinity);
+  });
+});

--- a/src/game/level1.ts
+++ b/src/game/level1.ts
@@ -48,3 +48,12 @@ export function level1EnemyCounts(stage: number): EnemyCounts {
   }
   return { random: 1, slow: 0, sight: 0, fast: 0 };
 }
+
+/**
+ * レベル1・2 共通の壁寿命設定を返します。
+ * ステージ91〜100では壁の表示が10ターンで消えます。
+ * それ以外では無限大 (Infinity) を返します。
+ */
+export function levelWallLifetime(stage: number): number {
+  return stage >= 91 && stage <= 100 ? 10 : Infinity;
+}


### PR DESCRIPTION
## Summary
- ステージ91～100で壁が10ターン後に消えるよう`levelWallLifetime`を実装
- レベル設定から壁寿命関数を指定できるよう更新
- ゲーム状態管理に`wallLifetimeFn`を追加し、ステージ進行で寿命を更新
- 新しいテスト`levelWallLifetime.test.ts`を追加

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6861e5ab531c832c91f3666b89c62bec