### PR TITLE
Change enemy spawn weight to player distance

### DIFF
--- a/src/game/__tests__/stageUtils.test.ts
+++ b/src/game/__tests__/stageUtils.test.ts
@@ -1,4 +1,9 @@
-import { randomCell, biasedPickGoal, shouldChangeMap } from '../maze';
+import {
+  randomCell,
+  biasedPickGoal,
+  biasedPickFrom,
+  shouldChangeMap,
+} from '../maze';
 import type { Vec2 } from '@/src/types/maze';
 
 describe('randomCell', () => {
@@ -23,6 +28,24 @@ describe('biasedPickGoal', () => {
   test('大きな乱数では遠い方が選ばれる', () => {
     const rnd = jest.fn().mockReturnValue(0.9); // 0.9*12 = 10.8 >2
     expect(biasedPickGoal(start, cells, rnd)).toEqual(cells[1]);
+  });
+});
+
+describe('biasedPickFrom', () => {
+  const origin: Vec2 = { x: 5, y: 5 };
+  const cells: Vec2[] = [
+    { x: 6, y: 5 }, // 重み2
+    { x: 9, y: 9 }, // 重み9
+  ];
+
+  test('小さな乱数では近い方が選ばれる', () => {
+    const rnd = jest.fn().mockReturnValue(0.05); // 0.05*11 = 0.55 <2
+    expect(biasedPickFrom(origin, cells, rnd)).toEqual(cells[0]);
+  });
+
+  test('大きな乱数では遠い方が選ばれる', () => {
+    const rnd = jest.fn().mockReturnValue(0.9); // 0.9*11 = 9.9 >2
+    expect(biasedPickFrom(origin, cells, rnd)).toEqual(cells[1]);
   });
 });
 

--- a/src/game/ai/spawn.ts
+++ b/src/game/ai/spawn.ts
@@ -2,7 +2,7 @@
 // プログラミング初心者向けにコメント多めで解説しています
 
 import type { MazeData, Vec2 } from '@/src/types/maze';
-import { allCells, biasedPickGoal } from '../maze';
+import { allCells, biasedPickFrom } from '../maze';
 
 /** 敵をランダムな位置に生成する */
 export function spawnEnemies(
@@ -26,7 +26,7 @@ export function spawnEnemies(
 
   while (enemies.length < count && candidates.length > 0) {
     const cell = biased
-      ? biasedPickGoal(origin, candidates, rnd)
+      ? biasedPickFrom(origin, candidates, rnd)
       : candidates[Math.floor(rnd() * candidates.length)];
     const key = `${cell.x},${cell.y}`;
     enemies.push(cell);

--- a/src/game/maze.ts
+++ b/src/game/maze.ts
@@ -115,6 +115,27 @@ export function biasedPickGoal(
 }
 
 /**
+ * 任意の位置から離れたマスほど選ばれやすい形で1マス取得する
+ * `biasedPickGoal` を一般化したもの。
+ */
+export function biasedPickFrom(
+  origin: Vec2,
+  cells: Vec2[],
+  rnd: () => number = Math.random,
+): Vec2 {
+  const weights = cells.map(
+    (c) => Math.abs(c.x - origin.x) + Math.abs(c.y - origin.y) + 1,
+  );
+  const sum = weights.reduce((a, b) => a + b, 0);
+  let r = rnd() * sum;
+  for (let i = 0; i < cells.length; i++) {
+    r -= weights[i];
+    if (r <= 0) return cells[i];
+  }
+  return cells[cells.length - 1];
+}
+
+/**
  * サイズから全てのマス座標を列挙する
  */
 export function allCells(size: number): Vec2[] {


### PR DESCRIPTION
## Summary
- generalize biased cell pick logic as `biasedPickFrom`
- use new logic in enemy spawn
- test `biasedPickFrom`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adc10ca98832c81e92045d1b55475