### PR TITLE
Fix stage clear flag reset

### DIFF
--- a/src/game/__tests__/resultActions.test.ts
+++ b/src/game/__tests__/resultActions.test.ts
@@ -121,4 +121,39 @@ describe('handleOk の広告表示後処理', () => {
     // リザルト関連フラグは false のまま
     expect(showResult).toBe(false);
   });
+
+  test('ステート更新が非同期でもフラグが正しくリセットされる', async () => {
+    const nextStage = jest.fn();
+    const resetRun = jest.fn();
+    const router = { replace: jest.fn() };
+
+    // 非同期で値が書き換わるようにモックする
+    setShowResult.mockImplementation(async (v: boolean) => {
+      await Promise.resolve();
+      showResult = v;
+    });
+    setStageClear.mockImplementation(async (v: boolean) => {
+      await Promise.resolve();
+      stageClear = v;
+    });
+
+    const actions = useResultActions({
+      state: { stage: 2 } as any,
+      maze: { size: 10 } as any,
+      nextStage,
+      resetRun,
+      router,
+      showSnackbar: jest.fn(),
+      pauseBgm: jest.fn(),
+      resumeBgm: jest.fn(),
+    });
+
+    await actions.handleOk();
+    await Promise.resolve();
+
+    expect(showAdIfNeeded).toHaveBeenCalledWith(2);
+    expect(nextStage).toHaveBeenCalled();
+    expect(showResult).toBe(false);
+    expect(stageClear).toBe(false);
+  });
 });

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -123,6 +123,10 @@ export function useResultActions({
     setOkLocked(true);
 
     const currentStage = state.stage;
+    // stageClear の値は setState で非同期に変化する可能性があるため
+    // 先に変数へ退避しておく
+    // フラグ(flag)とは処理分岐のための真偽値のこと
+    const wasStageClear = stageClear;
 
     // 現在の状態をログに出すことでデバッグしやすくする
     console.log('handleOk start', {
@@ -156,7 +160,8 @@ export function useResultActions({
       showResult,
     });
 
-    if (stageClear) {
+    // wasStageClear の値を使って広告表示や次ステージ遷移を判断する
+    if (wasStageClear) {
       console.log('showAdIfNeeded called with', currentStage);
       await showAdIfNeeded(currentStage);
       nextStage();


### PR DESCRIPTION
## Summary
- keep stageClear value in handleOk before resetting state
- use stored flag when showing ads and moving to next stage
- test async state updates in resultActions

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869cf0c9c2c832cab462e0377f28bcf