### PR TITLE
fix: インタースティシャル表示後のステージ遷移

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -205,12 +205,6 @@ export default function PlayScreen() {
   // リザルトモーダルのOKボタン処理
   // 広告表示が必要なときはここでインタースティシャルを挿入する
   const handleOk = async () => {
-    // 結果モーダルを閉じるのみ
-    setShowResult(false);
-    setGameOver(false);
-    setDebugAll(false);
-    setStageClear(false);
-    setGameClear(false);
     if (gameOver) {
       // ゲームオーバー時は1ステージ目から再開
       resetRun();
@@ -226,6 +220,12 @@ export default function PlayScreen() {
       }
       nextStage();
     }
+    // モーダルは最後に閉じて副作用をまとめて処理する
+    setShowResult(false);
+    setGameOver(false);
+    setDebugAll(false);
+    setStageClear(false);
+    setGameClear(false);
   };
 
   // Reset Maze 選択時に呼ばれる


### PR DESCRIPTION
## Summary
- インタースティシャル広告を表示する際、次ステージへ遷移する処理の順序を見直し
- 広告閉じた後に確実に `nextStage` が呼ばれるようにし、モーダル関連の状態はその後まとめてリセット

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68635968fae8832c99126f3e455bff03