### PR TITLE
インタースティシャル広告表示失敗時のハング対処

### DIFF
--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -7,6 +7,7 @@ import { useSharedValue } from 'react-native-reanimated';
 import { useGame } from '@/src/game/useGame';
 import { applyBumpFeedback, applyDistanceFeedback, nextPosition } from '@/src/game/utils';
 import { showInterstitial } from '@/src/ads/interstitial';
+import { useSnackbar } from '@/src/hooks/useSnackbar';
 import {
   loadHighScore,
   saveHighScore,
@@ -22,6 +23,7 @@ export function usePlayLogic() {
   const router = useRouter();
   const { state, move, maze, nextStage, resetRun } = useGame();
   const { width } = useWindowDimensions();
+  const { show: showSnackbar } = useSnackbar();
 
   // ステージ総数。迷路は正方形なので size×size となる
   const totalStages = maze.size * maze.size;
@@ -163,7 +165,12 @@ export function usePlayLogic() {
     } else if (stageClear) {
       // デバッグ用: ステージ1クリア時もインタースティシャル広告を表示する
       if (state.stage % 9 === 0 || state.stage === 1) {
-        await showInterstitial();
+        try {
+          await showInterstitial();
+        } catch (e) {
+          console.error('interstitial error', e);
+          showSnackbar('広告を表示できませんでした');
+        }
       }
       nextStage();
     }

--- a/src/hooks/useSnackbar.ts
+++ b/src/hooks/useSnackbar.ts
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+import { Alert, Platform, ToastAndroid } from 'react-native';
+
+/**
+ * 簡易スナックバー表示用フック
+ * Android では Toast を、その他では Alert を利用する
+ */
+export function useSnackbar() {
+  const show = useCallback((message: string) => {
+    if (Platform.OS === 'android') {
+      ToastAndroid.show(message, ToastAndroid.SHORT);
+    } else {
+      Alert.alert('', message);
+    }
+  }, []);
+
+  return { show } as const;
+}


### PR DESCRIPTION
## Summary
- add `useSnackbar` hook using Alert/Toast
- show snackbar when interstitial ad fails

## Testing
- `pnpm lint` *(fails: expo not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686395f224dc832c80333b2e569cedd2