### PR TITLE
Refactor PlayScreen layout

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,8 +1,6 @@
-import { View, Pressable, StyleSheet, useWindowDimensions, Platform } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import Animated, { useAnimatedStyle, useAnimatedProps, useDerivedValue } from "react-native-reanimated";
-import { LinearGradient } from "expo-linear-gradient";
+import { View, Pressable, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 import { DPad } from "@/components/DPad";
 import { MiniMap } from "@/src/components/MiniMap";
@@ -10,14 +8,9 @@ import type { MazeData as MazeView } from "@/src/types/maze";
 import { useLocale } from "@/src/locale/LocaleContext";
 import { usePlayLogic } from "@/src/hooks/usePlayLogic";
 import { PlayMenu } from "@/components/PlayMenu";
-import { ResultModal } from "@/components/ResultModal";
-
-// LinearGradient を Reanimated 用にラップ
-// Web 環境では setAttribute エラーを避けるためアニメーション無し
-const AnimatedLG =
-  Platform.OS === "web"
-    ? LinearGradient
-    : Animated.createAnimatedComponent(LinearGradient);
+import { ResultModal } from '@/components/ResultModal';
+import { EdgeOverlay } from '@/components/EdgeOverlay';
+import { playStyles } from '@/app/styles/playStyles';
 
 export default function PlayScreen() {
   const { t } = useLocale();
@@ -53,16 +46,6 @@ export default function PlayScreen() {
     handleExit,
   } = usePlayLogic();
 
-  const vertStyle = useAnimatedStyle(() => ({ height: borderW.value }));
-  const horizStyle = useAnimatedStyle(() => ({ width: borderW.value }));
-  const gradColors: [string, string, string] = [borderColor, borderColor, 'transparent'];
-  const gradStops = useDerivedValue<[number, number, number]>(() => {
-    const ratio = Math.min(borderW.value / maxBorder, 1);
-    const loc = 0.2 + ratio * 0.5;
-    return [0, loc, 1];
-  });
-  const gradProps = useAnimatedProps(() => ({ locations: gradStops.value }));
-  const gradLocs = Platform.OS === 'web' ? [0, 0.2, 1] : undefined;
 
   const dpadTop = height * (2 / 3);
   // ミニマップは ResultModal と重ならないよう少し上に配置する
@@ -73,59 +56,20 @@ export default function PlayScreen() {
   const resultTop = mapTop + 310;
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <View style={[playStyles.container, { paddingTop: insets.top }]}>
       {/* 左上のホームボタン。家アイコンを表示しタイトルへ戻る */}
       <Pressable
-        style={[styles.homeBtn, { top: insets.top + 10 }]}
+        style={[playStyles.homeBtn, { top: insets.top + 10 }]}
         onPress={handleExit}
         accessibilityLabel="ホーム画面へ戻る"
       >
         <MaterialIcons name="home" size={24} color="#555" />
       </Pressable>
-      {/* 枠線用のオーバーレイ。グラデーションで中央へ行くほど色が薄くなる */}
-      <AnimatedLG
-        pointerEvents="none"
-        colors={gradColors}
-        {...(Platform.OS === "web"
-          ? { locations: gradLocs }
-          : { animatedProps: gradProps })}
-        start={{ x: 0.5, y: 0 }}
-        end={{ x: 0.5, y: 1 }}
-        style={[styles.edge, styles.topEdge, vertStyle]}
-      />
-      <AnimatedLG
-        pointerEvents="none"
-        colors={gradColors}
-        {...(Platform.OS === "web"
-          ? { locations: gradLocs }
-          : { animatedProps: gradProps })}
-        start={{ x: 0.5, y: 1 }}
-        end={{ x: 0.5, y: 0 }}
-        style={[styles.edge, styles.bottomEdge, vertStyle]}
-      />
-      <AnimatedLG
-        pointerEvents="none"
-        colors={gradColors}
-        {...(Platform.OS === "web"
-          ? { locations: gradLocs }
-          : { animatedProps: gradProps })}
-        start={{ x: 0, y: 0.5 }}
-        end={{ x: 1, y: 0.5 }}
-        style={[styles.edge, styles.leftEdge, horizStyle]}
-      />
-      <AnimatedLG
-        pointerEvents="none"
-        colors={gradColors}
-        {...(Platform.OS === "web"
-          ? { locations: gradLocs }
-          : { animatedProps: gradProps })}
-        start={{ x: 1, y: 0.5 }}
-        end={{ x: 0, y: 0.5 }}
-        style={[styles.edge, styles.rightEdge, horizStyle]}
-      />
+      {/* 枠線用のオーバーレイ。処理は EdgeOverlay にまとめた */}
+      <EdgeOverlay borderColor={borderColor} borderW={borderW} maxBorder={maxBorder} />
       {/* 右上のリセットアイコン。迷路を初期状態に戻す */}
       <Pressable
-        style={[styles.resetBtn, { top: insets.top + 10 }]}
+        style={[playStyles.resetBtn, { top: insets.top + 10 }]}
         onPress={handleReset}
         accessibilityLabel="迷路をリセット"
       >
@@ -133,14 +77,14 @@ export default function PlayScreen() {
       </Pressable>
       {/* 右上のメニューアイコン */}
       <Pressable
-        style={[styles.menuBtn, { top: insets.top + 10 }]}
+        style={[playStyles.menuBtn, { top: insets.top + 10 }]}
         onPress={() => setShowMenu(true)}
         accessibilityLabel="メニューを開く"
       >
         {/* 背景が黒のためアイコンを濃いグレーにして視認性を確保 */}
         <MaterialIcons name="more-vert" size={24} color="#555" />
       </Pressable>
-      <View style={[styles.miniMapWrapper, { top: mapTop }]}>
+      <View style={[playStyles.miniMapWrapper, { top: mapTop }]}>
         <MiniMap
           maze={maze as MazeView}
           path={state.path}
@@ -158,7 +102,7 @@ export default function PlayScreen() {
           size={300}
         />
       </View>
-      <View style={[styles.dpadWrapper, { top: dpadTop }]}>
+      <View style={[playStyles.dpadWrapper, { top: dpadTop }]}>
         <DPad onPress={handleMove} disabled={locked} />
       </View>
       <PlayMenu
@@ -203,67 +147,3 @@ export default function PlayScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "black",
-  },
-  menuBtn: {
-    position: "absolute",
-    top: 10,
-    right: 10,
-    padding: 4,
-  },
-  // ホームボタン用スタイル。左上に固定表示
-  homeBtn: {
-    position: "absolute",
-    top: 10,
-    left: 10,
-    padding: 4,
-  },
-  // 迷路リセットボタン。メニューボタンの左隣に配置
-  resetBtn: {
-    position: "absolute",
-    top: 10,
-    right: 44,
-    padding: 4,
-  },
-  // ミニマップを画面上 1/3 より40px上の位置に中央揃えで配置
-  miniMapWrapper: {
-    position: "absolute",
-    left: 0,
-    right: 0,
-    alignItems: "center",
-  },
-  // DPad を画面下 1/3 の位置に中央揃えで配置
-  dpadWrapper: {
-    position: "absolute",
-    left: 0,
-    right: 0,
-    alignItems: "center",
-  },
-  // 枠線 (グラデーション) の各辺共通スタイル
-  edge: {
-    position: "absolute",
-  },
-  topEdge: {
-    top: 0,
-    left: 0,
-    right: 0,
-  },
-  bottomEdge: {
-    bottom: 0,
-    left: 0,
-    right: 0,
-  },
-  leftEdge: {
-    left: 0,
-    top: 0,
-    bottom: 0,
-  },
-  rightEdge: {
-    right: 0,
-    top: 0,
-    bottom: 0,
-  },
-});

--- a/app/styles/playStyles.ts
+++ b/app/styles/playStyles.ts
@@ -1,0 +1,68 @@
+import { StyleSheet } from 'react-native';
+
+// PlayScreen 専用スタイルをまとめたファイル
+// StyleSheet.create で生成したオブジェクトをそのまま export する
+export const playStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'black',
+  },
+  menuBtn: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    padding: 4,
+  },
+  // ホームボタン用スタイル。左上に固定表示
+  homeBtn: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    padding: 4,
+  },
+  // 迷路リセットボタン。メニューボタンの左隣に配置
+  resetBtn: {
+    position: 'absolute',
+    top: 10,
+    right: 44,
+    padding: 4,
+  },
+  // ミニマップを画面上 1/3 より40px上の位置に中央揃えで配置
+  miniMapWrapper: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  // DPad を画面下 1/3 の位置に中央揃えで配置
+  dpadWrapper: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  // 枠線 (グラデーション) の各辺共通スタイル
+  edge: {
+    position: 'absolute',
+  },
+  topEdge: {
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  bottomEdge: {
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+  leftEdge: {
+    left: 0,
+    top: 0,
+    bottom: 0,
+  },
+  rightEdge: {
+    right: 0,
+    top: 0,
+    bottom: 0,
+  },
+});

