### PR TITLE
Change createFirstStage options

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -35,17 +35,17 @@ export default function TitleScreen() {
   const startLevel = (id: string) => {
     const level = LEVELS.find((l) => l.id === id);
     if (!level) return;
-    newGame(
-      level.size,
-      level.enemies,
-      level.enemyPathLength,
-      level.playerPathLength,
-      level.wallLifetime,
-      level.enemyCountsFn,
-      level.wallLifetimeFn,
-      level.biasedSpawn,
-      level.id
-    );
+    newGame({
+      size: level.size,
+      counts: level.enemies,
+      enemyPathLength: level.enemyPathLength,
+      playerPathLength: level.playerPathLength,
+      wallLifetime: level.wallLifetime,
+      enemyCountsFn: level.enemyCountsFn,
+      wallLifetimeFn: level.wallLifetimeFn,
+      biasedSpawn: level.biasedSpawn,
+      levelId: level.id,
+    });
     router.replace("/play");
   };
   return (

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -24,17 +24,15 @@ export default function PracticeScreen() {
   const [wallLife, setWallLife] = React.useState<number>(Infinity);
 
   const start = (size: number) => {
-    newGame(
+    newGame({
       size,
-      { random, slow, sight, fast: 0 },
-      pathLen,
-      playerLen,
-      wallLife,
-      undefined,
-      undefined,
-      true,
-      'practice',
-    );
+      counts: { random, slow, sight, fast: 0 },
+      enemyPathLength: pathLen,
+      playerPathLength: playerLen,
+      wallLifetime: wallLife,
+      biasedSpawn: true,
+      levelId: 'practice',
+    });
     router.replace('/play');
   };
 

--- a/src/game/state/index.ts
+++ b/src/game/state/index.ts
@@ -4,3 +4,4 @@ export type { GameState, State } from './core';
 export { createFirstStage, nextStageState, restartRun } from './stage';
 export { reducer } from './reducer';
 export type { Action } from './reducer';
+export type { NewGameOptions } from './stage';

--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -1,9 +1,8 @@
 import { canMove, getHitWall, nextPosition, updateEnemyPaths, updatePlayerPath, decayHitMap, inSight } from '../utils';
 import { getEnemyMover } from '../enemy';
 import type { Dir, MazeData } from '@/src/types/maze';
-import type { EnemyCounts } from '@/src/types/enemy';
 import { initState, State } from './core';
-import { createFirstStage, nextStageState, restartRun } from './stage';
+import { createFirstStage, nextStageState, restartRun, type NewGameOptions } from './stage';
 
 // Reducer で使うアクション型
 export type Action =
@@ -12,14 +11,7 @@ export type Action =
   | {
       type: 'newMaze';
       maze: MazeData;
-      counts?: EnemyCounts;
-      enemyPathLength?: number;
-      playerPathLength?: number;
-      wallLifetime?: number;
-      enemyCountsFn?: (stage: number) => EnemyCounts;
-      wallLifetimeFn?: (stage: number) => number;
-      biasedSpawn?: boolean;
-      levelId?: string;
+      options: NewGameOptions;
     }
   | { type: 'nextStage' }
   | { type: 'resetRun' };
@@ -44,17 +36,17 @@ export function reducer(state: State, action: Action): State {
         state.levelId,
       );
     case 'newMaze':
-      return createFirstStage(
-        action.maze,
-        action.counts ?? state.enemyCounts,
-        action.enemyPathLength ?? state.enemyPathLength,
-        action.playerPathLength ?? state.playerPathLength,
-        action.wallLifetime ?? state.wallLifetime,
-        action.enemyCountsFn,
-        action.wallLifetimeFn,
-        action.biasedSpawn ?? state.biasedSpawn,
-        action.levelId,
-      );
+      return createFirstStage(action.maze, {
+        size: action.options.size,
+        counts: action.options.counts ?? state.enemyCounts,
+        enemyPathLength: action.options.enemyPathLength ?? state.enemyPathLength,
+        playerPathLength: action.options.playerPathLength ?? state.playerPathLength,
+        wallLifetime: action.options.wallLifetime ?? state.wallLifetime,
+        enemyCountsFn: action.options.enemyCountsFn,
+        wallLifetimeFn: action.options.wallLifetimeFn,
+        biasedSpawn: action.options.biasedSpawn ?? state.biasedSpawn,
+        levelId: action.options.levelId,
+      });
     case 'nextStage':
       return nextStageState(state);
     case 'resetRun':


### PR DESCRIPTION
## Summary
- add `NewGameOptions` interface and refactor `createFirstStage`
- update reducer and game hook to use new options object
- adjust call sites on title and practice screens

## Testing
- `pnpm lint`
- `npx tsc --noEmit` *(fails: cannot find many types)*

------
https://chatgpt.com/codex/tasks/task_e_68644e206210832ca062fb058ca44450