### PR TITLE
Add bilingual support

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,7 @@ import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { GameProvider } from '@/src/game/useGame';
+import { LocaleProvider } from '@/src/locale/LocaleContext';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -20,14 +21,16 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <GameProvider>
-        <Stack>
-          <Stack.Screen name="index" options={{ headerShown: false }} />
-          <Stack.Screen name="practice" options={{ headerShown: false }} />
-          <Stack.Screen name="play" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-      </GameProvider>
+      <LocaleProvider>
+        <GameProvider>
+          <Stack>
+            <Stack.Screen name="index" options={{ headerShown: false }} />
+            <Stack.Screen name="practice" options={{ headerShown: false }} />
+            <Stack.Screen name="play" options={{ headerShown: false }} />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+        </GameProvider>
+      </LocaleProvider>
       <StatusBar style="auto" />
     </ThemeProvider>
   );

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { Modal, StyleSheet, View } from 'react-native';
 import { PlainButton } from '@/components/PlainButton';
 import { useRouter } from 'expo-router';
 import { useGame } from '@/src/game/useGame';
+import { useLocale, type Lang, type MessageKey } from '@/src/locale/LocaleContext';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
@@ -12,6 +13,19 @@ export default function TitleScreen() {
   const router = useRouter();
   // GameProvider から新しい迷路を読み込む関数を取得
   const { newGame } = useGame();
+  // 言語関連のフックを取得
+  const { t, firstLaunch, changeLang } = useLocale();
+  const [showLang, setShowLang] = React.useState(false);
+
+  // 初回起動時は言語選択モーダルを表示する
+  React.useEffect(() => {
+    if (firstLaunch) setShowLang(true);
+  }, [firstLaunch]);
+
+  const select = (lang: Lang) => {
+    changeLang(lang);
+    setShowLang(false);
+  };
 
   // 定義済みレベルの設定を使ってゲームを開始する
   const startLevel = (id: string) => {
@@ -43,23 +57,58 @@ export default function TitleScreen() {
       </ThemedText>
       {/* 練習モードへの遷移 */}
       <PlainButton
-        title="練習モード"
+        title={t('practiceMode')}
         onPress={() => router.push('/practice')}
-        accessibilityLabel="練習モードを開く"
+        accessibilityLabel={t('openPractice')}
       />
       {/* プリセットレベルの開始ボタン */}
       {LEVELS.map((lv) => (
         <PlainButton
           key={lv.id}
-          title={lv.name}
+          title={t(lv.id as MessageKey)}
           onPress={() => startLevel(lv.id)}
-          accessibilityLabel={`${lv.name}を開始`}
+          accessibilityLabel={t('startLevel', { name: t(lv.id as MessageKey) })}
         />
       ))}
+      {/* 言語切り替え用ボタン */}
+      <PlainButton
+        title={t('changeLang')}
+        onPress={() => setShowLang(true)}
+        accessibilityLabel={t('changeLang')}
+      />
+      {/* 言語選択モーダル */}
+      <Modal transparent visible={showLang} animationType="fade">
+        <View style={styles.modalWrapper}>
+          <ThemedView style={styles.modalContent}>
+            <ThemedText type="title">{t('selectLang')}</ThemedText>
+            <PlainButton
+              title={t('japanese')}
+              onPress={() => select('ja')}
+              accessibilityLabel={t('japanese')}
+            />
+            <PlainButton
+              title={t('english')}
+              onPress={() => select('en')}
+              accessibilityLabel={t('english')}
+            />
+          </ThemedView>
+        </View>
+      </Modal>
     </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 20 },
+  modalWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  modalContent: {
+    gap: 16,
+    padding: 24,
+    backgroundColor: '#000',
+  },
 });

--- a/app/play.tsx
+++ b/app/play.tsx
@@ -28,6 +28,7 @@ import { PlainButton } from "@/components/PlainButton";
 import { MiniMap } from "@/src/components/MiniMap";
 import type { MazeData as MazeView, Dir } from "@/src/types/maze";
 import { useGame } from "@/src/game/useGame";
