### PR TITLE
Add volume adjustment submenu

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -11,6 +11,7 @@ import { useLocale } from "@/src/locale/LocaleContext";
 import { usePlayLogic } from "@/src/hooks/usePlayLogic";
 import { PlayMenu } from "@/components/PlayMenu";
 import { ResultModal } from "@/components/ResultModal";
+import { VolumeMenu } from "@/components/VolumeMenu";
 
 // LinearGradient を Reanimated 用にラップ
 // Web 環境では setAttribute エラーを避けるためアニメーション無し
@@ -36,6 +37,10 @@ export default function PlayScreen() {
     setShowMenu,
     debugAll,
     setDebugAll,
+    bgmVol,
+    setBgmVol,
+    seVol,
+    setSeVol,
     audioReady,
     borderColor,
     borderW,
@@ -46,6 +51,7 @@ export default function PlayScreen() {
     handleReset,
     handleExit,
   } = usePlayLogic();
+  const [showVolume, setShowVolume] = React.useState(false);
 
   const vertStyle = useAnimatedStyle(() => ({ height: borderW.value }));
   const horizStyle = useAnimatedStyle(() => ({ width: borderW.value }));
@@ -171,6 +177,21 @@ export default function PlayScreen() {
         labelResetAcc={t('resetMazeLabel')}
         labelShowAll={t('showAll')}
         labelShowMaze={t('showMazeAll')}
+        onVolume={() => setShowVolume(true)}
+        labelVolume={t('volumeSetting')}
+      />
+      <VolumeMenu
+        visible={showVolume}
+        top={insets.top + 80}
+        onClose={() => setShowVolume(false)}
+        bgm={bgmVol}
+        setBgm={setBgmVol}
+        se={seVol}
+        setSe={setSeVol}
+        labelTitle={t('volumeSetting')}
+        labelBgm={t('bgmVolume')}
+        labelSe={t('seVolume')}
+        labelClose={t('ok')}
       />
       <ResultModal
         visible={showResult}

--- a/components/PlayMenu.tsx
+++ b/components/PlayMenu.tsx
@@ -17,6 +17,8 @@ export function PlayMenu({
   labelResetAcc,
   labelShowAll,
   labelShowMaze,
+  onVolume,
+  labelVolume,
 }: {
   visible: boolean;
   top: number;
@@ -28,6 +30,8 @@ export function PlayMenu({
   labelResetAcc: string;
   labelShowAll: string;
   labelShowMaze: string;
+  onVolume: () => void;
+  labelVolume: string;
 }) {
   return (
     <Modal transparent visible={visible} animationType="fade">
@@ -51,6 +55,12 @@ export function PlayMenu({
               accessibilityLabel={labelShowMaze}
             />
           </View>
+          {/* 音量設定サブメニューを開くボタン */}
+          <PlainButton
+            title={labelVolume}
+            onPress={onVolume}
+            accessibilityLabel={labelVolume}
+          />
         </View>
       </Pressable>
     </Modal>

--- a/components/VolumeControl.tsx
+++ b/components/VolumeControl.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { PlainButton } from '@/components/PlainButton';
+import { ThemedText } from '@/components/ThemedText';
+import { useLocale } from '@/src/locale/LocaleContext';
+
+/**
+ * 音量を 0 〜 10 の整数値で増減させるコンポーネント
+ *   label: 表示ラベル
+ *   value: 現在の音量 (0〜10)
+ *   setValue: 値を更新する関数
+ */
+export function VolumeControl({
+  label,
+  value,
+  setValue,
+}: {
+  label: string;
+  value: number;
+  setValue: React.Dispatch<React.SetStateAction<number>>;
+}) {
+  const { t } = useLocale();
+  return (
+    <View style={styles.row}>
+      {/* ラベル表示 */}
+      <ThemedText lightColor="#fff" darkColor="#fff">{label}</ThemedText>
+      {/* マイナスボタンで 1 減らす。最小 0 */}
+      <PlainButton
+        title="-"
+        onPress={() => setValue((v) => Math.max(0, v - 1))}
+        accessibilityLabel={t('decrease', { label })}
+      />
+      {/* 現在値表示。0〜10 の範囲で表示 */}
+      <ThemedText lightColor="#fff" darkColor="#fff" style={styles.count}>
+        {value}
+      </ThemedText>
+      {/* プラスボタンで 1 増やす。最大 10 */}
+      <PlainButton
+        title="+"
+        onPress={() => setValue((v) => Math.min(10, v + 1))}
+        accessibilityLabel={t('increase', { label })}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  count: {
+    borderWidth: 1,
+    borderColor: '#888',
+    color: '#fff',
+    paddingHorizontal: 8,
+    minWidth: 32,
+    textAlign: 'center',
+  },
+});

--- a/components/VolumeMenu.tsx
+++ b/components/VolumeMenu.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Modal, Pressable, StyleSheet, View } from 'react-native';
+import { VolumeControl } from '@/components/VolumeControl';
+import { PlainButton } from '@/components/PlainButton';
+import { ThemedText } from '@/components/ThemedText';
+
+/**
+ * 音量調整用のサブメニュー
+ */
+export function VolumeMenu({
+  visible,
+  top,
+  onClose,
+  bgm,
+  setBgm,
+  se,
+  setSe,
+  labelTitle,
+  labelBgm,
+  labelSe,
+  labelClose,
+}: {
+  visible: boolean;
+  top: number;
+  onClose: () => void;
+  bgm: number;
+  setBgm: (v: number) => void;
+  se: number;
+  setSe: (v: number) => void;
+  labelTitle: string;
+  labelBgm: string;
+  labelSe: string;
+  labelClose: string;
+}) {
+  return (
+    <Modal transparent visible={visible} animationType="fade">
+      <Pressable
+        style={styles.overlay}
+        onPress={onClose}
+        accessibilityLabel="音量設定を閉じる"
+      >
+        <View style={[styles.content, { top }]}>
+          <ThemedText type="title">{labelTitle}</ThemedText>
+          <VolumeControl label={labelBgm} value={bgm} setValue={setBgm} />
+          <VolumeControl label={labelSe} value={se} setValue={setSe} />
+          <PlainButton title={labelClose} onPress={onClose} accessibilityLabel={labelClose} />
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1 },
+  content: {
+    position: 'absolute',
+    right: 10,
+    backgroundColor: '#fff',
+    padding: 10,
+    borderRadius: 8,
+    gap: 8,
+  },
+});

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -42,6 +42,9 @@ export function usePlayLogic() {
   const [debugAll, setDebugAll] = useState(false);
   // 再生中を視覚化するためのフラグ
   const [audioReady, setAudioReady] = useState(false);
+  // 音量設定。BGM は控えめに、効果音はやや大きめに初期化
+  const [bgmVol, setBgmVol] = useState(3);
+  const [seVol, setSeVol] = useState(7);
 
   // 枠線色は壁衝突時のみ赤に変更する
   const [borderColor, setBorderColor] = useState('transparent');
@@ -54,31 +57,39 @@ export function usePlayLogic() {
   const bgmRef = useRef<AudioPlayer | null>(null);
   const moveRef = useRef<AudioPlayer | null>(null);
 
-  // BGM と効果音を読み込む。コンポーネント初期化時に一度だけ実行
+  // BGM と効果音を読み込み、音量も設定する
   useEffect(() => {
     (async () => {
-      // サイレントモードでも再生できるように設定
-      await setAudioModeAsync({ playsInSilentMode: true });
+      if (!bgmRef.current) {
+        // サイレントモードでも再生できるように設定
+        await setAudioModeAsync({ playsInSilentMode: true });
 
-      // BGM を読み込みループ再生開始
-      // createAudioPlayer は音声再生オブジェクトを生成する関数
-      const bgm = createAudioPlayer(require('../../assets/sounds/タタリ.mp3'));
-      bgm.loop = true;
-      bgm.play();
-      bgmRef.current = bgm;
-      // BGM の再生開始を合図
-      setAudioReady(true);
+        // BGM を読み込みループ再生開始
+        const bgm = createAudioPlayer(require('../../assets/sounds/タタリ.mp3'));
+        bgm.loop = true;
+        bgm.play();
+        bgmRef.current = bgm;
 
-      // 移動時効果音を読み込み
-      const mv = createAudioPlayer(require('../../assets/sounds/歩く音200ms_2.mp3'));
-      moveRef.current = mv;
+        // 効果音も読み込み
+        const mv = createAudioPlayer(require('../../assets/sounds/歩く音200ms_2.mp3'));
+        moveRef.current = mv;
+
+        // BGM の再生開始を合図
+        setAudioReady(true);
+      }
+
+      // 既に存在する場合は音量だけ更新
+      if (bgmRef.current) bgmRef.current.volume = bgmVol / 10;
+      if (moveRef.current) moveRef.current.volume = seVol / 10;
     })();
     return () => {
       bgmRef.current?.remove();
       moveRef.current?.remove();
       setAudioReady(false);
     };
-  }, []);
+  }, [bgmVol, seVol]);
+
+
 
   // 選択したレベルが変わったらハイスコアを読み込み直す
   useEffect(() => {
@@ -264,6 +275,10 @@ export function usePlayLogic() {
     setShowMenu,
     debugAll,
     setDebugAll,
+    bgmVol,
+    setBgmVol,
+    seVol,
+    setSeVol,
     audioReady,
     borderColor,
     borderW,

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -44,6 +44,9 @@ const messages = {
     selectLang: '言語を選択してください',
     japanese: '日本語',
     english: 'English',
+    volumeSetting: '音量設定',
+    bgmVolume: 'BGM 音量',
+    seVolume: 'SE 音量',
     backToTitle: 'タイトルへ戻る',
   },
   en: {
@@ -82,6 +85,9 @@ const messages = {
     selectLang: 'Select language',
     japanese: 'Japanese',
     english: 'English',
+    volumeSetting: 'Sound Volume',
+    bgmVolume: 'BGM Volume',
+    seVolume: 'SE Volume',
     backToTitle: 'Back to title',
   },
 } as const;


### PR DESCRIPTION
## Summary
- add a volume control component and submenu
- control BGM/SE volume from play screen menu
- keep SE louder than BGM by default
- localize new labels in English and Japanese

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a19459b0832cae819bcf85c33d91