### PR TITLE
update maze import script to JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "prestart": "node ./scripts/update-maze-import.ts",
+    "prestart": "node ./scripts/update-maze-import.js",
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "preandroid": "node ./scripts/update-maze-import.ts",
+    "preandroid": "node ./scripts/update-maze-import.js",
     "android": "expo start --android",
-    "preios": "node ./scripts/update-maze-import.ts",
+    "preios": "node ./scripts/update-maze-import.js",
     "ios": "expo start --ios",
-    "preweb": "node ./scripts/update-maze-import.ts",
+    "preweb": "node ./scripts/update-maze-import.js",
     "web": "expo start --web",
     "lint": "expo lint",
     "test": "jest"

--- a/scripts/update-maze-import.js
+++ b/scripts/update-maze-import.js
@@ -1,17 +1,18 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
+// Node.js の標準モジュールを読み込む
+const fs = require('fs');
+const path = require('path');
 
 // __dirname はこのファイルがあるディレクトリを指す特殊変数
-const rootDir: string = path.join(__dirname, '..');
-const mazesDir: string = path.join(rootDir, 'assets', 'mazes');
+const rootDir = path.join(__dirname, '..');
+const mazesDir = path.join(rootDir, 'assets', 'mazes');
 
 // assets/mazes 内の JSON ファイル一覧を取得
-const mazeFiles: string[] = fs
+const mazeFiles = fs
   .readdirSync(mazesDir)
   .filter(
-    (name: string) =>
+    (name) =>
       name.endsWith('.json') && fs.statSync(path.join(mazesDir, name)).isFile()
   );
 
@@ -21,18 +22,18 @@ if (mazeFiles.length === 0) {
 }
 
 // 迷路サイズごとの import / export 行を保存する配列
-const importLines: string[] = [];
-const exportLines: string[] = [];
+const importLines = [];
+const exportLines = [];
 
 // ファイル名に含まれる数字順に並べ替え
 mazeFiles
   .slice()
-  .sort((a: string, b: string) => {
+  .sort((a, b) => {
     const aNum = parseInt(a.match(/(\d+)/)?.[1] ?? '0', 10);
     const bNum = parseInt(b.match(/(\d+)/)?.[1] ?? '0', 10);
     return aNum - bNum;
   })
-  .forEach((file: string) => {
+  .forEach((file) => {
     const basename = path.basename(file, '.json');
     // ファイル名から数字を取り出してサイズに利用
     const sizeMatch = basename.match(/(\d+)/);
@@ -42,8 +43,8 @@ mazeFiles
     exportLines.push(`export const mazeSet${size} = maze${size};`);
   });
 
-const outputPath: string = path.join(rootDir, 'src', 'game', 'mazeAsset.ts');
-const content: string =
+const outputPath = path.join(rootDir, 'src', 'game', 'mazeAsset.ts');
+const content =
   `// 自動生成: assets/mazes 内の迷路をサイズ別にエクスポート\n` +
   `// ${new Date().toISOString()}\n` +
   importLines.join('\n') +

--- a/src/game/mazeAsset.ts
+++ b/src/game/mazeAsset.ts
@@ -1,5 +1,5 @@
 // 自動生成: assets/mazes 内の迷路をサイズ別にエクスポート
-// 2025-07-01T05:27:38.777Z
+// 2025-07-03T05:56:33.055Z
 import maze5 from '@/assets/mazes/maze_5.json';
 import maze10 from '@/assets/mazes/maze_10.json';
 


### PR DESCRIPTION
## Summary
- rename `scripts/update-maze-import.ts` to `.js`
- remove TypeScript annotations and use CommonJS style
- update package.json scripts to use the new `.js` file
- regenerate `mazeAsset.ts`

## Testing
- `pnpm lint`
- `node scripts/update-maze-import.js`


------
https://chatgpt.com/codex/tasks/task_e_68661af99bb0832c841ee52d802d8cbf