### PR TITLE
Add audio and score hooks

### DIFF
--- a/src/hooks/useBgm.ts
+++ b/src/hooks/useBgm.ts
@@ -1,0 +1,4 @@
+// BGM 再生のためのフックを再輸出します
+// 実装本体は audio/BgmProvider.tsx にあるため
+// このファイルから呼び出すことで hooks フォルダに機能を集約しています
+export { useBgm } from '@/src/audio/BgmProvider';

--- a/src/hooks/useHighScore.ts
+++ b/src/hooks/useHighScore.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import {
+  loadHighScore,
+  saveHighScore,
+  isBetterScore,
+  type HighScore,
+} from '@/src/game/highScore';
+
+/**
+ * ハイスコアの読み込みと更新を行うフック。
+ * levelId が変わるたびにスコアを読み込み直す。
+ */
+export function useHighScore(levelId: string | null | undefined) {
+  // 現在保存されているハイスコア
+  const [highScore, setHighScore] = useState<HighScore | null>(null);
+  // 新記録かどうかを示すフラグ
+  const [newRecord, setNewRecord] = useState(false);
+
+  // levelId が変わったときはハイスコアを再取得する
+  useEffect(() => {
+    if (!levelId) {
+      setHighScore(null);
+      setNewRecord(false);
+      return;
+    }
+    (async () => {
+      const hs = await loadHighScore(levelId);
+      setHighScore(hs);
+      setNewRecord(false);
+    })();
+  }, [levelId]);
+
+  /**
+   * 現在のスコアを渡して、より良い記録なら保存する。
+   * `finalStage` が true の場合のみ新記録表示を行う。
+   */
+  const updateScore = async (score: HighScore, finalStage: boolean) => {
+    if (!levelId) return;
+    const old = await loadHighScore(levelId);
+    const better = isBetterScore(old, score);
+    if (better) {
+      await saveHighScore(levelId, score);
+      setHighScore(score);
+    } else {
+      setHighScore(old);
+    }
+    setNewRecord(better && finalStage);
+  };
+
+  return { highScore, newRecord, setNewRecord, updateScore } as const;
+}

--- a/src/hooks/useSE.ts
+++ b/src/hooks/useSE.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from 'react';
+import { createAudioPlayer, type AudioPlayer } from 'expo-audio';
+
+/**
+ * 効果音(SE)を管理するためのフック。
+ * `soundFile` には require した音声ファイルを渡します。
+ */
+export function useSE(soundFile: number) {
+  // プレイヤーオブジェクトを保持する参照
+  const playerRef = useRef<AudioPlayer | null>(null);
+  // 音量を 0〜1 の範囲で管理
+  const [volume, setVolume] = useState(1);
+
+  // 初期化時に効果音を読み込む
+  useEffect(() => {
+    const p = createAudioPlayer(soundFile);
+    p.volume = volume;
+    playerRef.current = p;
+    return () => {
+      playerRef.current?.remove();
+    };
+    // soundFile は固定値として扱うため依存配列は空
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 音量変更時に実際のプレイヤーへ反映
+  useEffect(() => {
+    if (playerRef.current) playerRef.current.volume = volume;
+  }, [volume]);
+
+  /** 効果音を頭から再生する */
+  const play = () => {
+    if (!playerRef.current) return;
+    playerRef.current.seekTo(0);
+    playerRef.current.play();
+  };
+
+  return { volume, setVolume, play } as const;
+}


### PR DESCRIPTION
## Summary
- create reusable SE, BGM, and HighScore hooks
- refactor play logic to use new hooks
- keep code comments in Japanese for clarity

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e659a3e4832ca130432325ec90b4