### PR TITLE
Refactor MiniMap drawing

### DIFF
--- a/src/components/mini-map/Enemies.tsx
+++ b/src/components/mini-map/Enemies.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Circle, Line } from 'react-native-svg';
+import type { Enemy } from '@/src/types/enemy';
+
+// 敵描画に関する処理
+
+// 中心から放射状に線を伸ばすヘルパー
+function enemyLines(cx: number, cy: number, r: number, count: number): React.JSX.Element[] {
+  const lines: React.JSX.Element[] = [];
+  const step = (2 * Math.PI) / count;
+  for (let i = 0; i < count; i++) {
+    const rad = i * step - Math.PI / 2; // 12時方向基準
+    lines.push(
+      <Line
+        key={`l${i}`}
+        x1={cx}
+        y1={cy}
+        x2={cx + r * Math.cos(rad)}
+        y2={cy + r * Math.sin(rad)}
+        stroke="white"
+        strokeWidth={1}
+      />
+    );
+  }
+  return lines;
+}
+
+export interface EnemiesProps {
+  enemies: Enemy[];
+  cell: number;
+  showAll: boolean;
+}
+
+// 敵本体と放射線を描画
+export function renderEnemies({ enemies, cell, showAll }: EnemiesProps): (React.JSX.Element | null)[] {
+  const lineMap = { random: 4, slow: 6, sight: 24, fast: 12 } as const;
+  return enemies.map((e, i) => {
+    if (!e.visible && !showAll) return null;
+    const cx = (e.pos.x + 0.5) * cell;
+    const cy = (e.pos.y + 0.5) * cell;
+    const lines = enemyLines(cx, cy, cell * 0.35, lineMap[e.kind ?? 'random']);
+    return (
+      <React.Fragment key={`enemy${i}`}>
+        <Circle cx={cx} cy={cy} r={cell * 0.1} fill="white" />
+        {lines}
+      </React.Fragment>
+    );
+  });
+}
+

--- a/src/components/mini-map/Paths.tsx
+++ b/src/components/mini-map/Paths.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { Defs, Line, LinearGradient, Rect, Stop } from 'react-native-svg';
+import type { Enemy } from '@/src/types/enemy';
+import type { Vec2 } from '@/src/types/maze';
+
+// 軌跡描画に関する関数群
+
+export interface PathProps {
+  path: Vec2[];
+  cell: number;
+  playerPathLength: number;
+}
+
+// プレイヤーの移動履歴を描画
+export function renderPath({ path, cell, playerPathLength }: PathProps): React.JSX.Element[] | null {
+  if (path.length < 2) return null;
+  const segments: React.JSX.Element[] = [];
+  for (let i = 0; i < path.length - 1; i++) {
+    const a = path[i];
+    const b = path[i + 1];
+    if (playerPathLength === Infinity) {
+      segments.push(
+        <Line
+          key={`p${i}`}
+          x1={(a.x + 0.5) * cell}
+          y1={(a.y + 0.5) * cell}
+          x2={(b.x + 0.5) * cell}
+          y2={(b.y + 0.5) * cell}
+          stroke="white"
+          strokeWidth={1}
+        />
+      );
+    } else {
+      const id = `pp${i}`;
+      const segs = path.length - 1;
+      const startO = i / segs;
+      const endO = (i + 1) / segs;
+      segments.push(
+        <React.Fragment key={id}>
+          <Defs>
+            <LinearGradient
+              id={id}
+              x1={(a.x + 0.5) * cell}
+              y1={(a.y + 0.5) * cell}
+              x2={(b.x + 0.5) * cell}
+              y2={(b.y + 0.5) * cell}
+              gradientUnits="userSpaceOnUse"
+            >
+              <Stop offset="0" stopColor="white" stopOpacity={startO} />
+              <Stop offset="1" stopColor="white" stopOpacity={endO} />
+            </LinearGradient>
+          </Defs>
+          <Line
+            x1={(a.x + 0.5) * cell}
+            y1={(a.y + 0.5) * cell}
+            x2={(b.x + 0.5) * cell}
+            y2={(b.y + 0.5) * cell}
+            stroke={`url(#${id})`}
+            strokeWidth={1}
+          />
+        </React.Fragment>
+      );
+    }
+  }
+  return segments;
+}
+
+export interface EnemyPathsProps {
+  enemyPaths: Vec2[][];
+  enemies: Enemy[];
+  cell: number;
+  showAll: boolean;
+}
+
+// 敵の移動履歴を描画
+export function renderEnemyPaths({ enemyPaths, enemies, cell, showAll }: EnemyPathsProps): React.JSX.Element[] {
+  const lines: React.JSX.Element[] = [];
+  enemyPaths.forEach((p, idx) => {
+    const enemy = enemies[idx];
+    if (enemy && !enemy.visible && !showAll) return;
+    for (let i = 0; i < p.length - 1; i++) {
+      const a = p[i];
+      const b = p[i + 1];
+      const id = `ep${idx}-${i}`;
+      const startO = i === 0 ? 0 : i === 1 ? 0.5 : 0.8;
+      const endO = i === p.length - 2 ? 1 : i === 0 ? 0.5 : 0.8;
+      lines.push(
+        <React.Fragment key={id}>
+          <Defs>
+            <LinearGradient
+              id={id}
+              x1={(a.x + 0.5) * cell}
+              y1={(a.y + 0.5) * cell}
+              x2={(b.x + 0.5) * cell}
+              y2={(b.y + 0.5) * cell}
+              gradientUnits="userSpaceOnUse"
+            >
+              <Stop offset="0" stopColor="white" stopOpacity={startO} />
+              <Stop offset="1" stopColor="white" stopOpacity={endO} />
+            </LinearGradient>
+          </Defs>
+          <Line
+            x1={(a.x + 0.5) * cell}
+            y1={(a.y + 0.5) * cell}
+            x2={(b.x + 0.5) * cell}
+            y2={(b.y + 0.5) * cell}
+            stroke={`url(#${id})`}
+            strokeWidth={1}
+          />
+        </React.Fragment>
+      );
+    }
+  });
+  return lines;
+}
+
+export interface VisitedProps {
+  visitedGoals?: Set<string>;
+  cell: number;
+  showResult: boolean;
+  showAll: boolean;
+}
+
+// 過去のゴール位置を枠のみで表示
+export function renderVisitedGoals({ visitedGoals, cell, showResult, showAll }: VisitedProps): React.JSX.Element[] | null {
+  if (!visitedGoals || (!showResult && !showAll)) return null;
+  const rects: React.JSX.Element[] = [];
+  visitedGoals.forEach((k) => {
+    const [x, y] = k.split(',').map(Number);
+    rects.push(
+      <Rect
+        key={`vg${k}`}
+        x={(x + 0.25) * cell}
+        y={(y + 0.25) * cell}
+        width={cell * 0.5}
+        height={cell * 0.5}
+        stroke="white"
+        strokeWidth={1}
+        fill="none"
+      />
+    );
+  });
+  return rects;
+}
+

