### PR TITLE
Add maxDist option to distance feedback

### DIFF
--- a/src/game/__tests__/feedback.test.ts
+++ b/src/game/__tests__/feedback.test.ts
@@ -37,6 +37,44 @@ describe('applyDistanceFeedback', () => {
     jest.advanceTimersByTime(result.wait);
     expect(clearSpy).toHaveBeenCalledWith(fakeId);
   });
+
+  test('maxDist を渡すと段階計算が変わる', () => {
+    const intervalSpy = jest.spyOn(global, 'setInterval');
+    const fakeId = {} as NodeJS.Timeout;
+    intervalSpy.mockReturnValue(fakeId);
+
+    // 距離8で maxDist も8 の場合は scaled が4になり Medium 振動
+    const result = applyDistanceFeedback(
+      { x: 0, y: 0 },
+      { x: 0, y: 8 },
+      { maxDist: 8 }
+    );
+
+    expect(result.wait).toBe(100);
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(
+      Haptics.ImpactFeedbackStyle.Medium
+    );
+    expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), 50);
+  });
+
+  test('距離が maxDist を超えると Light 振動になる', () => {
+    const intervalSpy = jest.spyOn(global, 'setInterval');
+    const fakeId = {} as NodeJS.Timeout;
+    intervalSpy.mockReturnValue(fakeId);
+
+    // maxDist 8 に対し距離9なので Light 振動
+    const result = applyDistanceFeedback(
+      { x: 0, y: 0 },
+      { x: 0, y: 9 },
+      { maxDist: 8 }
+    );
+
+    expect(result.wait).toBe(100);
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(
+      Haptics.ImpactFeedbackStyle.Light
+    );
+    expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), 50);
+  });
 });
 
 describe('applyBumpFeedback', () => {

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -60,26 +60,31 @@ export function applyDistanceFeedback(
   goal: Vec2,
   opts: FeedbackOptions = {}
 ): DistanceFeedbackResult {
-  // opts は互換性のために保持しているが現在は未使用
+  // 追加: 迷路の大きさに応じた最大距離を指定できるようにする
+  const maxDist = opts.maxDist ?? 4;
   // ゴールまでのマンハッタン距離を計算
   const dist = distance(pos, goal);
+  // 距離を 4 段階に正規化する。
+  // maxDist と同じ距離で 4、0 に近いほど 1 に近づくイメージ
+  const scaled = Math.max(1, Math.ceil((dist / maxDist) * 4));
 
-  // 距離に応じて振動スタイルと継続時間を決定
+  // 距離段階に応じて振動スタイルと継続時間を決定
   let style: Haptics.ImpactFeedbackStyle;
   let duration: number;
-  if (dist === 1) {
+  if (scaled === 1) {
     style = Haptics.ImpactFeedbackStyle.Heavy;
     duration = 400;
-  } else if (dist === 2) {
+  } else if (scaled === 2) {
     style = Haptics.ImpactFeedbackStyle.Heavy;
     duration = 200;
-  } else if (dist === 3) {
+  } else if (scaled === 3) {
     style = Haptics.ImpactFeedbackStyle.Medium;
     duration = 100;
-  } else if (dist === 4) {
+  } else if (scaled === 4) {
     style = Haptics.ImpactFeedbackStyle.Medium;
     duration = 100;
   } else {
+    // scaled が 5 以上の場合はかなり遠いとみなし最弱振動
     style = Haptics.ImpactFeedbackStyle.Light;
     duration = 100;
   }


### PR DESCRIPTION
## Summary
- use `opts.maxDist` in `applyDistanceFeedback` to scale distance stages
- document usage with Japanese comments
- add unit tests for new maxDist behavior

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686375bbaacc832c9aac6612e8e46225