### PR TITLE
Refactor play logic into hook

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,47 +1,16 @@
-import { useEffect, useState, useRef } from "react";
-import {
-  Modal,
-  StyleSheet,
-  View,
-  Pressable,
-  Switch,
-  useWindowDimensions,
-  Platform,
-} from "react-native";
+import { View, Pressable, StyleSheet, useWindowDimensions, Platform } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  useAnimatedProps,
-  useDerivedValue,
-} from "react-native-reanimated";
+import Animated, { useAnimatedStyle, useAnimatedProps, useDerivedValue } from "react-native-reanimated";
 import { LinearGradient } from "expo-linear-gradient";
-// expo-av が SDK54 で廃止されるため expo-audio を利用
-import { Audio } from "expo-audio";
 
 import { DPad } from "@/components/DPad";
-import { ThemedText } from "@/components/ThemedText";
-import { ThemedView } from "@/components/ThemedView";
-import { PlainButton } from "@/components/PlainButton";
 import { MiniMap } from "@/src/components/MiniMap";
-import type { MazeData as MazeView, Dir } from "@/src/types/maze";
-import { useGame } from "@/src/game/useGame";
+import type { MazeData as MazeView } from "@/src/types/maze";
 import { useLocale } from "@/src/locale/LocaleContext";
-import {
-  applyBumpFeedback,
-  applyDistanceFeedback,
-  nextPosition,
-} from "@/src/game/utils";
-// インタースティシャル広告表示用関数
-import { showInterstitial } from "@/src/ads/interstitial";
-import {
-  loadHighScore,
-  saveHighScore,
-  isBetterScore,
-  type HighScore,
-} from "@/src/game/highScore";
+import { usePlayLogic } from "@/src/hooks/usePlayLogic";
+import { PlayMenu } from "@/components/PlayMenu";
+import { ResultModal } from "@/components/ResultModal";
 
 // LinearGradient を Reanimated 用にラップ
 // Web 環境では setAttribute エラーを避けるためアニメーション無し
