### PR TITLE
Implement useStageEffects and result state refactor

### DIFF
--- a/src/hooks/useResultState.ts
+++ b/src/hooks/useResultState.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+/**
+ * リザルト表示に関する状態だけを管理するフック。
+ * 表示の ON/OFF やフラグをまとめて扱います。
+ */
+export function useResultState() {
+  const [showResult, setShowResult] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [stageClear, setStageClear] = useState(false);
+  const [gameClear, setGameClear] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+  const [debugAll, setDebugAll] = useState(false);
+  const [okLocked, setOkLocked] = useState(false);
+
+  return {
+    showResult,
+    setShowResult,
+    gameOver,
+    setGameOver,
+    stageClear,
+    setStageClear,
+    gameClear,
+    setGameClear,
+    showMenu,
+    setShowMenu,
+    debugAll,
+    setDebugAll,
+    okLocked,
+    setOkLocked,
+  } as const;
+}

--- a/src/hooks/useStageEffects.ts
+++ b/src/hooks/useStageEffects.ts
@@ -1,0 +1,33 @@
+import { showInterstitial } from '@/src/ads/interstitial';
+
+interface Options {
+  pauseBgm: () => void;
+  resumeBgm: () => void;
+  showSnackbar: (msg: string) => void;
+}
+
+/**
+ * ステージ間で行う広告表示や BGM 停止をまとめたフック。
+ * 副作用が多くなる処理を切り出して使いやすくします。
+ */
+export function useStageEffects({ pauseBgm, resumeBgm, showSnackbar }: Options) {
+  /**
+   * ステージ番号に応じて広告を表示する
+   * 9 の倍数または 1 ステージ目で実行
+   */
+  const showAdIfNeeded = async (stage: number) => {
+    if (stage % 9 === 0 || stage === 1) {
+      try {
+        pauseBgm();
+        await showInterstitial();
+      } catch (e) {
+        console.error('interstitial error', e);
+        showSnackbar('広告を表示できませんでした');
+      } finally {
+        resumeBgm();
+      }
+    }
+  };
+
+  return { showAdIfNeeded } as const;
+}


### PR DESCRIPTION
## Summary
- 抽象化した `useStageEffects` で広告表示と BGM 制御を担当
- `useResultState` を追加してリザルト表示用の状態を整理
- `useResultActions` は上記フックを利用するよう更新

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f04c4d60832c88f147ed508575fd