### PR TITLE
refactor: usePlayLogic をフック分割

### DIFF
--- a/src/hooks/useMoveHandler.ts
+++ b/src/hooks/useMoveHandler.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
+
+import { applyBumpFeedback, applyDistanceFeedback } from '@/src/game/feedback';
+import { nextPosition } from '@/src/game/maze';
+import type { Dir, MazeData, Vec2 } from '@/src/types/maze';
+
+interface Options {
+  statePos: Vec2;
+  maze: MazeData;
+  move: (dir: Dir) => boolean;
+  playMoveSe: () => void;
+  width: number;
+}
+
+/**
+ * DPad 入力時の移動処理や演出を担当するフック
+ */
+export function useMoveHandler({
+  statePos,
+  maze,
+  move,
+  playMoveSe,
+  width,
+}: Options) {
+  // 壁衝突時に表示する枠線の色
+  const [borderColor, setBorderColor] = useState('transparent');
+  // 枠線の幅を Reanimated で制御
+  const borderW = useSharedValue(0);
+  const maxBorder = width / 2;
+
+  const [locked, setLocked] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // コンポーネント破棄時はタイマーを解除
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  /** DPad からの入力処理 */
+  const handleMove = (dir: Dir) => {
+    if (locked) return;
+    setLocked(true);
+    const next = nextPosition(statePos, dir);
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    let wait: number;
+    if (!move(dir)) {
+      wait = applyBumpFeedback(borderW, setBorderColor);
+      setTimeout(() => setBorderColor('transparent'), wait);
+    } else {
+      playMoveSe();
+      const maxDist = (maze.size - 1) * 2;
+      const { wait: w, id } = applyDistanceFeedback(
+        next,
+        { x: maze.goal[0], y: maze.goal[1] },
+        { maxDist },
+      );
+      wait = w;
+      intervalRef.current = id;
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setLocked(false), wait + 10);
+  };
+
+  return { borderColor, borderW, maxBorder, locked, handleMove } as const;
+}

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -1,20 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useSharedValue } from 'react-native-reanimated';
 
 import { useGame } from '@/src/game/useGame';
-// フィードバックと座標計算のヘルパーは分割したモジュールから読み込む
-import { applyBumpFeedback, applyDistanceFeedback } from '@/src/game/feedback';
-import { nextPosition } from '@/src/game/maze';
-import { showInterstitial } from '@/src/ads/interstitial';
 import { useSnackbar } from '@/src/hooks/useSnackbar';
 import { useAudioControls } from '@/src/hooks/useAudioControls';
