### PR TITLE
Add enemy respawn feature

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -43,6 +43,7 @@ export default function PlayScreen() {
     okLocked,
     handleMove,
     handleOk,
+    handleRespawn,
     handleReset,
     handleExit,
   } = usePlayLogic();
@@ -55,6 +56,9 @@ export default function PlayScreen() {
   // ResultModal はミニマップ下端より 10px 下に表示する
   // MiniMap のサイズは 300px のため、mapTop + 310 が位置となる
   const resultTop = mapTop + 310;
+  // リセットボタンの色。使用回数に応じて白から黒へ変化させる
+  const gray = Math.round((state.respawnStock / 3) * 255);
+  const resetColor = `rgb(${gray},${gray},${gray})`;
 
   return (
     <View style={[playStyles.container, { paddingTop: insets.top }]}>
@@ -68,13 +72,13 @@ export default function PlayScreen() {
       </Pressable>
       {/* 枠線用のオーバーレイ。処理は EdgeOverlay にまとめた */}
       <EdgeOverlay borderColor={borderColor} borderW={borderW} maxBorder={maxBorder} />
-      {/* 右上のリセットアイコン。迷路を初期状態に戻す */}
+      {/* 右上のリセットアイコン。敵だけを再配置する */}
       <Pressable
         style={[playStyles.resetBtn, { top: insets.top + 10 }]}
-        onPress={handleReset}
-        accessibilityLabel="迷路をリセット"
+        onPress={handleRespawn}
+        accessibilityLabel="敵をリスポーン"
       >
-        <MaterialIcons name="refresh" size={24} color={UI.colors.icon} />
+        <MaterialIcons name="refresh" size={24} color={resetColor} />
       </Pressable>
       {/* 右上のメニューアイコン */}
       <Pressable

--- a/src/game/ai/spawn.ts
+++ b/src/game/ai/spawn.ts
@@ -11,21 +11,22 @@ export function spawnEnemies(
   rnd: () => number = Math.random,
   exclude: Set<string> = new Set(),
   biased: boolean = true,
+  // どこから遠ざけるかの基準位置。未指定ならスタート地点
+  origin: Vec2 = { x: maze.start[0], y: maze.start[1] },
 ): Vec2[] {
   const enemies: Vec2[] = [];
-  const start = { x: maze.start[0], y: maze.start[1] };
   const goal = { x: maze.goal[0], y: maze.goal[1] };
   const candidates = allCells(maze.size).filter((c) => {
     const key = `${c.x},${c.y}`;
     if (exclude.has(key)) return false;
-    if (c.x === start.x && c.y === start.y) return false;
+    if (c.x === origin.x && c.y === origin.y) return false;
     if (c.x === goal.x && c.y === goal.y) return false;
     return true;
   });
 
   while (enemies.length < count && candidates.length > 0) {
     const cell = biased
-      ? biasedPickGoal(start, candidates, rnd)
+      ? biasedPickGoal(origin, candidates, rnd)
       : candidates[Math.floor(rnd() * candidates.length)];
     const key = `${cell.x},${cell.y}`;
     enemies.push(cell);

--- a/src/game/saveGame.ts
+++ b/src/game/saveGame.ts
@@ -29,6 +29,7 @@ export interface StoredState {
   wallLifetime: number | null;
   biasedSpawn: boolean;
   levelId?: string;
+  respawnStock: number;
 }
 
 // State から保存用データへ変換
@@ -55,6 +56,7 @@ export function encodeState(state: State): StoredState {
     wallLifetime: state.wallLifetime,
     biasedSpawn: state.biasedSpawn,
     levelId: state.levelId,
+    respawnStock: state.respawnStock,
   };
 }
 
@@ -92,6 +94,7 @@ export function decodeState(data: StoredState): State {
     wallLifetimeFn: level?.wallLifetimeFn,
     biasedSpawn: data.biasedSpawn,
     levelId: data.levelId,
+    respawnStock: data.respawnStock,
   };
 }
 

--- a/src/game/state/core.ts
+++ b/src/game/state/core.ts
@@ -58,6 +58,8 @@ export interface GameState {
   biasedSpawn: boolean;
   /** 現在のレベル識別子。練習モードは undefined */
   levelId?: string;
+  /** 敵をリスポーンできる残り回数 */
+  respawnStock: number;
 }
 
 // Provider が保持する全体の状態
@@ -82,6 +84,7 @@ export function initState(
   wallLifetimeFn?: (stage: number) => number,
   biasedSpawn: boolean = true,
   levelId?: string,
+  respawnStock: number = 3,
 ): State {
   const maze = prepMaze(m);
   const enemies = createEnemies(enemyCounts, maze, biasedSpawn);
@@ -114,5 +117,6 @@ export function initState(
     wallLifetimeFn,
     biasedSpawn,
     levelId,
+    respawnStock,
   };
 }

--- a/src/game/state/enemy.ts
+++ b/src/game/state/enemy.ts
@@ -7,10 +7,11 @@ export function createEnemies(
   counts: EnemyCounts,
   maze: MazeData,
   biasedSpawn: boolean,
+  biasFrom?: { x: number; y: number },
 ): Enemy[] {
   const enemies: Enemy[] = [];
   const exclude = new Set<string>();
-  spawnEnemies(counts.random, maze, Math.random, exclude, biasedSpawn).forEach(
+  spawnEnemies(counts.random, maze, Math.random, exclude, biasedSpawn, biasFrom).forEach(
     (p) => {
       enemies.push({
         pos: p,
@@ -25,7 +26,7 @@ export function createEnemies(
       });
     },
   );
-  spawnEnemies(counts.slow, maze, Math.random, exclude, biasedSpawn).forEach((p) => {
+  spawnEnemies(counts.slow, maze, Math.random, exclude, biasedSpawn, biasFrom).forEach((p) => {
     enemies.push({
       pos: p,
       visible: true,
@@ -38,7 +39,7 @@ export function createEnemies(
       kind: 'slow',
     });
   });
-  spawnEnemies(counts.sight, maze, Math.random, exclude, biasedSpawn).forEach((p) => {
+  spawnEnemies(counts.sight, maze, Math.random, exclude, biasedSpawn, biasFrom).forEach((p) => {
     enemies.push({
       pos: p,
       visible: true,
@@ -50,7 +51,7 @@ export function createEnemies(
       kind: 'sight',
     });
   });
-  spawnEnemies(counts.fast ?? 0, maze, Math.random, exclude, biasedSpawn).forEach((p) => {
+  spawnEnemies(counts.fast ?? 0, maze, Math.random, exclude, biasedSpawn, biasFrom).forEach((p) => {
     enemies.push({
       pos: p,
       visible: true,

--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -3,6 +3,7 @@ import type { Dir, MazeData } from '@/src/types/maze';
 import type { EnemyCounts } from '@/src/types/enemy';
 import { initState, State } from './core';
 import { createFirstStage, nextStageState, restartRun } from './stage';
+import { createEnemies } from './enemy';
 
 // Reducer で使うアクション型
 export type Action =
@@ -22,7 +23,8 @@ export type Action =
       levelId?: string;
     }
   | { type: 'nextStage' }
-  | { type: 'resetRun' };
+  | { type: 'resetRun' }
+  | { type: 'respawnEnemies'; playerPos: { x: number; y: number } };
 
 export function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -59,6 +61,21 @@ export function reducer(state: State, action: Action): State {
       return nextStageState(state);
     case 'resetRun':
       return restartRun(state);
+    case 'respawnEnemies': {
+      const enemies = createEnemies(
+        state.enemyCounts,
+        state.mazeRaw,
+        state.biasedSpawn,
+        action.playerPos,
+      );
+      return {
+        ...state,
+        enemies,
+        enemyVisited: enemies.map((e) => new Map([[`${e.pos.x},${e.pos.y}`, 1]])),
+        enemyPaths: enemies.map((e) => [{ ...e.pos }]),
+        respawnStock: state.respawnStock - 1,
+      };
+    }
     case 'move': {
       return handleMoveAction(state, action.dir);
     }

--- a/src/game/state/stage.ts
+++ b/src/game/state/stage.ts
@@ -50,6 +50,7 @@ export function createFirstStage(
     wallLifetimeFn,
     biasedSpawn,
     levelId,
+    3,
   );
 }
 
@@ -79,6 +80,7 @@ export function nextStageState(state: State): State {
   const hitV = changeMap ? new Map<string, number>() : new Map(state.hitV);
   const hitH = changeMap ? new Map<string, number>() : new Map(state.hitH);
   const nextWallLife = state.wallLifetimeFn?.(state.stage + 1) ?? state.wallLifetime;
+  const stock = Math.min(state.respawnStock + 1, 3);
   return initState(
     maze,
     state.stage + 1,
@@ -94,6 +96,7 @@ export function nextStageState(state: State): State {
     state.wallLifetimeFn,
     state.biasedSpawn,
     state.levelId,
+    stock,
   );
 }
 

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -30,6 +30,7 @@ const GameContext = createContext<
       ) => void;
       nextStage: () => void;
       resetRun: () => void;
+      respawnEnemies: () => void;
       loadState: (s: State) => void;
       maze: MazeData;
     }
@@ -76,6 +77,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     });
   const nextStage = () => send({ type: 'nextStage' });
   const resetRun = () => send({ type: 'resetRun' });
+  const respawnEnemies = () => send({ type: 'respawnEnemies', playerPos: state.pos });
   const loadState = (s: State) => send({ type: 'load', state: s });
 
   // 状態が変化するたび自動保存するが、初回だけはスキップする
@@ -89,7 +91,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
 
   return (
     <GameContext.Provider
-      value={{ state, move, reset, newGame, maze: state.mazeRaw, nextStage, resetRun, loadState }}
+      value={{ state, move, reset, newGame, maze: state.mazeRaw, nextStage, resetRun, respawnEnemies, loadState }}
     >
       {children}
     </GameContext.Provider>

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -13,7 +13,7 @@ import { useMoveHandler } from '@/src/hooks/useMoveHandler';
  */
 export function usePlayLogic() {
   const router = useRouter();
-  const { state, move, maze, nextStage, resetRun } = useGame();
+  const { state, move, maze, nextStage, resetRun, respawnEnemies } = useGame();
   const { width } = useWindowDimensions();
   const { show: showSnackbar } = useSnackbar();
 
@@ -44,6 +44,15 @@ export function usePlayLogic() {
   // ステージ総数。迷路は正方形なので size×size となる
   const totalStages = maze.size * maze.size;
 
+  // 敵のみをリスポーンする処理
+  const handleRespawn = () => {
+    if (state.respawnStock <= 0) {
+      showSnackbar('リスポーン回数がありません');
+      return;
+    }
+    respawnEnemies();
+  };
+
   return {
     state,
     maze,
@@ -57,5 +66,6 @@ export function usePlayLogic() {
     decSe: audio.decSe,
     audioReady: audio.audioReady,
     ...moveCtrl,
+    handleRespawn,
   } as const;
 }


### PR DESCRIPTION
## Summary
- respawn enemies using bias from player position
- track respawn stock in game state and save data
- update PlayScreen UI for respawn button color
- expose respawn control via hooks and context

## Testing
- `pnpm lint`
- `npx tsc -p tsconfig.json` *(fails: cannot find types)*

------
https://chatgpt.com/codex/tasks/task_e_686ad97daf98832c9f5f9c1362ce77ae