### PR TITLE
Refactor play logic hooks

### DIFF
--- a/src/hooks/useMoveHandler.ts
+++ b/src/hooks/useMoveHandler.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react';
+import { useWindowDimensions } from 'react-native';
+import { useSharedValue } from 'react-native-reanimated';
+
+import { applyBumpFeedback, applyDistanceFeedback } from '@/src/game/feedback';
+import { nextPosition } from '@/src/game/maze';
+import type { Dir, MazeData } from '@/src/types/maze';
+import type { GameState } from '@/src/game/state';
+
+/**
+ * DPadでの移動を処理するフック。
+ * 壁への衝突時の振動や枠線エフェクトをまとめています。
+ */
+export function useMoveHandler(
+  state: GameState,
+  maze: MazeData,
+  move: (dir: Dir) => boolean,
+  playMoveSe: () => void,
+) {
+  // 幅積を計算して枠線表示範囲を決める
+  const { width } = useWindowDimensions();
+  // 枠線の色、大きさを管理
+  const [borderColor, setBorderColor] = useState('transparent');
+  const borderW = useSharedValue(0);
+  const maxBorder = width / 2;
+
+  // ボタン連打を防ぐためのロック
+  const [locked, setLocked] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  /**
+   * DPadの入力から移動処理を実行する
+   */
+  const handleMove = (dir: Dir) => {
+    if (locked) return;
+    setLocked(true);
+    const next = nextPosition(state.pos, dir);
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    let wait: number;
+    if (!move(dir)) {
+      wait = applyBumpFeedback(borderW, setBorderColor);
+      setTimeout(() => setBorderColor('transparent'), wait);
+    } else {
+      // 移動音を再生
+      playMoveSe();
+      const maxDist = (maze.size - 1) * 2;
+      const { wait: w, id } = applyDistanceFeedback(
+        next,
+        { x: maze.goal[0], y: maze.goal[1] },
+        { maxDist },
+      );
+      wait = w;
+      intervalRef.current = id;
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setLocked(false), wait + 10);
+  };
+
+  // コンポーネント解放時にタイマーを消去
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  return { borderColor, borderW, maxBorder, locked, handleMove } as const;
+}
+

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -1,53 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
-import { useWindowDimensions } from 'react-native';
-import { useRouter } from 'expo-router';
-import { useSharedValue } from 'react-native-reanimated';
-
 import { useGame } from '@/src/game/useGame';
-// フィードバックと座標計算のヘルパーは分割したモジュールから読み込む
-import { applyBumpFeedback, applyDistanceFeedback } from '@/src/game/feedback';
-import { nextPosition } from '@/src/game/maze';
-import { showInterstitial } from '@/src/ads/interstitial';
-import { useSnackbar } from '@/src/hooks/useSnackbar';
 import { useAudioControls } from '@/src/hooks/useAudioControls';
