### PR TITLE
Initialize Google Mobile Ads on startup

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,10 @@
+import React, { useEffect } from 'react';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
+import mobileAds from 'react-native-google-mobile-ads';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { GameProvider } from '@/src/game/useGame';
@@ -13,6 +15,11 @@ export default function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
+
+  // Google Mobile Ads SDK を初期化する。広告が表示されない問題を防ぐため
+  useEffect(() => {
+    mobileAds().initialize();
+  }, []);
 
   if (!loaded) {
     // Async font loading only occurs in development.


### PR DESCRIPTION
## Summary
- 初期化忘れによりインタースティシャル広告が dev-client で表示されない問題を修正
- `app/_layout.tsx` で `mobileAds().initialize()` を実行

## Testing
- `pnpm lint`
- `pnpm test` *(失敗: jest が見つかりません)*

------
https://chatgpt.com/codex/tasks/task_e_68638e3c3f68832cacbff9e675971ac5