### PR TITLE
ステージクリア時のハイスコア表示条件を調整

### DIFF
--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -37,6 +37,8 @@ const messages = {
     highScores: 'ハイスコア',
     openHighScores: 'ハイスコア一覧を開く',
     noRecord: '記録なし',
+    // ハイスコアを更新したときに表示するメッセージ
+    newRecord: '記録更新！',
     ok: 'OK',
     changeLang: '言語設定',
     selectLang: '言語を選択してください',
@@ -73,6 +75,8 @@ const messages = {
     highScores: 'High Scores',
     openHighScores: 'View High Scores',
     noRecord: 'No record',
+    // Message shown when a new high score is achieved
+    newRecord: 'New Record!',
     ok: 'OK',
     changeLang: 'Language',
     selectLang: 'Select language',


### PR DESCRIPTION
## Summary
- ハイスコア文言に記録更新メッセージを追加
- ゲームプレイ画面でハイスコア表示条件と更新判定を修正
- newRecord フラグを表示/初期化できるように変更

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68635fc5ac08832ca058c793ba4573f9