@@ -51,269 +20,45 @@ const AnimatedLG =
     : Animated.createAnimatedComponent(LinearGradient);
 
 export default function PlayScreen() {
-  const router = useRouter();
   const { t } = useLocale();
-  // SafeArea 用の余白情報を取得
   const insets = useSafeAreaInsets();
-  // 画面サイズを取得。useWindowDimensions は画面回転にも追従する
-  const { height, width } = useWindowDimensions();
-  const { state, move, maze, nextStage, resetRun } = useGame();
-  // 全体のステージ数。迷路サイズ×迷路サイズで計算する
-  // size は迷路の一辺のマス数なので、面積がステージ総数になる
-  const totalStages = maze.size * maze.size;
-  const [showResult, setShowResult] = useState(false);
-  const [gameOver, setGameOver] = useState(false);
-  const [stageClear, setStageClear] = useState(false);
-  const [gameClear, setGameClear] = useState(false);
-  // 保存済みハイスコア
-  const [highScore, setHighScore] = useState<HighScore | null>(null);
-  // ハイスコアを更新したかどうか
-  const [newRecord, setNewRecord] = useState(false);
-  // メニュー表示フラグ。true のときサブメニューを表示
-  const [showMenu, setShowMenu] = useState(false);
-  // 全てを可視化するかのフラグ。デフォルトはオフ
-  const [debugAll, setDebugAll] = useState(false);
-  // 枠線の色を状態として管理
-  const [borderColor, setBorderColor] = useState("transparent");
-  const borderW = useSharedValue(0);
-  // ゴール到達時に画面左右から中央まで埋まるよう
-  // 枠線の最大太さを画面幅の半分に設定する
-  const maxBorder = width / 2;
-  // 連打を防ぐための入力ロック
-  const [locked, setLocked] = useState(false);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-  // applyDistanceFeedback で使う setInterval の ID を保持
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  // BGM と効果音用サウンドオブジェクトを保持
-  const bgmRef = useRef<Audio.Sound | null>(null);
-  const moveRef = useRef<Audio.Sound | null>(null);
+  const { height } = useWindowDimensions();
+  const {
+    state,
+    maze,
+    totalStages,
+    showResult,
+    gameOver,
+    gameClear,
+    highScore,
+    newRecord,
+    showMenu,
+    setShowMenu,
+    debugAll,
+    setDebugAll,
+    borderColor,
+    borderW,
+    maxBorder,
+    locked,
+    handleMove,
+    handleOk,
+    handleReset,
+    handleExit,
+  } = usePlayLogic();
 
-  // 枠の太さを共通化するため縦横で別々の AnimatedStyle を用意
   const vertStyle = useAnimatedStyle(() => ({ height: borderW.value }));
   const horizStyle = useAnimatedStyle(() => ({ width: borderW.value }));
-  // グラデーションの色配列。中心に近いほど透明にする
-  // LinearGradient が期待する型に合わせるためタプルにする
-  // 枠線のグラデーション。最初の 20% を完全な色にしてから透明へと変化させる
-  const gradColors: [string, string, string] = [
-    borderColor,
-    borderColor,
-    "transparent",
-  ];
-
-  // 枠線の太さに応じて完全な色の領域を広げる
-  // borderW.value は SharedValue でアニメーション中も値が変わる
+  const gradColors: [string, string, string] = [borderColor, borderColor, 'transparent'];
   const gradStops = useDerivedValue<[number, number, number]>(() => {
     const ratio = Math.min(borderW.value / maxBorder, 1);
-    // 初期 0.2 から ratio に応じて最大 0.7 まで拡大
     const loc = 0.2 + ratio * 0.5;
     return [0, loc, 1];
   });
-  // AnimatedLinearGradient へ渡すプロパティ。Web では locations のみ固定
   const gradProps = useAnimatedProps(() => ({ locations: gradStops.value }));
-  const gradLocs = Platform.OS === "web" ? [0, 0.2, 1] : undefined;
-
-  // BGM と効果音を読み込み、BGM はループ再生する
-  useEffect(() => {
-    (async () => {
-      // サイレントモードでも再生されるよう設定
-      await Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
-      const bgm = new Audio.Sound();
-      await bgm.loadAsync(require("../assets/sounds/タタリ.mp3"));
-      await bgm.setIsLoopingAsync(true);
-      await bgm.playAsync();
-      bgmRef.current = bgm;
-
-      const mv = new Audio.Sound();
-      await mv.loadAsync(require("../assets/sounds/歩く音200ms_2.mp3"));
-      moveRef.current = mv;
-    })();
-    return () => {
-      bgmRef.current?.unloadAsync();
-      moveRef.current?.unloadAsync();
-    };
-  }, []);
-
-  // レベルが切り替わったとき保存済みハイスコアを読み込む
-  useEffect(() => {
-    if (!state.levelId) return;
-    (async () => {
-      const hs = await loadHighScore(state.levelId!);
-      setHighScore(hs);
-      setNewRecord(false);
-    })();
-  }, [state.levelId]);
-
-  useEffect(() => {
-    // 次ステージで迷路が変わるか判定
-    // ステージ番号が迷路サイズの倍数なら新しいマップを読み込む
-    const willChangeMap = state.stage % maze.size === 0;
-    if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
-      // ゴール到達。最終ステージかどうかで分岐
-      setStageClear(true);
-      setGameOver(false);
-      setGameClear(state.finalStage);
-      setShowResult(true);
-      // 次ステージが同じマップなら全体表示しない
-      setDebugAll(willChangeMap);
-      // クリア時はハイスコアを更新する
-      if (state.levelId) {
-        const current: HighScore = {
-          stage: state.stage,
-          steps: state.steps,
-          bumps: state.bumps,
-        };
-        (async () => {
-          const old = await loadHighScore(state.levelId!);
-          const better = isBetterScore(old, current);
-          if (better) {
-            await saveHighScore(state.levelId!, current);
-            setHighScore(current);
-          } else {
-            setHighScore(old);
-          }
-          // 最終ステージのみ記録更新を表示する
-          setNewRecord(better && state.finalStage);
-        })();
-      } else {
-        setNewRecord(false);
-      }
-    } else if (state.caught) {
-      // 敵に捕まったときは常に全てを可視化
-      setGameOver(true);
-      setStageClear(false);
-      setShowResult(true);
-      setDebugAll(true);
-      // ゲームオーバー時のハイスコア判定
-      if (state.levelId) {
-        const current: HighScore = {
-          stage: state.stage - 1,
-          steps: state.steps,
-          bumps: state.bumps,
-        };
-        (async () => {
-          const old = await loadHighScore(state.levelId!);
-          const better = isBetterScore(old, current);
-          if (better) {
-            await saveHighScore(state.levelId!, current);
-            setHighScore(current);
-          } else {
-            setHighScore(old);
-          }
-          setNewRecord(better);
-        })();
-      } else {
-        setNewRecord(false);
-      }
-    }
-  }, [
-    state.pos,
-    state.caught,
-    maze.goal,
-    state.finalStage,
-    state.stage,
-    maze.size,
-  ]);
-
-  // リザルトモーダルのOKボタン処理
-  // 広告表示が必要なときはここでインタースティシャルを挿入する
-  const handleOk = async () => {
-    if (gameOver) {
-      // ゲームオーバー時は1ステージ目から再開
-      resetRun();
-    } else if (gameClear) {
-      // 全ステージクリア
-      resetRun();
-      router.replace("/");
-    } else if (stageClear) {
-      // 通常クリアで次のステージへ
-      // 9ステージごとに広告を表示してから進む
-      if (state.stage % 9 === 0) {
-        await showInterstitial();
-      }
-      nextStage();
-    }
-    // モーダルは最後に閉じて副作用をまとめて処理する
-    setShowResult(false);
-    setGameOver(false);
-    setDebugAll(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-  };
-
-  // Reset Maze 選択時に呼ばれる
-  const handleReset = () => {
-    setShowMenu(false);
-    setGameOver(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-    resetRun();
-  };
-
-  // タイトルへ戻る処理を共通化
-  const handleExit = () => {
-    setShowMenu(false);
-    setGameOver(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-    resetRun();
-    router.replace("/");
-  };
-
-  // コンポーネント破棄時にタイマーを解除
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, []);
-
-  // DPad からの入力を処理する関数
-  const handleMove = (dir: Dir) => {
-    if (locked) return; // ロック中は無視
-    // ここでロックを開始
-    setLocked(true);
-    // 移動後の座標を計算しておく
-    const next = nextPosition(state.pos, dir);
-
-    // 前回の setInterval が残っていれば停止
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-
-    // move の戻り値が false のときは壁に衝突
-    let wait: number;
-    if (!move(dir)) {
-      wait = applyBumpFeedback(borderW, setBorderColor);
-      // 衝突表示が終わったら色を戻す
-      setTimeout(() => setBorderColor("transparent"), wait);
-    } else {
-      // 移動成功時は歩行音を再生
-      moveRef.current?.replayAsync();
-      // 盤面サイズから求めた最大マンハッタン距離 (例: 10×10 なら 18)
-      const maxDist = (maze.size - 1) * 2;
-      const { wait: w, id } = applyDistanceFeedback(
-        next,
-        { x: maze.goal[0], y: maze.goal[1] },
-        { maxDist }
-      );
-      wait = w;
-      intervalRef.current = id;
-    }
-
-    // フィードバック終了から 10ms 後にロック解除
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setLocked(false), wait + 10);
-  };
+  const gradLocs = Platform.OS === 'web' ? [0, 0.2, 1] : undefined;
 
   const dpadTop = height * (2 / 3);
-  // ミニマップを画面上1/3の位置から少し上へずらす
-  // 今回は40pxだけ上に移動させる
   const mapTop = height / 3 - 40;
-  // リザルト表示位置。ミニマップより少し下へ配置する
   const resultTop = mapTop + 260;
 
   return (
@@ -405,71 +150,31 @@ export default function PlayScreen() {
       <View style={[styles.dpadWrapper, { top: dpadTop }]}>
         <DPad onPress={handleMove} disabled={locked} />
       </View>
-      {/* サブメニュー本体 */}
-      <Modal transparent visible={showMenu} animationType="fade">
-        {/* 画面全体を押すと閉じるオーバーレイ */}
-        <Pressable
-          style={styles.menuOverlay}
-          onPress={() => setShowMenu(false)}
-          accessibilityLabel="メニューを閉じる"
-        >
-          <View style={[styles.menuContent, { top: insets.top + 40 }]}>
-            <PlainButton
-              title={t('resetMaze')}
-              onPress={handleReset}
-              accessibilityLabel={t('resetMazeLabel')}
-            />
-            {/* デバッグ用スイッチ */}
-            <View style={styles.switchRow}>
-              <ThemedText>{t('showAll')}</ThemedText>
-              <Switch
-                value={debugAll}
-                onValueChange={setDebugAll}
-                accessibilityLabel={t('showMazeAll')}
-              />
-            </View>
-          </View>
-        </Pressable>
-      </Modal>
-      <Modal transparent visible={showResult} animationType="fade">
-        <View
-          style={styles.modalWrapper}
-          accessible
-          accessibilityLabel="結果表示オーバーレイ"
-        >
-          <ThemedView style={[styles.modalContent, { marginTop: resultTop }]}>
-            <ThemedText type="title">
-              {gameClear
-                ? t('gameClear')
-                : gameOver
-                ? t('gameOver')
-                : t('goal')}
-            </ThemedText>
-            <ThemedText>{t('steps', { count: state.steps })}</ThemedText>
-            <ThemedText>{t('bumps', { count: state.bumps })}</ThemedText>
-            {/* 現在クリアしたステージ数と総ステージ数を表示 */}
-            {/* totalStages は maze.size × maze.size で計算した結果 */}
-            <ThemedText>{t('stage', { current: state.stage, total: totalStages })}</ThemedText>
-            {highScore && (gameClear || gameOver) && (
-              <ThemedText>
-                {t('best', {
-                  stage: highScore.stage,
-                  steps: highScore.steps,
-                  bumps: highScore.bumps,
-                })}
-              </ThemedText>
-            )}
-            {newRecord && (gameClear || gameOver) && (
-              <ThemedText>{t('newRecord')}</ThemedText>
-            )}
-            <PlainButton
-              title={t('ok')}
-              onPress={handleOk}
-              accessibilityLabel={t('backToTitle')}
-            />
-          </ThemedView>
-        </View>
-      </Modal>
+      <PlayMenu
+        visible={showMenu}
+        top={insets.top + 40}
+        onClose={() => setShowMenu(false)}
+        onReset={handleReset}
+        debugAll={debugAll}
+        setDebugAll={setDebugAll}
+        labelReset={t('resetMaze')}
+        labelResetAcc={t('resetMazeLabel')}
+        labelShowAll={t('showAll')}
+        labelShowMaze={t('showMazeAll')}
+      />
+      <ResultModal
+        visible={showResult}
+        top={resultTop}
+        title={gameClear ? t('gameClear') : gameOver ? t('gameOver') : t('goal')}
+        steps={t('steps', { count: state.steps })}
+        bumps={t('bumps', { count: state.bumps })}
+        stageText={t('stage', { current: state.stage, total: totalStages })}
+        highScore={highScore && (gameClear || gameOver) ? highScore : null}
+        newRecord={newRecord && (gameClear || gameOver)}
+        onOk={handleOk}
+        okLabel={t('ok')}
+        accLabel={t('backToTitle')}
+      />
     </View>
   );
 }
@@ -498,36 +203,6 @@ const styles = StyleSheet.create({
     top: 10,
     right: 44,
     padding: 4,
-  },
-  menuOverlay: { flex: 1 },
-  menuContent: {
-    position: "absolute",
-    top: 40,
-    right: 10,
-    backgroundColor: "#fff",
-    padding: 10,
-    borderRadius: 8,
-    gap: 8,
-  },
-  switchRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  modalWrapper: {
-    flex: 1,
-    // リザルトを上寄せにするため中央揃えを解除
-    justifyContent: "flex-start",
-    alignItems: "center",
-    backgroundColor: "rgba(0,0,0,0.5)",
-  },
-  modalContent: {
-    backgroundColor: "#fff",
-    padding: 20,
-    borderRadius: 8,
-    alignItems: "center",
-    gap: 10,
-    width: 250,
   },
   // ミニマップを画面上 1/3 より40px上の位置に中央揃えで配置
   miniMapWrapper: {

--- a/components/PlayMenu.tsx
+++ b/components/PlayMenu.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Modal, Pressable, StyleSheet, Switch, View } from 'react-native';
+import { PlainButton } from '@/components/PlainButton';
+import { ThemedText } from '@/components/ThemedText';
+
+/**
+ * プレイ中に表示するメニューコンポーネント
+ */
+export function PlayMenu({
+  visible,
+  top,
+  onClose,
+  onReset,
+  debugAll,
+  setDebugAll,
+  labelReset,
+  labelResetAcc,
+  labelShowAll,
+  labelShowMaze,
+}: {
+  visible: boolean;
+  top: number;
+  onClose: () => void;
+  onReset: () => void;
+  debugAll: boolean;
+  setDebugAll: (v: boolean) => void;
+  labelReset: string;
+  labelResetAcc: string;
+  labelShowAll: string;
+  labelShowMaze: string;
+}) {
+  return (
+    <Modal transparent visible={visible} animationType="fade">
+      {/* 背景をタップすると閉じるオーバーレイ */}
+      <Pressable
+        style={styles.overlay}
+        onPress={onClose}
+        accessibilityLabel="メニューを閉じる"
+      >
+        <View style={[styles.content, { top }]}>
+          <PlainButton
+            title={labelReset}
+            onPress={onReset}
+            accessibilityLabel={labelResetAcc}
+          />
+          <View style={styles.switchRow}>
+            <ThemedText>{labelShowAll}</ThemedText>
+            <Switch
+              value={debugAll}
+              onValueChange={setDebugAll}
+              accessibilityLabel={labelShowMaze}
+            />
+          </View>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1 },
+  content: {
+    position: 'absolute',
+    right: 10,
+    backgroundColor: '#fff',
+    padding: 10,
+    borderRadius: 8,
+    gap: 8,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+});

--- a/components/ResultModal.tsx
+++ b/components/ResultModal.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Modal, StyleSheet, View } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { PlainButton } from '@/components/PlainButton';
+import type { HighScore } from '@/src/game/highScore';
+
+/** 結果表示モーダル */
+export function ResultModal({
+  visible,
+  top,
+  title,
+  steps,
+  bumps,
+  stageText,
+  highScore,
+  newRecord,
+  onOk,
+  okLabel,
+  accLabel,
+}: {
+  visible: boolean;
+  top: number;
+  title: string;
+  steps: string;
+  bumps: string;
+  stageText: string;
+  highScore: HighScore | null;
+  newRecord: boolean;
+  onOk: () => void | Promise<void>;
+  okLabel: string;
+  accLabel: string;
+}) {
+  return (
+    <Modal transparent visible={visible} animationType="fade">
+      <View style={styles.wrapper} accessible accessibilityLabel="結果表示オーバーレイ">
+        <ThemedView style={[styles.content, { marginTop: top }]}>
+          <ThemedText type="title">{title}</ThemedText>
+          <ThemedText>{steps}</ThemedText>
+          <ThemedText>{bumps}</ThemedText>
+          <ThemedText>{stageText}</ThemedText>
+          {highScore && (
+            <ThemedText>
+              Best: {highScore.stage}ステージ / {highScore.steps} steps / {highScore.bumps} bumps
+            </ThemedText>
+          )}
+          {newRecord && <ThemedText>記録更新！</ThemedText>}
+          <PlainButton title={okLabel} onPress={onOk} accessibilityLabel={accLabel} />
+        </ThemedView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  content: {
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 8,
+    alignItems: 'center',
+    gap: 10,
+    width: 250,
+  },
+});

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -1,0 +1,251 @@
+import { useEffect, useRef, useState } from 'react';
+import { useWindowDimensions } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Audio } from 'expo-audio';
+import { useSharedValue } from 'react-native-reanimated';
+
+import { useGame } from '@/src/game/useGame';
+import { applyBumpFeedback, applyDistanceFeedback, nextPosition } from '@/src/game/utils';
+import { showInterstitial } from '@/src/ads/interstitial';
+import {
+  loadHighScore,
+  saveHighScore,
+  isBetterScore,
+  type HighScore,
+} from '@/src/game/highScore';
+import type { Dir } from '@/src/types/maze';
+
+/**
+ * Play 画面で利用するロジックをまとめたカスタムフック
+ */
+export function usePlayLogic() {
+  const router = useRouter();
+  const { state, move, maze, nextStage, resetRun } = useGame();
+  const { width } = useWindowDimensions();
+
+  // ステージ総数。迷路は正方形なので size×size となる
+  const totalStages = maze.size * maze.size;
+
+  const [showResult, setShowResult] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [stageClear, setStageClear] = useState(false);
+  const [gameClear, setGameClear] = useState(false);
+  const [highScore, setHighScore] = useState<HighScore | null>(null);
+  const [newRecord, setNewRecord] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+  const [debugAll, setDebugAll] = useState(false);
+
+  // 枠線色は壁衝突時のみ赤に変更する
+  const [borderColor, setBorderColor] = useState('transparent');
+  const borderW = useSharedValue(0);
+  const maxBorder = width / 2;
+
+  const [locked, setLocked] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const bgmRef = useRef<Audio.Sound | null>(null);
+  const moveRef = useRef<Audio.Sound | null>(null);
+
+  // BGM と効果音を読み込む。コンポーネント初期化時に一度だけ実行
+  useEffect(() => {
+    (async () => {
+      await Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
+      const bgm = new Audio.Sound();
+      await bgm.loadAsync(require('../../assets/sounds/タタリ.mp3'));
+      await bgm.setIsLoopingAsync(true);
+      await bgm.playAsync();
+      bgmRef.current = bgm;
+
+      const mv = new Audio.Sound();
+      await mv.loadAsync(require('../../assets/sounds/歩く音200ms_2.mp3'));
+      moveRef.current = mv;
+    })();
+    return () => {
+      bgmRef.current?.unloadAsync();
+      moveRef.current?.unloadAsync();
+    };
+  }, []);
+
+  // 選択したレベルが変わったらハイスコアを読み込み直す
+  useEffect(() => {
+    if (!state.levelId) return;
+    (async () => {
+      const hs = await loadHighScore(state.levelId!);
+      setHighScore(hs);
+      setNewRecord(false);
+    })();
+  }, [state.levelId]);
+
+  // ゴール到達や敵に捕まった際の処理をまとめる
+  useEffect(() => {
+    const willChangeMap = state.stage % maze.size === 0;
+    if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
+      setStageClear(true);
+      setGameOver(false);
+      setGameClear(state.finalStage);
+      setShowResult(true);
+      setDebugAll(willChangeMap);
+      if (state.levelId) {
+        const current: HighScore = {
+          stage: state.stage,
+          steps: state.steps,
+          bumps: state.bumps,
+        };
+        (async () => {
+          const old = await loadHighScore(state.levelId!);
+          const better = isBetterScore(old, current);
+          if (better) {
+            await saveHighScore(state.levelId!, current);
+            setHighScore(current);
+          } else {
+            setHighScore(old);
+          }
+          setNewRecord(better && state.finalStage);
+        })();
+      } else {
+        setNewRecord(false);
+      }
+    } else if (state.caught) {
+      setGameOver(true);
+      setStageClear(false);
+      setShowResult(true);
+      setDebugAll(true);
+      if (state.levelId) {
+        const current: HighScore = {
+          stage: state.stage - 1,
+          steps: state.steps,
+          bumps: state.bumps,
+        };
+        (async () => {
+          const old = await loadHighScore(state.levelId!);
+          const better = isBetterScore(old, current);
+          if (better) {
+            await saveHighScore(state.levelId!, current);
+            setHighScore(current);
+          } else {
+            setHighScore(old);
+          }
+          setNewRecord(better);
+        })();
+      } else {
+        setNewRecord(false);
+      }
+    }
+  }, [
+    state.pos,
+    state.caught,
+    maze.goal,
+    state.finalStage,
+    state.stage,
+    maze.size,
+    state.steps,
+    state.bumps,
+    state.levelId,
+  ]);
+
+  // コンポーネントが破棄される際にタイマーを解除
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  /**
+   * リザルトモーダルで OK を押した際の処理
+   */
+  const handleOk = async () => {
+    if (gameOver) {
+      resetRun();
+    } else if (gameClear) {
+      resetRun();
+      router.replace('/');
+    } else if (stageClear) {
+      if (state.stage % 9 === 0) {
+        await showInterstitial();
+      }
+      nextStage();
+    }
+    setShowResult(false);
+    setGameOver(false);
+    setDebugAll(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+  };
+
+  /** Reset Maze が選ばれたときの処理 */
+  const handleReset = () => {
+    setShowMenu(false);
+    setGameOver(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+    resetRun();
+  };
+
+  /** タイトルへ戻る処理 */
+  const handleExit = () => {
+    setShowMenu(false);
+    setGameOver(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+    resetRun();
+    router.replace('/');
+  };
+
+  /** DPad からの入力処理 */
+  const handleMove = (dir: Dir) => {
+    if (locked) return;
+    setLocked(true);
+    const next = nextPosition(state.pos, dir);
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    let wait: number;
+    if (!move(dir)) {
+      wait = applyBumpFeedback(borderW, setBorderColor);
+      setTimeout(() => setBorderColor('transparent'), wait);
+    } else {
+      moveRef.current?.replayAsync();
+      const maxDist = (maze.size - 1) * 2;
+      const { wait: w, id } = applyDistanceFeedback(
+        next,
+        { x: maze.goal[0], y: maze.goal[1] },
+        { maxDist },
+      );
+      wait = w;
+      intervalRef.current = id;
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setLocked(false), wait + 10);
+  };
+
+  return {
+    state,
+    maze,
+    totalStages,
+    showResult,
+    gameOver,
+    gameClear,
+    highScore,
+    newRecord,
+    showMenu,
+    setShowMenu,
+    debugAll,
+    setDebugAll,
+    borderColor,
+    borderW,
+    maxBorder,
+    locked,
+    handleMove,
+    handleOk,
+    handleReset,
+    handleExit,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- extract play screen game logic to `usePlayLogic`
- add `PlayMenu` and `ResultModal` components
- simplify `app/play.tsx` to use the new hook and components

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686383f8ca48832c8dfe2e9508f68c96