### PR TITLE
Fix React undefined error in PlayScreen

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { View, Pressable, StyleSheet, useWindowDimensions, Platform } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";


### PR DESCRIPTION
## Summary
- fix missing React import in `PlayScreen`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6864ad74b0f8832cb69df2a3b75a7b4a