### PR TITLE
広告後のリザルト挙動を修正

### DIFF
--- a/src/hooks/useResultState.ts
+++ b/src/hooks/useResultState.ts
@@ -12,6 +12,8 @@ export function useResultState() {
   const [showMenu, setShowMenu] = useState(false);
   const [debugAll, setDebugAll] = useState(false);
   const [okLocked, setOkLocked] = useState(false);
+  // 各ステージで広告を一度だけ表示したかを記録するフラグ
+  const [adShown, setAdShown] = useState(false);
 
   return {
     showResult,
@@ -28,5 +30,7 @@ export function useResultState() {
     setDebugAll,
     okLocked,
     setOkLocked,
+    adShown,
+    setAdShown,
   } as const;
 }


### PR DESCRIPTION
## Summary
- useResultState に `adShown` を追加し、広告表示済みかを管理
- handleOk を改修し、広告後は同じリザルトを再表示して次ステージへ進まないよう変更
- リセット・終了時に `adShown` を初期化
- テストを仕様変更に合わせ更新

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d69a59fc832c8a095f6bc37701dd