### PR TITLE
Export MazeSets and update move helpers

### DIFF
--- a/src/game/__tests__/utils.test.ts
+++ b/src/game/__tests__/utils.test.ts
@@ -3,8 +3,9 @@
 
 import { canMove, getHitWall, wallSet } from '../maze';
 import type { MazeData, Vec2 } from '@/src/types/maze';
+import type { MazeSets } from '../state/core';
 
-type TestMaze = MazeData & { v_walls: Set<string>; h_walls: Set<string> };
+type TestMaze = MazeSets;
 
 // 迷路サイズは型の都合で常に 10 とするが、今回は数マスしか使わない
 const baseMaze: Omit<MazeData, 'v_walls' | 'h_walls'> = {

--- a/src/game/enemyAI.ts
+++ b/src/game/enemyAI.ts
@@ -1,6 +1,7 @@
 // 敵の移動や配置に関する処理を集めたモジュール
 
 import type { MazeData, Vec2, Dir } from '@/src/types/maze';
+import type { MazeSets } from './state/core';
 import type { Enemy } from '@/src/types/enemy';
 import { canMove, nextPosition, allCells, biasedPickGoal } from './maze';
 
@@ -40,7 +41,7 @@ export function spawnEnemies(
 /** ランダムに一マス移動する単純な行動 */
 export function moveEnemyRandom(
   enemy: Enemy,
-  maze: MazeData,
+  maze: MazeSets,
   _visited?: Map<string, number>,
   _player?: Vec2,
   rnd: () => number = Math.random,
@@ -56,7 +57,7 @@ export function moveEnemyRandom(
 /** 未踏マスを優先して移動する基本行動 */
 export function moveEnemyBasic(
   enemy: Enemy,
-  maze: MazeData,
+  maze: MazeSets,
   visited: Map<string, number>,
   rnd: () => number = Math.random,
 ): Enemy {
@@ -89,7 +90,7 @@ export function moveEnemyBasic(
 export function shortestStep(
   start: Vec2,
   goal: Vec2,
-  maze: MazeData,
+  maze: MazeSets,
 ): { next: Vec2; dist: number } | null {
   const visited = new Set<string>([`${start.x},${start.y}`]);
   type Node = { pos: Vec2; dist: number; first: Vec2 | null };
@@ -118,7 +119,7 @@ export function shortestStep(
  */
 export function moveEnemySmart(
   enemy: Enemy,
-  maze: MazeData,
+  maze: MazeSets,
   visited: Map<string, number>,
   player: Vec2,
   rnd: () => number = Math.random,
@@ -140,7 +141,7 @@ export function moveEnemySmart(
 export function inSight(
   enemy: Vec2,
   player: Vec2,
-  maze: MazeData,
+  maze: MazeSets,
   range: number = Infinity,
 ): boolean {
   if (enemy.x === player.x) {
@@ -171,7 +172,7 @@ export function inSight(
  */
 export function moveEnemySight(
   enemy: Enemy,
-  maze: MazeData,
+  maze: MazeSets,
   visited: Map<string, number>,
   player: Vec2,
   rnd: () => number = Math.random,

--- a/src/game/maze.ts
+++ b/src/game/maze.ts
@@ -1,6 +1,7 @@
 // 迷路関連の汎用処理をまとめたモジュール
 
-import type { MazeData, Vec2, Dir } from '@/src/types/maze';
+import type { Vec2, Dir } from '@/src/types/maze';
+import type { MazeSets } from './state/core';
 
 /**
  * 壁配列から高速検索用の Set を作成する
@@ -12,9 +13,9 @@ export function wallSet(walls: [number, number][]): Set<string> {
 /**
  * 現在位置から指定方向へ移動できるかを判定
  */
-export function canMove({ x, y }: Vec2, dir: Dir, maze: MazeData): boolean {
-  const h = maze.v_walls as unknown as Set<string>;
-  const v = maze.h_walls as unknown as Set<string>;
+export function canMove({ x, y }: Vec2, dir: Dir, maze: MazeSets): boolean {
+  const h = maze.v_walls;
+  const v = maze.h_walls;
   const last = maze.size - 1;
   switch (dir) {
     case 'Right':
@@ -57,10 +58,10 @@ export function nextPosition(pos: Vec2, dir: Dir): Vec2 {
 export function getHitWall(
   { x, y }: Vec2,
   dir: Dir,
-  maze: MazeData,
+  maze: MazeSets,
 ): { kind: 'v' | 'h'; key: string } | null {
-  const h = maze.v_walls as unknown as Set<string>;
-  const v = maze.h_walls as unknown as Set<string>;
+  const h = maze.v_walls;
+  const v = maze.h_walls;
   const last = maze.size - 1;
   switch (dir) {
     case 'Right':

--- a/src/game/state/core.ts
+++ b/src/game/state/core.ts
@@ -5,7 +5,7 @@ import type { Enemy, EnemyCounts } from '@/src/types/enemy';
 import { createEnemies } from './enemy';
 
 // MazeData から壁情報を Set 化して検索を高速にするヘルパー
-interface MazeSets extends MazeData {
+export interface MazeSets extends MazeData {
   v_walls: Set<string>;
   h_walls: Set<string>;
 }

--- a/src/game/state/index.ts
+++ b/src/game/state/index.ts
@@ -1,6 +1,6 @@
 export { createEnemies } from './enemy';
 export { prepMaze, initState } from './core';
-export type { GameState, State } from './core';
+export type { GameState, State, MazeSets } from './core';
 export { createFirstStage, nextStageState, restartRun } from './stage';
 export { reducer } from './reducer';
 export type { Action } from './reducer';

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -5,3 +5,4 @@ export * from './math';
 export * from './feedback';
 export * from './maze';
 export * from './enemyAI';
+export type { MazeSets } from './state';


### PR DESCRIPTION
## Summary
- MazeSets型を公開
- canMoveとgetHitWallの型をMazeSetsに修正
- enemyAIなど呼び出し側を更新
- utilモジュールでもMazeSetsを再エクスポート

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865eeca76e8832cad5ae1791e519229