### PR TITLE
Fix language modal text visibility

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -86,7 +86,10 @@ export default function TitleScreen() {
       <Modal transparent visible={showLang} animationType="fade">
         <View style={styles.modalWrapper}>
           <ThemedView style={styles.modalContent}>
-            <ThemedText type="title">{t('selectLang')}</ThemedText>
+          {/* モーダル内では背景が黒なので、文字色を白に固定して読みやすくする */}
+          <ThemedText type="title" lightColor="#fff" darkColor="#fff">
+            {t('selectLang')}
+          </ThemedText>
             <PlainButton
               title={t('japanese')}
               onPress={() => select('ja')}


### PR DESCRIPTION
## Summary
- fix language selection modal text color

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686366424b00832c8f1b3f5ce632d2d1