### PR TITLE
ログ出力の拡充

### DIFF
--- a/src/ads/interstitial.ts
+++ b/src/ads/interstitial.ts
@@ -25,6 +25,7 @@ export async function showInterstitial() {
 
     // 広告イベントを監視し、読み込み完了で表示、閉じるかエラーで終了
     const unsubscribe = ad.addAdEventsListener(({ type }) => {
+      console.log('Interstitial event', type);
       if (type === AdEventType.LOADED) {
         ad.show();
       }

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -164,7 +164,11 @@ export function useResultActions({
     if (wasStageClear) {
       console.log('showAdIfNeeded called with', currentStage);
       await showAdIfNeeded(currentStage);
+      console.log('showAdIfNeeded finished', { stage: state.stage });
       nextStage();
+      // nextStage はステージ番号を 1 増やす
+      await Promise.resolve();
+      console.log('after nextStage', { stage: state.stage });
     }
 
     okLockedRef.current = false;

--- a/src/hooks/useStageEffects.ts
+++ b/src/hooks/useStageEffects.ts
@@ -16,12 +16,15 @@ export function useStageEffects({ pauseBgm, resumeBgm, showSnackbar }: Options) 
    * 9 の倍数または 1 ステージ目で実行
    */
   const showAdIfNeeded = async (stage: number) => {
-    // 広告表示の条件と実行ステージをログに残す
-    console.log('showAdIfNeeded check', { stage });
-    if (stage % 9 === 0 || stage === 1) {
+    // 実行条件となるステージかどうか計算しておく
+    const shouldShow = stage % 9 === 0 || stage === 1;
+    console.log('showAdIfNeeded check', { stage, shouldShow });
+    if (shouldShow) {
       try {
+        console.log('interstitial start');
         pauseBgm();
         await showInterstitial();
+        console.log('interstitial end');
       } catch (e) {
         console.error('interstitial error', e);
         showSnackbar('広告を表示できませんでした');


### PR DESCRIPTION
## Summary
- インタースティシャル広告関連のログを追加
- ステージ遷移処理後の状態を確認できるようログを強化

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6869d09b3b10832cb685ff6169983ca0