### PR TITLE
fix: ensure result flags reset

### DIFF
--- a/src/game/__tests__/resultActions.test.ts
+++ b/src/game/__tests__/resultActions.test.ts
@@ -92,4 +92,33 @@ describe('handleOk の広告表示後処理', () => {
     expect(showResult).toBe(false);
     expect(stageClear).toBe(false);
   });
+
+  test('広告なしでもリザルト非表示を維持', async () => {
+    const nextStage = jest.fn();
+    const resetRun = jest.fn();
+    const router = { replace: jest.fn() };
+
+    // ステージクリアでない状態を想定
+    stageClear = false;
+
+    const actions = useResultActions({
+      state: { stage: 1 } as any,
+      maze: { size: 10 } as any,
+      nextStage,
+      resetRun,
+      router,
+      showSnackbar: jest.fn(),
+      pauseBgm: jest.fn(),
+      resumeBgm: jest.fn(),
+    });
+
+    await actions.handleOk();
+
+    // 広告やステージ遷移は呼ばれない
+    expect(showAdIfNeeded).not.toHaveBeenCalled();
+    expect(nextStage).not.toHaveBeenCalled();
+
+    // リザルト関連フラグは false のまま
+    expect(showResult).toBe(false);
+  });
 });

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -139,6 +139,9 @@ export function useResultActions({
     setGameClear(false);
     setNewRecord(false);
 
+    // 上記ステート更新が反映されるのを待つための空await
+    await Promise.resolve();
+
     if (stageClear) {
       await showAdIfNeeded(currentStage);
       nextStage();


### PR DESCRIPTION
## Summary
- wait before proceeding after resetting result flags
- test to confirm result is kept hidden after handleOk

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c82569f0832c9d0a6fb666c82bc0