### PR TITLE
Add DIRECTIONS constant and use in utils

### DIFF
--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -1,6 +1,7 @@
 import * as Haptics from "expo-haptics";
 import { withTiming, withSequence, SharedValue } from "react-native-reanimated";
 import type { MazeData, Vec2, Dir } from "@/src/types/maze";
+import { DIRECTIONS } from "@/src/types/maze";
 import type { Enemy } from "@/src/types/enemy";
 
 /**
@@ -282,7 +283,7 @@ export function moveEnemyRandom(
   _player?: Vec2,
   rnd: () => number = Math.random
 ): Enemy {
-  const dirs: Dir[] = ["Up", "Down", "Left", "Right"].filter((d) =>
+  const dirs: Dir[] = DIRECTIONS.filter((d) =>
     canMove(enemy.pos, d, maze)
   );
   if (dirs.length === 0) return enemy;
@@ -300,7 +301,7 @@ export function moveEnemyBasic(
   visited: Map<string, number>,
   rnd: () => number = Math.random
 ): Enemy {
-  const dirs: Dir[] = ["Up", "Down", "Left", "Right"].filter((d) =>
+  const dirs: Dir[] = DIRECTIONS.filter((d) =>
     canMove(enemy.pos, d, maze)
   );
   if (dirs.length === 0) return enemy;
@@ -344,7 +345,7 @@ export function shortestStep(
       return { next: first ?? pos, dist };
     }
 
-    for (const dir of ["Up", "Down", "Left", "Right"] as const) {
+    for (const dir of DIRECTIONS) {
       if (!canMove(pos, dir, maze)) continue;
       const nxt = nextPosition(pos, dir);
       const key = `${nxt.x},${nxt.y}`;
@@ -369,7 +370,7 @@ export function moveEnemySmart(
   player: Vec2,
   rnd: () => number = Math.random
 ): Enemy {
-  const dirs: Dir[] = ["Up", "Down", "Left", "Right"].filter((d) =>
+  const dirs: Dir[] = DIRECTIONS.filter((d) =>
     canMove(enemy.pos, d, maze)
   );
   if (dirs.length === 0) return enemy;
@@ -461,7 +462,7 @@ export function moveEnemySense(
   const manhattan =
     Math.abs(enemy.pos.x - player.x) + Math.abs(enemy.pos.y - player.y);
   if (manhattan <= range) {
-    const dirs: Dir[] = ["Up", "Down", "Left", "Right"].filter((d) =>
+    const dirs: Dir[] = DIRECTIONS.filter((d) =>
       canMove(enemy.pos, d, maze)
     );
     if (dirs.length === 0) return enemy;

--- a/src/types/maze.ts
+++ b/src/types/maze.ts
@@ -17,3 +17,7 @@ export interface Vec2 {
 
 export type Dir = 'Up' | 'Down' | 'Left' | 'Right';
 
+// よく使う進行方向を配列でまとめた定数です
+// as const を付けると、要素が文字列リテラル型として扱われます
+export const DIRECTIONS = ['Up', 'Down', 'Left', 'Right'] as const;
+


### PR DESCRIPTION
## Summary
- define `DIRECTIONS` in maze types
- replace inline配列 with this constant in game utilities

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644e43c8dc832ca871d6d53d4bcfb0