### PR TITLE
Update maze import script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,14 @@ mazesense/
 ```
 
 迷路 JSON の形式や詳細な仕様は `APP_SPEC.md` を参照してください。
+
+## 迷路データの更新手順
+
+`assets/mazes` フォルダに迷路 JSON を配置した状態で `pnpm start` などの起動
+コマンドを実行すると、`scripts/update-maze-import.js` が自動的に走り
+`src/game/mazeAsset.ts` が生成されます。これにより迷路セットが最新の内容に
+置き換わります。手動で更新したい場合は以下を実行してください。
+
+```bash
+pnpm exec node scripts/update-maze-import.js
+```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "android": "expo start --android",
     "preios": "node ./scripts/update-maze-import.js",
     "ios": "expo start --ios",
+    "preweb": "node ./scripts/update-maze-import.js",
     "web": "expo start --web",
     "lint": "expo lint"
   },

--- a/src/game/mazeAsset.ts
+++ b/src/game/mazeAsset.ts
@@ -1,4 +1,5 @@
-// assets/mazes 内の迷路を読み込み、サイズ別にエクスポートする
+// 自動生成: assets/mazes 内の迷路をサイズ別にエクスポート
+// 2025-07-01T05:27:38.777Z
 import maze5 from '@/assets/mazes/maze_5.json';
 import maze10 from '@/assets/mazes/maze_10.json';
 


### PR DESCRIPTION
## Summary
- update update-maze-import.js script to handle multiple maze files
- hook update-maze-import.js before starting web
- explain how maze data gets updated in README
- regenerate mazeAsset.ts via script

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68637118b07c832cb9187f4b543cf5e3