### PR TITLE
update maze import script to ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "prestart": "node ./scripts/update-maze-import.js",
+    "prestart": "node ./scripts/update-maze-import.ts",
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "preandroid": "node ./scripts/update-maze-import.js",
+    "preandroid": "node ./scripts/update-maze-import.ts",
     "android": "expo start --android",
-    "preios": "node ./scripts/update-maze-import.js",
+    "preios": "node ./scripts/update-maze-import.ts",
     "ios": "expo start --ios",
-    "preweb": "node ./scripts/update-maze-import.js",
+    "preweb": "node ./scripts/update-maze-import.ts",
     "web": "expo start --web",
     "lint": "expo lint",
     "test": "jest"

--- a/scripts/update-maze-import.ts
+++ b/scripts/update-maze-import.ts
@@ -1,16 +1,18 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
-const rootDir = path.join(__dirname, '..');
-const mazesDir = path.join(rootDir, 'assets', 'mazes');
+// __dirname はこのファイルがあるディレクトリを指す特殊変数
+const rootDir: string = path.join(__dirname, '..');
+const mazesDir: string = path.join(rootDir, 'assets', 'mazes');
 
-// assets/mazes 内の JSON ファイルを検索
-const mazeFiles = fs
+// assets/mazes 内の JSON ファイル一覧を取得
+const mazeFiles: string[] = fs
   .readdirSync(mazesDir)
   .filter(
-    (name) => name.endsWith('.json') && fs.statSync(path.join(mazesDir, name)).isFile()
+    (name: string) =>
+      name.endsWith('.json') && fs.statSync(path.join(mazesDir, name)).isFile()
   );
 
 if (mazeFiles.length === 0) {
@@ -18,21 +20,21 @@ if (mazeFiles.length === 0) {
   process.exit(1);
 }
 
-// 迷路サイズごとに import を生成
-const importLines = [];
-const exportLines = [];
+// 迷路サイズごとの import / export 行を保存する配列
+const importLines: string[] = [];
+const exportLines: string[] = [];
 
-// サイズ順に並べ替え
+// ファイル名に含まれる数字順に並べ替え
 mazeFiles
   .slice()
-  .sort((a, b) => {
+  .sort((a: string, b: string) => {
     const aNum = parseInt(a.match(/(\d+)/)?.[1] ?? '0', 10);
     const bNum = parseInt(b.match(/(\d+)/)?.[1] ?? '0', 10);
     return aNum - bNum;
   })
-  .forEach((file) => {
+  .forEach((file: string) => {
     const basename = path.basename(file, '.json');
-    // ファイル名から数字を抽出してサイズに利用
+    // ファイル名から数字を取り出してサイズに利用
     const sizeMatch = basename.match(/(\d+)/);
     if (!sizeMatch) return; // サイズを特定できないファイルは無視
     const size = sizeMatch[1];
@@ -40,8 +42,8 @@ mazeFiles
     exportLines.push(`export const mazeSet${size} = maze${size};`);
   });
 
-const outputPath = path.join(rootDir, 'src', 'game', 'mazeAsset.ts');
-const content =
+const outputPath: string = path.join(rootDir, 'src', 'game', 'mazeAsset.ts');
+const content: string =
   `// 自動生成: assets/mazes 内の迷路をサイズ別にエクスポート\n` +
   `// ${new Date().toISOString()}\n` +
   importLines.join('\n') +
@@ -51,4 +53,3 @@ const content =
 
 fs.writeFileSync(outputPath, content);
 console.log(`mazeAsset.ts updated with ${mazeFiles.join(', ')}`);
-


### PR DESCRIPTION
## Summary
- rename `update-maze-import` script to TypeScript
- use ES module imports with TypeScript types
- update package.json to call the `.ts` script

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686602c62784832cb3bdf0001164e1e0