### PR TITLE
Show ad on stage1 clear for debug

### DIFF
--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -161,7 +161,8 @@ export function usePlayLogic() {
       resetRun();
       router.replace('/');
     } else if (stageClear) {
-      if (state.stage % 9 === 0) {
+      // デバッグ用: ステージ1クリア時もインタースティシャル広告を表示する
+      if (state.stage % 9 === 0 || state.stage === 1) {
         await showInterstitial();
       }
       nextStage();


### PR DESCRIPTION
## Summary
- display the interstitial ad even after clearing stage 1

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68638f7a6d28832c91c5d6679e3d8318