### PR TITLE
Add resume feature

### DIFF
--- a/src/game/saveGame.ts
+++ b/src/game/saveGame.ts
@@ -1,0 +1,121 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { prepMaze } from './state/core';
+import type { State } from './state';
+import { LEVELS } from '@/constants/levels';
+
+// 保存に使用するキー
+const STORAGE_KEY = 'suspendData';
+
+// JSON 化して保存するための型
+export interface StoredState {
+  mazeRaw: State['mazeRaw'];
+  pos: State['pos'];
+  steps: number;
+  bumps: number;
+  path: State['path'];
+  hitV: [string, number][];
+  hitH: [string, number][];
+  enemies: State['enemies'];
+  enemyVisited: [string, number][][];
+  enemyPaths: State['enemyPaths'];
+  caught: boolean;
+  stage: number;
+  visitedGoals: string[];
+  finalStage: boolean;
+  enemyBehavior: State['enemyBehavior'];
+  enemyCounts: State['enemyCounts'];
+  enemyPathLength: number;
+  playerPathLength: number;
+  wallLifetime: number;
+  biasedSpawn: boolean;
+  levelId?: string;
+}
+
+// State から保存用データへ変換
+export function encodeState(state: State): StoredState {
+  return {
+    mazeRaw: state.mazeRaw,
+    pos: state.pos,
+    steps: state.steps,
+    bumps: state.bumps,
+    path: state.path,
+    hitV: Array.from(state.hitV.entries()),
+    hitH: Array.from(state.hitH.entries()),
+    enemies: state.enemies,
+    enemyVisited: state.enemyVisited.map((m) => Array.from(m.entries())),
+    enemyPaths: state.enemyPaths,
+    caught: state.caught,
+    stage: state.stage,
+    visitedGoals: Array.from(state.visitedGoals.values()),
+    finalStage: state.finalStage,
+    enemyBehavior: state.enemyBehavior,
+    enemyCounts: state.enemyCounts,
+    enemyPathLength: state.enemyPathLength,
+    playerPathLength: state.playerPathLength,
+    wallLifetime: state.wallLifetime,
+    biasedSpawn: state.biasedSpawn,
+    levelId: state.levelId,
+  };
+}
+
+// 保存データから State を復元する
+export function decodeState(data: StoredState): State {
+  const level = LEVELS.find((l) => l.id === data.levelId);
+  return {
+    mazeRaw: data.mazeRaw,
+    maze: prepMaze(data.mazeRaw),
+    pos: data.pos,
+    steps: data.steps,
+    bumps: data.bumps,
+    path: data.path,
+    hitV: new Map(data.hitV),
+    hitH: new Map(data.hitH),
+    enemies: data.enemies,
+    enemyVisited: data.enemyVisited.map((arr) => new Map(arr)),
+    enemyPaths: data.enemyPaths,
+    caught: data.caught,
+    stage: data.stage,
+    visitedGoals: new Set(data.visitedGoals),
+    finalStage: data.finalStage,
+    enemyBehavior: data.enemyBehavior,
+    enemyCounts: data.enemyCounts,
+    enemyCountsFn: level?.enemyCountsFn,
+    enemyPathLength: data.enemyPathLength,
+    playerPathLength: data.playerPathLength,
+    wallLifetime: data.wallLifetime,
+    wallLifetimeFn: level?.wallLifetimeFn,
+    biasedSpawn: data.biasedSpawn,
+    levelId: data.levelId,
+  };
+}
+
+// データを保存する
+export async function saveGame(state: State) {
+  try {
+    const data = encodeState(state);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // 失敗時は無視
+  }
+}
+
+// 保存データを読み込む
+export async function loadGame(): Promise<State | null> {
+  try {
+    const json = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!json) return null;
+    const data = JSON.parse(json) as StoredState;
+    return decodeState(data);
+  } catch {
+    return null;
+  }
+}
+
+// 保存データを削除する
+export async function clearGame() {
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // 失敗しても無視
+  }
+}

--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -8,6 +8,7 @@ import { createFirstStage, nextStageState, restartRun } from './stage';
 export type Action =
   | { type: 'reset' }
   | { type: 'move'; dir: Dir }
+  | { type: 'load'; state: State }
   | {
       type: 'newMaze';
       maze: MazeData;
@@ -61,6 +62,8 @@ export function reducer(state: State, action: Action): State {
     case 'move': {
       return handleMoveAction(state, action.dir);
     }
+    case 'load':
+      return action.state;
   }
 }
 

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -1,6 +1,7 @@
-import { createContext, useContext, useReducer, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useReducer, type ReactNode } from 'react';
 import { canMove } from './maze';
 import { loadMaze } from './loadMaze';
+import { saveGame } from './saveGame';
 import type { MazeData, Dir } from '@/src/types/maze';
 import type { EnemyCounts } from '@/src/types/enemy';
 import {
@@ -8,6 +9,7 @@ import {
   createFirstStage,
   type GameState,
   type Action,
+  type State,
 } from './state';
 
 const GameContext = createContext<
@@ -28,6 +30,7 @@ const GameContext = createContext<
       ) => void;
       nextStage: () => void;
       resetRun: () => void;
+      loadState: (s: State) => void;
       maze: MazeData;
     }
   | undefined
@@ -71,10 +74,16 @@ export function GameProvider({ children }: { children: ReactNode }) {
     });
   const nextStage = () => send({ type: 'nextStage' });
   const resetRun = () => send({ type: 'resetRun' });
+  const loadState = (s: State) => send({ type: 'load', state: s });
+
+  // 状態が変化するたび自動保存する
+  useEffect(() => {
+    saveGame(state);
+  }, [state]);
 
   return (
     <GameContext.Provider
-      value={{ state, move, reset, newGame, maze: state.mazeRaw, nextStage, resetRun }}
+      value={{ state, move, reset, newGame, maze: state.mazeRaw, nextStage, resetRun, loadState }}
     >
       {children}
     </GameContext.Provider>

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -47,6 +47,11 @@ const messages = {
     japanese: '日本語',
     english: 'English',
     backToTitle: 'タイトルへ戻る',
+    continue: 'つづきから',
+    startFromBegin: '{{name}}をはじめからプレイ',
+    confirmReset: '中断中のゲームデータを削除して新しいゲームを開始しますか？',
+    yes: 'はい',
+    cancel: 'キャンセル',
   },
   en: {
     practiceMode: 'Practice Mode',
@@ -87,6 +92,11 @@ const messages = {
     japanese: 'Japanese',
     english: 'English',
     backToTitle: 'Back to title',
+    continue: 'Continue',
+    startFromBegin: 'Play {{name}} from start',
+    confirmReset: 'Delete saved game and start new?',
+    yes: 'Yes',
+    cancel: 'Cancel',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- add game saving/restoring helper
- auto-save every turn
- allow resuming from title screen
- confirm before starting new game if save exists
- update locale messages for new feature

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6866ece4ac08832cb1c6ea3a892ba1db