--- a/src/components/mini-map/Walls.tsx
+++ b/src/components/mini-map/Walls.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Line, Rect } from 'react-native-svg';
+import type { MazeData } from '@/src/types/maze';
+
+// 壁描画処理をまとめたファイル
+// MiniMap 以外でも使えるように関数として定義
+
+// グレーの壁色を定数化
+const WALL_COLOR = 'gray';
+
+export interface WallsProps {
+  maze: MazeData;
+  cell: number;
+  size: number;
+  showAll: boolean;
+}
+
+// 迷路全体の壁を描く関数
+export function renderWalls({ maze, cell, size, showAll }: WallsProps): React.JSX.Element[] | null {
+  if (!showAll) return null;
+  const lines: React.JSX.Element[] = [];
+  // 迷路の外周がわかりやすいように白枠を追加
+  lines.push(
+    <Rect
+      key="debugBorder"
+      x={0}
+      y={0}
+      width={size}
+      height={size}
+      stroke="white"
+      strokeWidth={1}
+      fill="none"
+    />
+  );
+
+  // 縦方向の壁
+  for (const [x, y] of maze.v_walls) {
+    const px = (x + 1) * cell;
+    const py = y * cell;
+    lines.push(
+      <Line
+        key={`v${x},${y}`}
+        x1={px}
+        y1={py}
+        x2={px}
+        y2={py + cell}
+        stroke={WALL_COLOR}
+        strokeWidth={1}
+      />
+    );
+  }
+
+  // 横方向の壁
+  for (const [x, y] of maze.h_walls) {
+    const px = x * cell;
+    const py = (y + 1) * cell;
+    lines.push(
+      <Line
+        key={`h${x},${y}`}
+        x1={px}
+        y1={py}
+        x2={px + cell}
+        y2={py}
+        stroke={WALL_COLOR}
+        strokeWidth={1}
+      />
+    );
+  }
+
+  return lines;
+}
+
+export interface HitWallProps {
+  cell: number;
+  hitV?: Map<string, number>;
+  hitH?: Map<string, number>;
+  wallLifetime: number;
+}
+
+// 衝突した壁を描く関数
+export function renderHitWalls({ cell, hitV, hitH, wallLifetime }: HitWallProps): React.JSX.Element[] {
+  const lines: React.JSX.Element[] = [];
+  hitV?.forEach((life, k) => {
+    const [x, y] = k.split(',').map(Number);
+    const op = wallLifetime === Infinity || life === Infinity ? 1 : life / wallLifetime;
+    lines.push(
+      <Line
+        key={`hv${k}`}
+        x1={(x + 1) * cell}
+        y1={y * cell}
+        x2={(x + 1) * cell}
+        y2={y * cell + cell}
+        stroke={`rgba(128,128,128,${op})`}
+        strokeWidth={1}
+      />
+    );
+  });
+  hitH?.forEach((life, k) => {
+    const [x, y] = k.split(',').map(Number);
+    const op = wallLifetime === Infinity || life === Infinity ? 1 : life / wallLifetime;
+    lines.push(
+      <Line
+        key={`hh${k}`}
+        x1={x * cell}
+        y1={(y + 1) * cell}
+        x2={x * cell + cell}
+        y2={(y + 1) * cell}
+        stroke={`rgba(128,128,128,${op})`}
+        strokeWidth={1}
+      />
+    );
+  });
+  return lines;
+}
+


### PR DESCRIPTION
## Summary
- split MiniMap drawing logic into mini-map directory
- add Walls, Paths and Enemies helper modules
- simplify MiniMap by using the new helper functions

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686602b431c8832cbbd153d23a141f22