### PR TITLE
Fix minimap flash

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -158,6 +158,7 @@ export default function PlayScreen() {
           showResult={showResult}
           hitV={state.hitV}
           hitH={state.hitH}
+          flash={borderW}
           playerPathLength={state.playerPathLength}
           wallLifetime={state.wallLifetime}
           // ミニマップを300pxで表示する


### PR DESCRIPTION
## Summary
- ミニマップの表示で枠線のアニメーションが働かなくなっていたので `flash` プロパティを復旧

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6864b02dec60832c85f896253e421b22