### PR TITLE
Add okLocked state to disable ResultModal OK

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -46,6 +46,7 @@ export default function PlayScreen() {
     borderW,
     maxBorder,
     locked,
+    okLocked,
     handleMove,
     handleOk,
     handleReset,
@@ -196,6 +197,7 @@ export default function PlayScreen() {
         onOk={handleOk}
         okLabel={t('ok')}
         accLabel={t('backToTitle')}
+        disabled={okLocked}
       />
     </View>
   );

--- a/components/ResultModal.tsx
+++ b/components/ResultModal.tsx
@@ -19,6 +19,7 @@ export function ResultModal({
   onOk,
   okLabel,
   accLabel,
+  disabled,
 }: {
   visible: boolean;
   top: number;
@@ -31,6 +32,7 @@ export function ResultModal({
   onOk: () => void | Promise<void>;
   okLabel: string;
   accLabel: string;
+  disabled?: boolean;
 }) {
   // 画面の文言を取得するためにロケールフックを利用
   const { t } = useLocale();
@@ -52,7 +54,12 @@ export function ResultModal({
             </ThemedText>
           )}
           {newRecord && <ThemedText>{t('newRecord')}</ThemedText>}
-          <PlainButton title={okLabel} onPress={onOk} accessibilityLabel={accLabel} />
+          <PlainButton
+            title={okLabel}
+            onPress={onOk}
+            accessibilityLabel={accLabel}
+            disabled={disabled}
+          />
         </ThemedView>
       </View>
     </Modal>

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -45,6 +45,8 @@ export function usePlayLogic() {
   const maxBorder = width / 2;
 
   const [locked, setLocked] = useState(false);
+  // OK ボタン連打を防ぐためのフラグ
+  const [okLocked, setOkLocked] = useState(false);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const { volume: bgmVolume, setVolume: setBgmVolume, pause: pauseBgm, resume: resumeBgm } = useBgm();
@@ -118,6 +120,9 @@ export function usePlayLogic() {
    * リザルトモーダルで OK を押した際の処理
    */
   const handleOk = async () => {
+    // ボタン連打で複数回処理が走らないようロック
+    if (okLocked) return;
+    setOkLocked(true);
     if (gameOver) {
       resetRun();
     } else if (gameClear) {
@@ -144,6 +149,7 @@ export function usePlayLogic() {
     setStageClear(false);
     setGameClear(false);
     setNewRecord(false);
+    setOkLocked(false);
   };
 
   /** Reset Maze が選ばれたときの処理 */
@@ -237,6 +243,7 @@ export function usePlayLogic() {
     borderW,
     maxBorder,
     locked,
+    okLocked,
     handleMove,
     handleOk,
     handleReset,


### PR DESCRIPTION
## Summary
- prevent rapid presses on ResultModal OK button
- expose okLocked from play logic
- disable PlainButton when locked

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6865ebec7940832cbdd2e4bc6239b4ce