### PR TITLE
Add overlay accessibility labels

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -84,7 +84,11 @@ export default function TitleScreen() {
       />
       {/* 言語選択モーダル */}
       <Modal transparent visible={showLang} animationType="fade">
-        <View style={styles.modalWrapper}>
+        <View
+          style={styles.modalWrapper}
+          accessible
+          accessibilityLabel="言語選択オーバーレイ"
+        >
           <ThemedView style={styles.modalContent}>
           {/* モーダル内では背景が黒なので、文字色を白に固定して読みやすくする */}
           <ThemedText type="title" lightColor="#fff" darkColor="#fff">

--- a/app/play.tsx
+++ b/app/play.tsx
@@ -411,6 +411,7 @@ export default function PlayScreen() {
         <Pressable
           style={styles.menuOverlay}
           onPress={() => setShowMenu(false)}
+          accessibilityLabel="メニューを閉じる"
         >
           <View style={[styles.menuContent, { top: insets.top + 40 }]}>
             <PlainButton
@@ -431,7 +432,11 @@ export default function PlayScreen() {
         </Pressable>
       </Modal>
       <Modal transparent visible={showResult} animationType="fade">
-        <View style={styles.modalWrapper}>
+        <View
+          style={styles.modalWrapper}
+          accessible
+          accessibilityLabel="結果表示オーバーレイ"
+        >
           <ThemedView style={[styles.modalContent, { marginTop: resultTop }]}>
             <ThemedText type="title">
               {gameClear


### PR DESCRIPTION
## Summary
- メニューを閉じるオーバーレイに `accessibilityLabel` を追加
- 言語選択・結果表示の各オーバーレイにラベルを付与

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686375cbc400832ca1a3102458f79c61