### PR TITLE
Improve maze import script comments

### DIFF
--- a/scripts/update-maze-import.ts
+++ b/scripts/update-maze-import.ts
@@ -3,6 +3,12 @@
 import fs from 'fs';
 import path from 'path';
 
+// ---------- スクリプトの目的 ----------
+// assets/mazes フォルダにある迷路 JSON を調べて
+// src/game/mazeAsset.ts というファイルを作り直します。
+// 迷路を追加するたびに手で import を書く必要をなくすための自動生成です。
+// -------------------------------------
+
 // このスクリプトは assets/mazes フォルダ内の JSON を読み取り、
 // src/game/mazeAsset.ts に迷路データの import 文をまとめて自動生成します。
 // "自動生成" はプログラムが人の手を介さずファイルを作り直すことを意味します。
@@ -10,6 +16,8 @@ import path from 'path';
 // __dirname はこのファイルがあるディレクトリを指す特殊変数
 const rootDir: string = path.join(__dirname, '..');
 const mazesDir: string = path.join(rootDir, 'assets', 'mazes');
+
+// ↑ここまでで迷路フォルダのパスが決まりました
 
 // 迷路データのファイル一覧を取得する処理
 // fs.readdirSync はフォルダ内の名前をすぐに配列で返す「同期処理」です
@@ -22,10 +30,12 @@ const mazeFiles: string[] = fs
 
 // ↑ここまでで mazeFiles に JSON ファイル名だけが入りました
 
+// ファイルが無い場合はここでエラーを出して終了します
 if (mazeFiles.length === 0) {
   console.error('assets/mazes に JSON ファイルがありません');
   process.exit(1);
 }
+// ↑ここまでで空チェックが完了しました
 
 // ここから取得したファイル名を使って import と export の行を作ります
 // ファイル名に含まれる数字をサイズとして扱うため並び替えを行います
@@ -54,6 +64,7 @@ mazeFiles
 
 // ↑ここまでで importLines と exportLines の配列が完成しました
 
+// ここから mazeAsset.ts に書き込むテキストを作ります
 const outputPath: string = path.join(rootDir, 'src', 'game', 'mazeAsset.ts');
 const content: string =
   `// 自動生成: assets/mazes 内の迷路をサイズ別にエクスポート\n` +


### PR DESCRIPTION
## Summary
- add a clear explanation at the top of `scripts/update-maze-import.ts`
- insert additional comments around path setup and file handling steps

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6866e5b0b65c832c940a56aab7851b3d