### PR TITLE
Fix game over return

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -162,7 +162,9 @@ export function useResultActions({
     });
 
     if (gameOver) {
+      // ゲームオーバー時はランをリセットしてタイトルへ戻る
       resetRun();
+      router.replace('/');
     } else if (gameClear) {
       resetRun();
       router.replace('/');


### PR DESCRIPTION
## Summary
- when hitting OK after a game over, return to the title screen

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686ae94ed1e8832c9d336e77cc7cf037