-import { useHighScore } from '@/src/hooks/useHighScore';
-import type { Dir } from '@/src/types/maze';
+import { useMoveHandler } from '@/src/hooks/useMoveHandler';
+import { useResultHandler } from '@/src/hooks/useResultHandler';
 
 /**
- * Play 画面で利用するロジックをまとめたカスタムフック
+ * Play画面のロジックを統合するフック。
+ * 各機能をサブフックに分割して実装する。
  */
 export function usePlayLogic() {
-  const router = useRouter();
   const { state, move, maze, nextStage, resetRun } = useGame();
-  const { width } = useWindowDimensions();
-  const { show: showSnackbar } = useSnackbar();
 
-  // ステージ総数。迷路は正方形なので size×size となる
-  const totalStages = maze.size * maze.size;
-
-  const [showResult, setShowResult] = useState(false);
-  const [gameOver, setGameOver] = useState(false);
-  const [stageClear, setStageClear] = useState(false);
-  const [gameClear, setGameClear] = useState(false);
-  const {
-    highScore,
-    newRecord,
-    setNewRecord,
-    updateScore,
-  } = useHighScore(state.levelId);
-  const [showMenu, setShowMenu] = useState(false);
-  const [debugAll, setDebugAll] = useState(false);
-
-  // 枠線色は壁衝突時のみ赤に変更する
-  const [borderColor, setBorderColor] = useState('transparent');
-  const borderW = useSharedValue(0);
-  const maxBorder = width / 2;
-
-  const [locked, setLocked] = useState(false);
-  // OK ボタン連打を防ぐためのフラグ
-  const [okLocked, setOkLocked] = useState(false);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  // サウンドの操作管理
   const {
     bgmVolume,
     seVolume,
@@ -61,155 +24,34 @@ export function usePlayLogic() {
     audioReady,
   } = useAudioControls(require('../../assets/sounds/歩く音200ms_2.mp3'));
 
+  // 移動に関する処理
+  const {
+    borderColor,
+    borderW,
+    maxBorder,
+    locked,
+    handleMove,
+  } = useMoveHandler(state, maze, move, playMoveSe);
 
-  // ハイスコアの読み込みは useHighScore 内で行う
+  // 結果表示やメニュー操作
+  const {
+    highScore,
+    newRecord,
+    showResult,
+    gameOver,
+    gameClear,
+    showMenu,
+    setShowMenu,
+    debugAll,
+    setDebugAll,
+    okLocked,
+    handleOk,
+    handleReset,
+    handleExit,
+  } = useResultHandler(state, maze, nextStage, resetRun, pauseBgm, resumeBgm);
 
-  // ゴール到達や敵に捕まった際の処理をまとめる
-  useEffect(() => {
-    const willChangeMap = state.stage % maze.size === 0;
-    if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
-      setStageClear(true);
-      setGameOver(false);
-      setGameClear(state.finalStage);
-      setShowResult(true);
-      setDebugAll(willChangeMap);
-      if (state.levelId) {
-        const current = {
-          stage: state.stage,
-          steps: state.steps,
-          bumps: state.bumps,
-        };
-        updateScore(current, state.finalStage);
-      } else {
-        setNewRecord(false);
-      }
-    } else if (state.caught) {
-      setGameOver(true);
-      setStageClear(false);
-      setShowResult(true);
-      setDebugAll(true);
-      if (state.levelId) {
-        const current = {
-          stage: state.stage - 1,
-          steps: state.steps,
-          bumps: state.bumps,
-        };
-        updateScore(current, false);
-      } else {
-        setNewRecord(false);
-      }
-    }
-  }, [
-    state.pos,
-    state.caught,
-    maze.goal,
-    state.finalStage,
-    state.stage,
-    maze.size,
-    state.steps,
-    state.bumps,
-    state.levelId,
-    updateScore,
-    setNewRecord,
-  ]);
-
-  // コンポーネントが破棄される際にタイマーを解除
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, []);
-
-  /**
-   * リザルトモーダルで OK を押した際の処理
-   */
-  const handleOk = async () => {
-    // ボタン連打で複数回処理が走らないようロック
-    if (okLocked) return;
-    setOkLocked(true);
-    if (gameOver) {
-      resetRun();
-    } else if (gameClear) {
-      resetRun();
-      router.replace('/');
-    } else if (stageClear) {
-      // デバッグ用: ステージ1クリア時もインタースティシャル広告を表示する
-      if (state.stage % 9 === 0 || state.stage === 1) {
-        try {
-          pauseBgm();
-          await showInterstitial();
-        } catch (e) {
-          console.error('interstitial error', e);
-          showSnackbar('広告を表示できませんでした');
-        } finally {
-          resumeBgm();
-        }
-      }
-      nextStage();
-    }
-    setShowResult(false);
-    setGameOver(false);
-    setDebugAll(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-    setOkLocked(false);
-  };
-
-  /** Reset Maze が選ばれたときの処理 */
-  const handleReset = () => {
-    setShowMenu(false);
-    setGameOver(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-    resetRun();
-  };
-
-  /** タイトルへ戻る処理 */
-  const handleExit = () => {
-    setShowMenu(false);
-    setGameOver(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-    resetRun();
-    router.replace('/');
-  };
-
-
-  /** DPad からの入力処理 */
-  const handleMove = (dir: Dir) => {
-    if (locked) return;
-    setLocked(true);
-    const next = nextPosition(state.pos, dir);
-
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-
-    let wait: number;
-    if (!move(dir)) {
-      wait = applyBumpFeedback(borderW, setBorderColor);
-      setTimeout(() => setBorderColor('transparent'), wait);
-    } else {
-      // 移動音を再生し、効果音再生フラグも更新
-      playMoveSe();
-      const maxDist = (maze.size - 1) * 2;
-      const { wait: w, id } = applyDistanceFeedback(
-        next,
-        { x: maze.goal[0], y: maze.goal[1] },
-        { maxDist },
-      );
-      wait = w;
-      intervalRef.current = id;
-    }
-
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setLocked(false), wait + 10);
-  };
+  // 全ステージ数。迷路は正方形なので size の二乗
+  const totalStages = maze.size * maze.size;
 
   return {
     state,
@@ -242,3 +84,4 @@ export function usePlayLogic() {
     handleExit,
   } as const;
 }
+

--- a/src/hooks/useResultHandler.ts
+++ b/src/hooks/useResultHandler.ts
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'expo-router';
+
+import { showInterstitial } from '@/src/ads/interstitial';
+import { useSnackbar } from '@/src/hooks/useSnackbar';
+import { useHighScore } from '@/src/hooks/useHighScore';
+import type { GameState } from '@/src/game/state';
+import type { MazeData } from '@/src/types/maze';
+
+/**
+ * ゴールに到達したときや敵に捕まったときなど、
+ * 結果表示に関する状態を管理するフック。
+ */
+export function useResultHandler(
+  state: GameState,
+  maze: MazeData,
+  nextStage: () => void,
+  resetRun: () => void,
+  pauseBgm: () => void,
+  resumeBgm: () => void,
+) {
+  const router = useRouter();
+  const { show: showSnackbar } = useSnackbar();
+  const { highScore, newRecord, setNewRecord, updateScore } = useHighScore(
+    state.levelId,
+  );
+
+  const [showResult, setShowResult] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [stageClear, setStageClear] = useState(false);
+  const [gameClear, setGameClear] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+  const [debugAll, setDebugAll] = useState(false);
+  const [okLocked, setOkLocked] = useState(false);
+
+  // ゴール到達と敵捕捉の判定
+  useEffect(() => {
+    const willChangeMap = state.stage % maze.size === 0;
+    if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
+      setStageClear(true);
+      setGameOver(false);
+      setGameClear(state.finalStage);
+      setShowResult(true);
+      setDebugAll(willChangeMap);
+      if (state.levelId) {
+        const current = {
+          stage: state.stage,
+          steps: state.steps,
+          bumps: state.bumps,
+        };
+        updateScore(current, state.finalStage);
+      } else {
+        setNewRecord(false);
+      }
+    } else if (state.caught) {
+      setGameOver(true);
+      setStageClear(false);
+      setShowResult(true);
+      setDebugAll(true);
+      if (state.levelId) {
+        const current = {
+          stage: state.stage - 1,
+          steps: state.steps,
+          bumps: state.bumps,
+        };
+        updateScore(current, false);
+      } else {
+        setNewRecord(false);
+      }
+    }
+  }, [
+    state.pos,
+    state.caught,
+    maze.goal,
+    state.finalStage,
+    state.stage,
+    maze.size,
+    state.steps,
+    state.bumps,
+    state.levelId,
+    updateScore,
+    setNewRecord,
+  ]);
+
+  /**
+   * 結果モーダルで OK を押した時の処理
+   */
+  const handleOk = async () => {
+    if (okLocked) return;
+    setOkLocked(true);
+    if (gameOver) {
+      resetRun();
+    } else if (gameClear) {
+      resetRun();
+      router.replace('/');
+    } else if (stageClear) {
+      if (state.stage % 9 === 0 || state.stage === 1) {
+        try {
+          pauseBgm();
+          await showInterstitial();
+        } catch (e) {
+          console.error('interstitial error', e);
+          showSnackbar('広告を表示できませんでした');
+        } finally {
+          resumeBgm();
+        }
+      }
+      nextStage();
+    }
+    setShowResult(false);
+    setGameOver(false);
+    setDebugAll(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+    setOkLocked(false);
+  };
+
+  /** Reset Maze が選ばれたときの処理 */
+  const handleReset = () => {
+    setShowMenu(false);
+    setGameOver(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+    resetRun();
+  };
+
+  /** タイトルへ戻る処理 */
+  const handleExit = () => {
+    setShowMenu(false);
+    setGameOver(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+    resetRun();
+    router.replace('/');
+  };
+
+  return {
+    highScore,
+    newRecord,
+    showResult,
+    gameOver,
+    gameClear,
+    showMenu,
+    setShowMenu,
+    debugAll,
+    setDebugAll,
+    okLocked,
+    handleOk,
+    handleReset,
+    handleExit,
+  } as const;
+}
+


### PR DESCRIPTION
## Summary
- split movement logic into `useMoveHandler`
- extract result management to `useResultHandler`
- simplify `usePlayLogic` to compose sub hooks

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6866e5ab5cdc832cad47e5deef9a8d76