### PR TITLE
Fix result reset timing

### DIFF
--- a/src/game/__tests__/resultActions.test.ts
+++ b/src/game/__tests__/resultActions.test.ts
@@ -1,0 +1,95 @@
+/* eslint-disable import/first */
+
+// React の機能は簡易モックで置き換え
+jest.mock('react', () => ({
+  useEffect: jest.fn(),
+  useRef: (init: any) => ({ current: init }),
+}));
+
+// 状態管理フックをモック
+let showResult = true;
+let stageClear = true;
+const setShowResult = jest.fn((v: boolean) => {
+  showResult = v;
+});
+const setStageClear = jest.fn((v: boolean) => {
+  stageClear = v;
+});
+const setGameOver = jest.fn();
+const setGameClear = jest.fn();
+const setDebugAll = jest.fn();
+const setNewRecord = jest.fn();
+const setOkLocked = jest.fn();
+const setShowMenu = jest.fn();
+
+jest.mock('@/src/hooks/useResultState', () => ({
+  useResultState: () => ({
+    showResult,
+    setShowResult,
+    gameOver: false,
+    setGameOver,
+    stageClear,
+    setStageClear,
+    gameClear: false,
+    setGameClear,
+    showMenu: false,
+    setShowMenu,
+    debugAll: false,
+    setDebugAll,
+    okLocked: false,
+    setOkLocked,
+  }),
+}));
+
+jest.mock('@/src/hooks/useHighScore', () => ({
+  useHighScore: () => ({
+    highScore: null,
+    newRecord: false,
+    setNewRecord,
+    updateScore: jest.fn(),
+  }),
+}));
+
+const showAdIfNeeded = jest.fn(async () => {
+  // 広告表示時点でリザルト関連フラグが全て false になっているか確認
+  expect(showResult).toBe(false);
+  expect(stageClear).toBe(false);
+});
+
+jest.mock('@/src/hooks/useStageEffects', () => ({
+  useStageEffects: () => ({ showAdIfNeeded }),
+}));
+
+import { useResultActions } from '@/src/hooks/useResultActions';
+
+describe('handleOk の広告表示後処理', () => {
+  beforeEach(() => {
+    showResult = true;
+    stageClear = true;
+    jest.clearAllMocks();
+  });
+
+  test('広告閉鎖後に次ステージでリザルトが自動表示されない', async () => {
+    const nextStage = jest.fn();
+    const resetRun = jest.fn();
+    const router = { replace: jest.fn() };
+
+    const actions = useResultActions({
+      state: { stage: 2 } as any,
+      maze: { size: 10 } as any,
+      nextStage,
+      resetRun,
+      router,
+      showSnackbar: jest.fn(),
+      pauseBgm: jest.fn(),
+      resumeBgm: jest.fn(),
+    });
+
+    await actions.handleOk();
+
+    expect(showAdIfNeeded).toHaveBeenCalledWith(2);
+    expect(nextStage).toHaveBeenCalled();
+    expect(showResult).toBe(false);
+    expect(stageClear).toBe(false);
+  });
+});

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -121,21 +121,29 @@ export function useResultActions({
     if (okLockedRef.current) return;
     okLockedRef.current = true;
     setOkLocked(true);
+
+    const currentStage = state.stage;
+
     if (gameOver) {
       resetRun();
     } else if (gameClear) {
       resetRun();
       router.replace('/');
-    } else if (stageClear) {
-      await showAdIfNeeded(state.stage);
-      nextStage();
     }
+
+    // リザルト関連のフラグを先にリセットしておく
     setShowResult(false);
     setGameOver(false);
     setDebugAll(false);
     setStageClear(false);
     setGameClear(false);
     setNewRecord(false);
+
+    if (stageClear) {
+      await showAdIfNeeded(currentStage);
+      nextStage();
+    }
+
     okLockedRef.current = false;
     setOkLocked(false);
   };


### PR DESCRIPTION
## Summary
- ensure handleOk clears result state before awaiting ads
- test that ads don't trigger immediate result on next stage

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698622f130832caf871f7cc01d609e