### PR TITLE
Fix levelId not defined

### DIFF
--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -287,6 +287,7 @@ function initState(
   enemyCountsFn?: (stage: number) => EnemyCounts,
   wallLifetimeFn?: (stage: number) => number,
   biasedSpawn: boolean = true,
+  levelId?: string,
 ): State {
   const maze = prepMaze(m);
   const enemies = createEnemies(enemyCounts, maze, biasedSpawn);


### PR DESCRIPTION
## Summary
- fix `levelId` missing in `initState`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68634e131b7c832c9d480cb579d0797b