+import { useLocale } from "@/src/locale/LocaleContext";
 import {
   applyBumpFeedback,
   applyDistanceFeedback,
@@ -51,6 +52,7 @@ const AnimatedLG =
 
 export default function PlayScreen() {
   const router = useRouter();
+  const { t } = useLocale();
   // SafeArea 用の余白情報を取得
   const insets = useSafeAreaInsets();
   // 画面サイズを取得。useWindowDimensions は画面回転にも追従する
@@ -397,17 +399,17 @@ export default function PlayScreen() {
         >
           <View style={[styles.menuContent, { top: insets.top + 40 }]}>
             <PlainButton
-              title="Reset Maze"
+              title={t('resetMaze')}
               onPress={handleReset}
-              accessibilityLabel="迷路を最初から"
+              accessibilityLabel={t('resetMazeLabel')}
             />
             {/* デバッグ用スイッチ */}
             <View style={styles.switchRow}>
-              <ThemedText>全てを可視化</ThemedText>
+              <ThemedText>{t('showAll')}</ThemedText>
               <Switch
                 value={debugAll}
                 onValueChange={setDebugAll}
-                accessibilityLabel="迷路を全て表示"
+                accessibilityLabel={t('showMazeAll')}
               />
             </View>
           </View>
@@ -418,28 +420,29 @@ export default function PlayScreen() {
           <ThemedView style={[styles.modalContent, { marginTop: resultTop }]}>
             <ThemedText type="title">
               {gameClear
-                ? "ゲームクリア"
+                ? t('gameClear')
                 : gameOver
-                ? "ゲームオーバー"
-                : "ゴール！"}
+                ? t('gameOver')
+                : t('goal')}
             </ThemedText>
-            <ThemedText>Steps: {state.steps}</ThemedText>
-            <ThemedText>Bumps: {state.bumps}</ThemedText>
+            <ThemedText>{t('steps', { count: state.steps })}</ThemedText>
+            <ThemedText>{t('bumps', { count: state.bumps })}</ThemedText>
             {/* 現在クリアしたステージ数と総ステージ数を表示 */}
             {/* totalStages は maze.size × maze.size で計算した結果 */}
-            <ThemedText>
-              Stage: {state.stage}/{totalStages}
-            </ThemedText>
+            <ThemedText>{t('stage', { current: state.stage, total: totalStages })}</ThemedText>
             {highScore && (
               <ThemedText>
-                Best: {highScore.stage}ステージ / {highScore.steps}
-                steps / {highScore.bumps} bumps
+                {t('best', {
+                  stage: highScore.stage,
+                  steps: highScore.steps,
+                  bumps: highScore.bumps,
+                })}
               </ThemedText>
             )}
             <PlainButton
-              title="OK"
+              title={t('ok')}
               onPress={handleOk}
-              accessibilityLabel="タイトルへ戻る"
+              accessibilityLabel={t('backToTitle')}
             />
           </ThemedView>
         </View>

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 import { PlainButton } from '@/components/PlainButton';
 import { useRouter } from 'expo-router';
 import { useGame } from '@/src/game/useGame';
+import { useLocale } from '@/src/locale/LocaleContext';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { EnemyCounter } from '@/components/EnemyCounter';
@@ -10,6 +11,7 @@ import { EnemyCounter } from '@/components/EnemyCounter';
 export default function PracticeScreen() {
   const router = useRouter();
   const { newGame } = useGame();
+  const { t } = useLocale();
   // 各敵タイプの数を状態として管理
   const [random, setRandom] = React.useState(0);
   const [slow, setSlow] = React.useState(0);
@@ -39,23 +41,23 @@ export default function PracticeScreen() {
   return (
     <ThemedView lightColor="#000" darkColor="#000" style={styles.container}>
       <ThemedText type="title" lightColor="#fff" darkColor="#fff">
-        練習モード
+        {t('practiceMode')}
       </ThemedText>
-      <EnemyCounter label="等速・ランダム" value={random} setValue={setRandom} />
-      <EnemyCounter label="鈍足・視認" value={slow} setValue={setSlow} />
-      <EnemyCounter label="等速・視認" value={sight} setValue={setSight} />
+      <EnemyCounter label={t('enemyRandom')} value={random} setValue={setRandom} />
+      <EnemyCounter label={t('enemySlow')} value={slow} setValue={setSlow} />
+      <EnemyCounter label={t('enemySight')} value={sight} setValue={setSight} />
       {/* 敵の軌跡長 */}
-      <EnemyCounter label="敵軌跡長" value={pathLen} setValue={setPathLen} />
+      <EnemyCounter label={t('enemyPathLen')} value={pathLen} setValue={setPathLen} />
       {/* プレイヤーの軌跡長。無限大選択を許可 */}
       <EnemyCounter
-        label="自分軌跡長"
+        label={t('playerPathLen')}
         value={playerLen}
         setValue={setPlayerLen}
         allowInfinity
       />
       {/* 壁表示ターン数 */}
       <EnemyCounter
-        label="壁表示"
+        label={t('wallDuration')}
         value={wallLife}
         setValue={setWallLife}
         allowInfinity
@@ -63,12 +65,12 @@ export default function PracticeScreen() {
       <PlainButton
         title="5×5"
         onPress={() => start(5)}
-        accessibilityLabel="5マス迷路を開始"
+        accessibilityLabel={t('startMazeSize', { size: 5 })}
       />
       <PlainButton
         title="10×10"
         onPress={() => start(10)}
-        accessibilityLabel="10マス迷路を開始"
+        accessibilityLabel={t('startMazeSize', { size: 10 })}
       />
     </ThemedView>
   );

--- a/components/EnemyCounter.tsx
+++ b/components/EnemyCounter.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { PlainButton } from '@/components/PlainButton';
 
 import { ThemedText } from '@/components/ThemedText';
+import { useLocale } from '@/src/locale/LocaleContext';
 
 /**
  * 敵の数を増減させる共通コンポーネント
@@ -25,6 +26,7 @@ export function EnemyCounter({
   max?: number;
   allowInfinity?: boolean;
 }) {
+  const { t } = useLocale();
   const display = allowInfinity && value === Infinity ? '∞' : value;
   return (
     <View style={styles.row}>
@@ -39,7 +41,7 @@ export function EnemyCounter({
             return Math.max(min, v - 1);
           })
         }
-        accessibilityLabel={`${label}を減らす`}
+        accessibilityLabel={t('decrease', { label })}
       />
       {/* 現在値表示 */}
       <ThemedText lightColor="#fff" darkColor="#fff" style={styles.count}>
@@ -55,7 +57,7 @@ export function EnemyCounter({
             return Math.min(max, next);
           })
         }
-        accessibilityLabel={`${label}を増やす`}
+        accessibilityLabel={t('increase', { label })}
       />
     </View>
   );

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -1,0 +1,141 @@
+import React, { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type Lang = 'ja' | 'en';
+
+// 言語設定を保存する際のキー
+const STORAGE_KEY = 'lang';
+
+// 画面で表示する文言の定義
+const messages = {
+  ja: {
+    practiceMode: '練習モード',
+    openPractice: '練習モードを開く',
+    level1: 'レベル1',
+    level2: 'レベル2',
+    startLevel: '{{name}}を開始',
+    enemyRandom: '等速・ランダム',
+    enemySlow: '鈍足・視認',
+    enemySight: '等速・視認',
+    enemyPathLen: '敵軌跡長',
+    playerPathLen: '自分軌跡長',
+    wallDuration: '壁表示',
+    startMazeSize: '{{size}}マス迷路を開始',
+    increase: '{{label}}を増やす',
+    decrease: '{{label}}を減らす',
+    resetMaze: '迷路リセット',
+    resetMazeLabel: '迷路を最初から',
+    showAll: '全てを可視化',
+    showMazeAll: '迷路を全て表示',
+    gameClear: 'ゲームクリア',
+    gameOver: 'ゲームオーバー',
+    goal: 'ゴール！',
+    steps: 'Steps: {{count}}',
+    bumps: 'Bumps: {{count}}',
+    stage: 'Stage: {{current}}/{{total}}',
+    best: 'Best: {{stage}}ステージ / {{steps}} steps / {{bumps}} bumps',
+    ok: 'OK',
+    changeLang: '言語設定',
+    selectLang: '言語を選択してください',
+    japanese: '日本語',
+    english: 'English',
+    backToTitle: 'タイトルへ戻る',
+  },
+  en: {
+    practiceMode: 'Practice Mode',
+    openPractice: 'Open Practice',
+    level1: 'Level 1',
+    level2: 'Level 2',
+    startLevel: 'Start {{name}}',
+    enemyRandom: 'Normal Random',
+    enemySlow: 'Slow Vision',
+    enemySight: 'Normal Vision',
+    enemyPathLen: 'Enemy Path',
+    playerPathLen: 'Player Path',
+    wallDuration: 'Wall Lifetime',
+    startMazeSize: 'Start {{size}} maze',
+    increase: 'Increase {{label}}',
+    decrease: 'Decrease {{label}}',
+    resetMaze: 'Reset Maze',
+    resetMazeLabel: 'Reset maze',
+    showAll: 'Show All',
+    showMazeAll: 'Show whole maze',
+    gameClear: 'Game Clear',
+    gameOver: 'Game Over',
+    goal: 'Goal!',
+    steps: 'Steps: {{count}}',
+    bumps: 'Bumps: {{count}}',
+    stage: 'Stage: {{current}}/{{total}}',
+    best: 'Best: {{stage}} stages / {{steps}} steps / {{bumps}} bumps',
+    ok: 'OK',
+    changeLang: 'Language',
+    selectLang: 'Select language',
+    japanese: 'Japanese',
+    english: 'English',
+    backToTitle: 'Back to title',
+  },
+} as const;
+
+type Messages = typeof messages.ja;
+export type MessageKey = keyof Messages;
+
+// 文言を取得しプレースホルダーを差し替える簡易関数
+function translate(lang: Lang, key: MessageKey, params?: Record<string, string | number>) {
+  let template = messages[lang][key] ?? messages.ja[key];
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      template = template.replace(`{{${k}}}`, String(v));
+    }
+  }
+  return template;
+}
+
+interface LocaleContextValue {
+  lang: Lang;
+  t: (key: MessageKey, params?: Record<string, string | number>) => string;
+  changeLang: (l: Lang) => Promise<void>;
+  ready: boolean;
+  firstLaunch: boolean;
+}
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
+
+export function LocaleProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState<Lang>('ja');
+  const [ready, setReady] = useState(false);
+  const [firstLaunch, setFirstLaunch] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const stored = await AsyncStorage.getItem(STORAGE_KEY);
+      if (stored === 'ja' || stored === 'en') {
+        setLang(stored);
+      } else {
+        // 言語未選択なら初回起動とみなす
+        setFirstLaunch(true);
+      }
+      setReady(true);
+    })();
+  }, []);
+
+  const changeLang = async (l: Lang) => {
+    setLang(l);
+    await AsyncStorage.setItem(STORAGE_KEY, l);
+    setFirstLaunch(false);
+  };
+
+  const t = (key: MessageKey, params?: Record<string, string | number>) =>
+    translate(lang, key, params);
+
+  return (
+    <LocaleContext.Provider value={{ lang, t, changeLang, ready, firstLaunch }}>
+      {children}
+    </LocaleContext.Provider>
+  );
+}
+
+export function useLocale() {
+  const ctx = useContext(LocaleContext);
+  if (!ctx) throw new Error('useLocale は LocaleProvider 内で利用してください');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add `LocaleProvider` with simple translation table
- wrap the app with `LocaleProvider`
- make home screen show language selector modal
- translate practice screen, play screen, and enemy counters

## Testing
- `pnpm lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686205ab0468832ca63215a9dc1aab14