-import { useHighScore } from '@/src/hooks/useHighScore';
-import type { Dir } from '@/src/types/maze';
+import { useResultActions } from '@/src/hooks/useResultActions';
+import { useMoveHandler } from '@/src/hooks/useMoveHandler';
 
 /**
- * Play 画面で利用するロジックをまとめたカスタムフック
+ * Play 画面全体のロジックをまとめるフック
+ * それぞれの機能は専用フックに分割して読み込む
  */
 export function usePlayLogic() {
   const router = useRouter();
@@ -22,230 +17,45 @@ export function usePlayLogic() {
   const { width } = useWindowDimensions();
   const { show: showSnackbar } = useSnackbar();
 
+  // BGM・SE 操作は専用フックに委譲
+  const audio = useAudioControls(require('../../assets/sounds/歩く音200ms_2.mp3'));
+
+  // リザルト表示やメニュー操作の管理
+  const result = useResultActions({
+    state,
+    maze,
+    nextStage,
+    resetRun,
+    router,
+    showSnackbar,
+    pauseBgm: audio.pauseBgm,
+    resumeBgm: audio.resumeBgm,
+  });
+
+  // DPad 移動に関する演出・ロック制御
+  const moveCtrl = useMoveHandler({
+    statePos: state.pos,
+    maze,
+    move,
+    playMoveSe: audio.playMoveSe,
+    width,
+  });
+
   // ステージ総数。迷路は正方形なので size×size となる
   const totalStages = maze.size * maze.size;
-
-  const [showResult, setShowResult] = useState(false);
-  const [gameOver, setGameOver] = useState(false);
-  const [stageClear, setStageClear] = useState(false);
-  const [gameClear, setGameClear] = useState(false);
-  const {
-    highScore,
-    newRecord,
-    setNewRecord,
-    updateScore,
-  } = useHighScore(state.levelId);
-  const [showMenu, setShowMenu] = useState(false);
-  const [debugAll, setDebugAll] = useState(false);
-
-  // 枠線色は壁衝突時のみ赤に変更する
-  const [borderColor, setBorderColor] = useState('transparent');
-  const borderW = useSharedValue(0);
-  const maxBorder = width / 2;
-
-  const [locked, setLocked] = useState(false);
-  // OK ボタン連打を防ぐためのフラグ
-  const [okLocked, setOkLocked] = useState(false);
-  // 状態更新より早く現在のロック状態を参照するため useRef でも保持する
-  // useRef は値が変わっても再描画されないことがポイント
-  const okLockedRef = useRef<boolean>(false);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const {
-    bgmVolume,
-    seVolume,
-    incBgm,
-    decBgm,
-    incSe,
-    decSe,
-    playMoveSe,
-    pauseBgm,
-    resumeBgm,
-    audioReady,
-  } = useAudioControls(require('../../assets/sounds/歩く音200ms_2.mp3'));
-
-
-  // ハイスコアの読み込みは useHighScore 内で行う
-
-  // ゴール到達や敵に捕まった際の処理をまとめる
-  useEffect(() => {
-    const willChangeMap = state.stage % maze.size === 0;
-    if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
-      setStageClear(true);
-      setGameOver(false);
-      setGameClear(state.finalStage);
-      setShowResult(true);
-      setDebugAll(willChangeMap);
-      if (state.levelId) {
-        const current = {
-          stage: state.stage,
-          steps: state.steps,
-          bumps: state.bumps,
-        };
-        updateScore(current, state.finalStage);
-      } else {
-        setNewRecord(false);
-      }
-    } else if (state.caught) {
-      setGameOver(true);
-      setStageClear(false);
-      setShowResult(true);
-      setDebugAll(true);
-      if (state.levelId) {
-        const current = {
-          stage: state.stage - 1,
-          steps: state.steps,
-          bumps: state.bumps,
-        };
-        updateScore(current, false);
-      } else {
-        setNewRecord(false);
-      }
-    }
-  }, [
-    state.pos,
-    state.caught,
-    maze.goal,
-    state.finalStage,
-    state.stage,
-    maze.size,
-    state.steps,
-    state.bumps,
-    state.levelId,
-    updateScore,
-    setNewRecord,
-  ]);
-
-  // コンポーネントが破棄される際にタイマーを解除
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, []);
-
-  /**
-   * リザルトモーダルで OK を押した際の処理
-   */
-  const handleOk = async () => {
-    // ボタン連打で複数回処理が走らないようロック
-    // okLockedRef.current で即座に状態を確認できる
-    if (okLockedRef.current) return;
-    okLockedRef.current = true;
-    setOkLocked(true);
-    if (gameOver) {
-      resetRun();
-    } else if (gameClear) {
-      resetRun();
-      router.replace('/');
-    } else if (stageClear) {
-      // デバッグ用: ステージ1クリア時もインタースティシャル広告を表示する
-      if (state.stage % 9 === 0 || state.stage === 1) {
-        try {
-          pauseBgm();
-          await showInterstitial();
-        } catch (e) {
-          console.error('interstitial error', e);
-          showSnackbar('広告を表示できませんでした');
-        } finally {
-          resumeBgm();
-        }
-      }
-      nextStage();
-    }
-    setShowResult(false);
-    setGameOver(false);
-    setDebugAll(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-    // 処理が完了したらロック解除
-    okLockedRef.current = false;
-    setOkLocked(false);
-  };
-
-  /** Reset Maze が選ばれたときの処理 */
-  const handleReset = () => {
-    setShowMenu(false);
-    setGameOver(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-    resetRun();
-  };
-
-  /** タイトルへ戻る処理 */
-  const handleExit = () => {
-    setShowMenu(false);
-    setGameOver(false);
-    setStageClear(false);
-    setGameClear(false);
-    setNewRecord(false);
-    resetRun();
-    router.replace('/');
-  };
-
-
-  /** DPad からの入力処理 */
-  const handleMove = (dir: Dir) => {
-    if (locked) return;
-    setLocked(true);
-    const next = nextPosition(state.pos, dir);
-
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-
-    let wait: number;
-    if (!move(dir)) {
-      wait = applyBumpFeedback(borderW, setBorderColor);
-      setTimeout(() => setBorderColor('transparent'), wait);
-    } else {
-      // 移動音を再生し、効果音再生フラグも更新
-      playMoveSe();
-      const maxDist = (maze.size - 1) * 2;
-      const { wait: w, id } = applyDistanceFeedback(
-        next,
-        { x: maze.goal[0], y: maze.goal[1] },
-        { maxDist },
-      );
-      wait = w;
-      intervalRef.current = id;
-    }
-
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setLocked(false), wait + 10);
-  };
 
   return {
     state,
     maze,
     totalStages,
-    showResult,
-    gameOver,
-    gameClear,
-    highScore,
-    newRecord,
-    showMenu,
-    setShowMenu,
-    debugAll,
-    setDebugAll,
-    bgmVolume,
-    seVolume,
-    incBgm,
-    decBgm,
-    incSe,
-    decSe,
-    audioReady,
-    borderColor,
-    borderW,
-    maxBorder,
-    locked,
-    okLocked,
-    handleMove,
-    handleOk,
-    handleReset,
-    handleExit,
+    ...result,
+    bgmVolume: audio.bgmVolume,
+    seVolume: audio.seVolume,
+    incBgm: audio.incBgm,
+    decBgm: audio.decBgm,
+    incSe: audio.incSe,
+    decSe: audio.decSe,
+    audioReady: audio.audioReady,
+    ...moveCtrl,
   } as const;
 }

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'react';
+import type { useRouter } from 'expo-router';
+
+import { showInterstitial } from '@/src/ads/interstitial';
+import { useHighScore } from '@/src/hooks/useHighScore';
+import type { GameState } from '@/src/game/state';
+import type { MazeData } from '@/src/types/maze';
+
+interface Options {
+  state: GameState;
+  maze: MazeData;
+  nextStage: () => void;
+  resetRun: () => void;
+  router: ReturnType<typeof useRouter>;
+  showSnackbar: (msg: string) => void;
+  pauseBgm: () => void;
+  resumeBgm: () => void;
+}
+
+/**
+ * リザルト表示やメニュー関連の状態を扱うフック
+ */
+export function useResultActions({
+  state,
+  maze,
+  nextStage,
+  resetRun,
+  router,
+  showSnackbar,
+  pauseBgm,
+  resumeBgm,
+}: Options) {
+  const {
+    highScore,
+    newRecord,
+    setNewRecord,
+    updateScore,
+  } = useHighScore(state.levelId);
+
+  const [showResult, setShowResult] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [stageClear, setStageClear] = useState(false);
+  const [gameClear, setGameClear] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+  const [debugAll, setDebugAll] = useState(false);
+
+  const [okLocked, setOkLocked] = useState(false);
+  const okLockedRef = useRef(false);
+
+  // ゴール到達や捕まったときの処理をまとめる
+  useEffect(() => {
+    const willChangeMap = state.stage % maze.size === 0;
+    if (state.pos.x === maze.goal[0] && state.pos.y === maze.goal[1]) {
+      setStageClear(true);
+      setGameOver(false);
+      setGameClear(state.finalStage);
+      setShowResult(true);
+      setDebugAll(willChangeMap);
+      if (state.levelId) {
+        const current = {
+          stage: state.stage,
+          steps: state.steps,
+          bumps: state.bumps,
+        };
+        updateScore(current, state.finalStage);
+      } else {
+        setNewRecord(false);
+      }
+    } else if (state.caught) {
+      setGameOver(true);
+      setStageClear(false);
+      setShowResult(true);
+      setDebugAll(true);
+      if (state.levelId) {
+        const current = {
+          stage: state.stage - 1,
+          steps: state.steps,
+          bumps: state.bumps,
+        };
+        updateScore(current, false);
+      } else {
+        setNewRecord(false);
+      }
+    }
+  }, [
+    state.pos,
+    state.caught,
+    maze.goal,
+    state.finalStage,
+    state.stage,
+    maze.size,
+    state.steps,
+    state.bumps,
+    state.levelId,
+    updateScore,
+    setNewRecord,
+  ]);
+
+  // OK ボタン押下時の処理
+  const handleOk = async () => {
+    if (okLockedRef.current) return;
+    okLockedRef.current = true;
+    setOkLocked(true);
+    if (gameOver) {
+      resetRun();
+    } else if (gameClear) {
+      resetRun();
+      router.replace('/');
+    } else if (stageClear) {
+      if (state.stage % 9 === 0 || state.stage === 1) {
+        try {
+          pauseBgm();
+          await showInterstitial();
+        } catch (e) {
+          console.error('interstitial error', e);
+          showSnackbar('広告を表示できませんでした');
+        } finally {
+          resumeBgm();
+        }
+      }
+      nextStage();
+    }
+    setShowResult(false);
+    setGameOver(false);
+    setDebugAll(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+    okLockedRef.current = false;
+    setOkLocked(false);
+  };
+
+  // リセット処理
+  const handleReset = () => {
+    setShowMenu(false);
+    setGameOver(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+    resetRun();
+  };
+
+  // タイトルへ戻る処理
+  const handleExit = () => {
+    setShowMenu(false);
+    setGameOver(false);
+    setStageClear(false);
+    setGameClear(false);
+    setNewRecord(false);
+    resetRun();
+    router.replace('/');
+  };
+
+  return {
+    showResult,
+    gameOver,
+    stageClear,
+    gameClear,
+    highScore,
+    newRecord,
+    showMenu,
+    setShowMenu,
+    debugAll,
+    setDebugAll,
+    okLocked,
+    handleOk,
+    handleReset,
+    handleExit,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- `usePlayLogic` を小さなフックに整理
- 移動処理を `useMoveHandler` へ、結果処理を `useResultActions` へ分離
- 各フックに日本語コメントを追加

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6866e7298410832cb52c82f87d396ea3