--- a/components/EdgeOverlay.tsx
+++ b/components/EdgeOverlay.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Platform } from 'react-native';
+import Animated, {
+  useAnimatedProps,
+  useAnimatedStyle,
+  useDerivedValue,
+  type SharedValue,
+} from 'react-native-reanimated';
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { playStyles } from '@/app/styles/playStyles';
+
+// LinearGradient を Reanimated 用にラップする
+const AnimatedLG =
+  Platform.OS === 'web'
+    ? LinearGradient
+    : Animated.createAnimatedComponent(LinearGradient);
+
+interface EdgeOverlayProps {
+  /** 枠線の色 */
+  borderColor: string;
+  /** アニメーションさせる枠線の幅 */
+  borderW: SharedValue<number>;
+  /** 最大幅 (アニメーション停止位置) */
+  maxBorder: number;
+}
+
+/**
+ * 画面四辺に表示するグラデーション枠線コンポーネント
+ */
+export function EdgeOverlay({ borderColor, borderW, maxBorder }: EdgeOverlayProps) {
+  // 縦方向エッジの高さ、横方向エッジの幅をそれぞれアニメーションさせる
+  const vertStyle = useAnimatedStyle(() => ({ height: borderW.value }));
+  const horizStyle = useAnimatedStyle(() => ({ width: borderW.value }));
+
+  // 枠線の色配列。中央に向かうほど透明に近づける
+  const gradColors: [string, string, string] = [borderColor, borderColor, 'transparent'];
+  const gradStops = useDerivedValue<[number, number, number]>(() => {
+    const ratio = Math.min(borderW.value / maxBorder, 1);
+    const loc = 0.2 + ratio * 0.5;
+    return [0, loc, 1];
+  });
+  const gradProps = useAnimatedProps(() => ({ locations: gradStops.value }));
+  const gradLocs = Platform.OS === 'web' ? [0, 0.2, 1] : undefined;
+
+  return (
+    <>
+      <AnimatedLG
+        pointerEvents="none"
+        colors={gradColors}
+        {...(Platform.OS === 'web'
+          ? { locations: gradLocs }
+          : { animatedProps: gradProps })}
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.5, y: 1 }}
+        style={[playStyles.edge, playStyles.topEdge, vertStyle]}
+      />
+      <AnimatedLG
+        pointerEvents="none"
+        colors={gradColors}
+        {...(Platform.OS === 'web'
+          ? { locations: gradLocs }
+          : { animatedProps: gradProps })}
+        start={{ x: 0.5, y: 1 }}
+        end={{ x: 0.5, y: 0 }}
+        style={[playStyles.edge, playStyles.bottomEdge, vertStyle]}
+      />
+      <AnimatedLG
+        pointerEvents="none"
+        colors={gradColors}
+        {...(Platform.OS === 'web'
+          ? { locations: gradLocs }
+          : { animatedProps: gradProps })}
+        start={{ x: 0, y: 0.5 }}
+        end={{ x: 1, y: 0.5 }}
+        style={[playStyles.edge, playStyles.leftEdge, horizStyle]}
+      />
+      <AnimatedLG
+        pointerEvents="none"
+        colors={gradColors}
+        {...(Platform.OS === 'web'
+          ? { locations: gradLocs }
+          : { animatedProps: gradProps })}
+        start={{ x: 1, y: 0.5 }}
+        end={{ x: 0, y: 0.5 }}
+        style={[playStyles.edge, playStyles.rightEdge, horizStyle]}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- move PlayScreen styles to `app/styles/playStyles.ts`
- add `EdgeOverlay` component for gradient borders
- simplify `play.tsx` to focus on game logic

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6866f01e16f4832c8e0ded1923202039