### PR TITLE
Add console logs for debugging stage skip

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -124,6 +124,15 @@ export function useResultActions({
 
     const currentStage = state.stage;
 
+    // 現在の状態をログに出すことでデバッグしやすくする
+    console.log('handleOk start', {
+      stage: state.stage,
+      gameOver,
+      gameClear,
+      stageClear,
+      showResult,
+    });
+
     if (gameOver) {
       resetRun();
     } else if (gameClear) {
@@ -139,10 +148,16 @@ export function useResultActions({
     setGameClear(false);
     setNewRecord(false);
 
-    // 上記ステート更新が反映されるのを待つための空await
+    // ステート更新後の値を確認するための空await
     await Promise.resolve();
 
+    console.log('after reset', {
+      stageClear,
+      showResult,
+    });
+
     if (stageClear) {
+      console.log('showAdIfNeeded called with', currentStage);
       await showAdIfNeeded(currentStage);
       nextStage();
     }

--- a/src/hooks/useStageEffects.ts
+++ b/src/hooks/useStageEffects.ts
@@ -16,6 +16,8 @@ export function useStageEffects({ pauseBgm, resumeBgm, showSnackbar }: Options) 
    * 9 の倍数または 1 ステージ目で実行
    */
   const showAdIfNeeded = async (stage: number) => {
+    // 広告表示の条件と実行ステージをログに残す
+    console.log('showAdIfNeeded check', { stage });
     if (stage % 9 === 0 || stage === 1) {
       try {
         pauseBgm();


### PR DESCRIPTION
## Summary
- add debug logs in `useResultActions` to trace OK button flow
- log ad display checks in `useStageEffects`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6869ca5f7c48832c847e59cd20086279