### PR TITLE
Fix OK lock after ad

### DIFF
--- a/src/hooks/useHighScore.ts
+++ b/src/hooks/useHighScore.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import {
   loadHighScore,
   saveHighScore,
@@ -34,7 +34,7 @@ export function useHighScore(levelId: string | null | undefined) {
    * 現在のスコアを渡して、より良い記録なら保存する。
    * `finalStage` が true の場合のみ新記録表示を行う。
    */
-  const updateScore = async (score: HighScore, finalStage: boolean) => {
+  const updateScore = useCallback(async (score: HighScore, finalStage: boolean) => {
     if (!levelId) return;
     const old = await loadHighScore(levelId);
     const better = isBetterScore(old, score);
@@ -45,7 +45,7 @@ export function useHighScore(levelId: string | null | undefined) {
       setHighScore(old);
     }
     setNewRecord(better && finalStage);
-  };
+  }, [levelId]);
 
   return { highScore, newRecord, setNewRecord, updateScore } as const;
 }

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -67,18 +67,21 @@ export function useResultActions({
   });
   const okLockedRef = useRef(false);
 
-  // 広告表示後にリザルト画面が再表示された際、
-  // OKボタンが押せないままになることを防ぐためのロック解除処理
+  // リザルト画面が表示されている間に OK ボタンが押せなくなる
+  // (ロックされたままになる) 状態を避けるための処理
   useEffect(() => {
-    // showResult が true で広告表示済みかつボタンがロックされている場合
-    if (showResult && adShown && okLocked) {
-      const id = setTimeout(() => {
+    // showResult が true かつボタンがロックされているときのみ解除タイマーを設定
+    if (showResult && okLocked) {
+      // setTimeout で少し待ってからロックを解除する
+      // number 型の ID が返るため型を明示している
+      const id: ReturnType<typeof setTimeout> = setTimeout(() => {
         okLockedRef.current = false;
         setOkLocked(false);
       }, OK_UNLOCK_DELAY);
+      // showResult が変化した場合はタイマーをクリア
       return () => clearTimeout(id);
     }
-  }, [showResult, adShown, okLocked, setOkLocked]);
+  }, [showResult, okLocked, setOkLocked]);
 
   // ゴール到達や捕まったときの処理をまとめる
   useEffect(() => {


### PR DESCRIPTION
## Summary
- stabilize `updateScore` by useCallback to prevent infinite updates

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869dd001d74832cb48d16f256fd3371