### PR TITLE
fix result screen re-display when no ad

### DIFF
--- a/src/game/__tests__/resultActions.test.ts
+++ b/src/game/__tests__/resultActions.test.ts
@@ -60,6 +60,8 @@ const showAdIfNeeded = jest.fn(async () => {
   // 広告表示時点でリザルト関連フラグが全て false になっているか確認
   expect(showResult).toBe(false);
   expect(stageClear).toBe(true);
+  // テストでは広告が表示された想定で true を返す
+  return true;
 });
 
 jest.mock('@/src/hooks/useStageEffects', () => ({
@@ -122,6 +124,34 @@ describe('handleOk の広告表示後処理', () => {
     await actions.handleOk();
 
     expect(showAdIfNeeded).not.toHaveBeenCalled();
+    expect(nextStage).toHaveBeenCalled();
+    expect(showResult).toBe(false);
+    expect(stageClear).toBe(false);
+  });
+
+  test('広告条件外ならリザルトを再表示しない', async () => {
+    const nextStage = jest.fn();
+    const resetRun = jest.fn();
+    const router = { replace: jest.fn() };
+
+    // このテストでは広告を表示しない想定で false を返す
+    showAdIfNeeded.mockResolvedValueOnce(false);
+
+    const actions = useResultActions({
+      state: { stage: 3 } as any,
+      maze: { size: 10 } as any,
+      nextStage,
+      resetRun,
+      router,
+      showSnackbar: jest.fn(),
+      pauseBgm: jest.fn(),
+      resumeBgm: jest.fn(),
+    });
+
+    await actions.handleOk();
+
+    expect(showAdIfNeeded).toHaveBeenCalledWith(3);
+    // 広告が無いのでそのまま次ステージへ
     expect(nextStage).toHaveBeenCalled();
     expect(showResult).toBe(false);
     expect(stageClear).toBe(false);

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -168,17 +168,21 @@ export function useResultActions({
       router.replace('/');
     }
 
-    // ステージクリア直後で広告未表示なら広告を出してリザルトを再表示
+    // ステージクリア直後で広告未表示なら広告を検討
     if (wasStageClear && !adShown) {
       setShowResult(false);
       setAdShown(true);
-      await showAdIfNeeded(currentStage);
-      setShowResult(true);
-      setTimeout(() => {
-        okLockedRef.current = false;
-        setOkLocked(false);
-      }, OK_UNLOCK_DELAY);
-      return;
+      const didShow = await showAdIfNeeded(currentStage);
+      if (didShow) {
+        // 広告を表示した場合はリザルトを再表示
+        setShowResult(true);
+        setTimeout(() => {
+          okLockedRef.current = false;
+          setOkLocked(false);
+        }, OK_UNLOCK_DELAY);
+        return;
+      }
+      // 広告を表示しなかった場合はこのまま次の処理へ
     }
 
     // リザルト関連のフラグをリセット

--- a/src/hooks/useStageEffects.ts
+++ b/src/hooks/useStageEffects.ts
@@ -15,7 +15,7 @@ export function useStageEffects({ pauseBgm, resumeBgm, showSnackbar }: Options) 
    * ステージ番号に応じて広告を表示する
    * 9 の倍数または 1 ステージ目で実行
    */
-  const showAdIfNeeded = async (stage: number) => {
+  const showAdIfNeeded = async (stage: number): Promise<boolean> => {
     // 実行条件となるステージかどうか計算しておく
     const shouldShow = stage % 9 === 0 || stage === 1;
     console.log('showAdIfNeeded check', { stage, shouldShow });
@@ -31,7 +31,9 @@ export function useStageEffects({ pauseBgm, resumeBgm, showSnackbar }: Options) 
       } finally {
         resumeBgm();
       }
+      return true;
     }
+    return false;
   };
 
   return { showAdIfNeeded } as const;


### PR DESCRIPTION
## Summary
- adjust useStageEffects to return whether an ad was shown
- rework handleOk so results aren't shown again when no ad displays
- update tests for new showAdIfNeeded behavior and add coverage

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869e760d57c832cbe54ddd89460e7bc