### PR TITLE
広告の事前読込とステージ表示を追加

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,16 +1,17 @@
-import { View, Pressable, useWindowDimensions } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { View, Pressable, useWindowDimensions } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 
 import { DPad } from "@/components/DPad";
 import { MiniMap } from "@/src/components/MiniMap";
 import type { MazeData as MazeView } from "@/src/types/maze";
 import { useLocale } from "@/src/locale/LocaleContext";
 import { usePlayLogic } from "@/src/hooks/usePlayLogic";
-import { ResultModal } from '@/components/ResultModal';
-import { EdgeOverlay } from '@/components/EdgeOverlay';
-import { playStyles } from '@/src/styles/playStyles';
-import { UI } from '@/constants/ui';
+import { ResultModal } from "@/components/ResultModal";
+import { StageBanner } from "@/components/StageBanner";
+import { EdgeOverlay } from "@/components/EdgeOverlay";
+import { playStyles } from "@/src/styles/playStyles";
+import { UI } from "@/constants/ui";
 
 export default function PlayScreen() {
   const { t } = useLocale();
@@ -32,12 +33,13 @@ export default function PlayScreen() {
     maxBorder,
     locked,
     okLocked,
+    okLabel,
+    showBanner,
     handleMove,
     handleOk,
     handleRespawn,
     handleExit,
   } = usePlayLogic();
-
 
   const dpadTop = height * (2 / 3);
   // ミニマップは ResultModal と重ならないよう少し上に配置する
@@ -61,7 +63,11 @@ export default function PlayScreen() {
         <MaterialIcons name="home" size={24} color={UI.colors.icon} />
       </Pressable>
       {/* 枠線用のオーバーレイ。処理は EdgeOverlay にまとめた */}
-      <EdgeOverlay borderColor={borderColor} borderW={borderW} maxBorder={maxBorder} />
+      <EdgeOverlay
+        borderColor={borderColor}
+        borderW={borderW}
+        maxBorder={maxBorder}
+      />
       {/* 右上のリセットアイコン。敵だけを再配置する */}
       <Pressable
         style={[playStyles.resetBtn, { top: insets.top + 10 }]}
@@ -74,11 +80,11 @@ export default function PlayScreen() {
       <Pressable
         style={[playStyles.menuBtn, { top: insets.top + 10 }]}
         onPress={() => setDebugAll(!debugAll)}
-        accessibilityLabel={t('showMazeAll')}
+        accessibilityLabel={t("showMazeAll")}
       >
         {/* debugAll の状態に応じてアイコンを変更 */}
         <MaterialIcons
-          name={debugAll ? 'visibility-off' : 'visibility'}
+          name={debugAll ? "visibility-off" : "visibility"}
           size={24}
           color={UI.colors.icon}
         />
@@ -107,18 +113,24 @@ export default function PlayScreen() {
       <ResultModal
         visible={showResult}
         top={resultTop}
-        title={gameClear ? t('gameClear') : gameOver ? t('gameOver') : t('goal')}
-        steps={t('steps', { count: state.steps })}
-        bumps={t('bumps', { count: state.bumps })}
-        stageText={t('stage', { current: state.stage, total: totalStages })}
+        title={
+          gameClear ? t("gameClear") : gameOver ? t("gameOver") : t("goal")
+        }
+        steps={t("steps", { count: state.steps })}
+        bumps={t("bumps", { count: state.bumps })}
+        stageText={t("stage", { current: state.stage, total: totalStages })}
         highScore={highScore && (gameClear || gameOver) ? highScore : null}
         newRecord={newRecord && (gameClear || gameOver)}
         onOk={handleOk}
-        okLabel={t('ok')}
-        accLabel={t('backToTitle')}
+        okLabel={okLabel}
+        accLabel={t("backToTitle")}
         disabled={okLocked}
+      />
+      <StageBanner
+        visible={showBanner}
+        stage={state.stage + 1}
+        onFinish={() => {}}
       />
     </View>
   );
 }
-

--- a/components/StageBanner.tsx
+++ b/components/StageBanner.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect } from "react";
+import { Modal, StyleSheet, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+
+/**
+ * ステージ番号を表示するオーバーレイコンポーネント
+ * visible が true の間だけ表示し、1 秒後に onFinish を呼び出す
+ */
+export function StageBanner({
+  visible,
+  stage,
+  onFinish,
+}: {
+  visible: boolean;
+  stage: number;
+  onFinish: () => void;
+}) {
+  useEffect(() => {
+    if (!visible) return;
+    const id = setTimeout(onFinish, 1000);
+    return () => clearTimeout(id);
+  }, [visible, onFinish]);
+
+  if (!visible) return null;
+  return (
+    <Modal transparent visible animationType="fade">
+      <View
+        style={styles.wrapper}
+        accessible
+        accessibilityLabel={`Stage ${stage}`}
+      >
+        <ThemedText type="title" style={styles.text}>
+          Stage {stage}
+        </ThemedText>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  text: {
+    color: "#fff",
+  },
+});

--- a/src/hooks/useResultState.ts
+++ b/src/hooks/useResultState.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState } from "react";
 
 /**
  * リザルト表示に関する状態だけを管理するフック。
@@ -14,6 +14,8 @@ export function useResultState() {
   const [okLocked, setOkLocked] = useState(false);
   // 各ステージで広告を一度だけ表示したかを記録するフラグ
   const [adShown, setAdShown] = useState(false);
+  // ステージ番号を表示する黒画面の表示フラグ
+  const [showBanner, setShowBanner] = useState(false);
 
   return {
     showResult,
@@ -32,5 +34,7 @@ export function useResultState() {
     setOkLocked,
     adShown,
     setAdShown,
+    showBanner,
+    setShowBanner,
   } as const;
 }

--- a/src/hooks/useStageEffects.ts
+++ b/src/hooks/useStageEffects.ts
@@ -1,4 +1,8 @@
-import { showInterstitial } from '@/src/ads/interstitial';
+import {
+  loadInterstitial,
+  showLoadedInterstitial,
+  type InterstitialAd,
+} from "@/src/ads/interstitial";
 
 interface Options {
   pauseBgm: () => void;
@@ -10,31 +14,44 @@ interface Options {
  * ステージ間で行う広告表示や BGM 停止をまとめたフック。
  * 副作用が多くなる処理を切り出して使いやすくします。
  */
-export function useStageEffects({ pauseBgm, resumeBgm, showSnackbar }: Options) {
+export function useStageEffects({
+  pauseBgm,
+  resumeBgm,
+  showSnackbar,
+}: Options) {
   /**
    * ステージ番号に応じて広告を表示する
    * 9 の倍数または 1 ステージ目で実行
    */
-  const showAdIfNeeded = async (stage: number): Promise<boolean> => {
-    // 実行条件となるステージかどうか計算しておく
-    const shouldShow = stage % 9 === 0 || stage === 1;
-    console.log('showAdIfNeeded check', { stage, shouldShow });
-    if (shouldShow) {
-      try {
-        console.log('interstitial start');
-        pauseBgm();
-        await showInterstitial();
-        console.log('interstitial end');
-      } catch (e) {
-        console.error('interstitial error', e);
-        showSnackbar('広告を表示できませんでした');
-      } finally {
-        resumeBgm();
-      }
-      return true;
-    }
-    return false;
+  const shouldShowAd = (stage: number) => stage % 9 === 0 || stage === 1;
+
+  const loadAdIfNeeded = async (
+    stage: number,
+  ): Promise<InterstitialAd | null> => {
+    const shouldShow = shouldShowAd(stage);
+    console.log("loadAdIfNeeded", { stage, shouldShow });
+    if (!shouldShow) return null;
+    return loadInterstitial();
   };
 
-  return { showAdIfNeeded } as const;
+  const showAd = async (ad: InterstitialAd | null): Promise<boolean> => {
+    if (!ad) return false;
+    try {
+      pauseBgm();
+      await showLoadedInterstitial(ad);
+    } catch (e) {
+      console.error("interstitial error", e);
+      showSnackbar("広告を表示できませんでした");
+    } finally {
+      resumeBgm();
+    }
+    return true;
+  };
+
+  const showAdIfNeeded = async (stage: number): Promise<boolean> => {
+    const ad = await loadAdIfNeeded(stage);
+    return showAd(ad);
+  };
+
+  return { loadAdIfNeeded, showAd, showAdIfNeeded } as const;
 }

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -1,102 +1,112 @@
-import React, { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
-export type Lang = 'ja' | 'en';
+export type Lang = "ja" | "en";
 
 // 言語設定を保存する際のキー
-const STORAGE_KEY = 'lang';
+const STORAGE_KEY = "lang";
 
 // 画面で表示する文言の定義
 const messages = {
   ja: {
-    practiceMode: '練習モード',
-    openPractice: '練習モードを開く',
-    level1: 'レベル1',
-    level2: 'レベル2',
-    startLevel: '{{name}}を開始',
-    enemyRandom: '等速・ランダム',
-    enemySlow: '鈍足・視認',
-    enemySight: '等速・視認',
-    enemyPathLen: '敵軌跡長',
-    playerPathLen: '自分軌跡長',
-    wallDuration: '壁表示',
-    startMazeSize: '{{size}}マス迷路を開始',
-    increase: '{{label}}を増やす',
-    decrease: '{{label}}を減らす',
-    bgmVolume: 'BGM音量',
-    seVolume: 'SE音量',
-    resetMaze: '迷路リセット',
-    resetMazeLabel: '迷路を最初から',
-    showAll: '全てを可視化',
-    showMazeAll: '迷路を全て表示',
-    gameClear: 'ゲームクリア',
-    gameOver: 'ゲームオーバー',
-    goal: 'ゴール！',
-    steps: 'Steps: {{count}}',
-    bumps: 'Bumps: {{count}}',
-    stage: 'Stage: {{current}}/{{total}}',
-    best: 'Best: {{stage}}ステージ / {{steps}} steps / {{bumps}} bumps',
-    highScores: 'ハイスコア',
-    openHighScores: 'ハイスコア一覧を開く',
-    noRecord: '記録なし',
+    practiceMode: "練習モード",
+    openPractice: "練習モードを開く",
+    level1: "レベル1",
+    level2: "レベル2",
+    startLevel: "{{name}}を開始",
+    enemyRandom: "等速・ランダム",
+    enemySlow: "鈍足・視認",
+    enemySight: "等速・視認",
+    enemyPathLen: "敵軌跡長",
+    playerPathLen: "自分軌跡長",
+    wallDuration: "壁表示",
+    startMazeSize: "{{size}}マス迷路を開始",
+    increase: "{{label}}を増やす",
+    decrease: "{{label}}を減らす",
+    bgmVolume: "BGM音量",
+    seVolume: "SE音量",
+    resetMaze: "迷路リセット",
+    resetMazeLabel: "迷路を最初から",
+    showAll: "全てを可視化",
+    showMazeAll: "迷路を全て表示",
+    gameClear: "ゲームクリア",
+    gameOver: "ゲームオーバー",
+    goal: "ゴール！",
+    steps: "Steps: {{count}}",
+    bumps: "Bumps: {{count}}",
+    stage: "Stage: {{current}}/{{total}}",
+    best: "Best: {{stage}}ステージ / {{steps}} steps / {{bumps}} bumps",
+    highScores: "ハイスコア",
+    openHighScores: "ハイスコア一覧を開く",
+    noRecord: "記録なし",
     // ハイスコアを更新したときに表示するメッセージ
-    newRecord: '記録更新！',
-    ok: 'OK',
-    changeLang: '言語設定',
-    selectLang: '言語を選択してください',
-    japanese: '日本語',
-    english: 'English',
-    backToTitle: 'タイトルへ戻る',
-    continue: 'つづきから',
-    startFromBegin: '{{name}}をはじめからプレイ',
-    confirmReset: '中断中のゲームデータを削除して新しいゲームを開始しますか？',
-    yes: 'はい',
-    cancel: 'キャンセル',
+    newRecord: "記録更新！",
+    ok: "OK",
+    loadingAd: "広告を読み込んでいます",
+    showAd: "広告を表示して次に進む",
+    changeLang: "言語設定",
+    selectLang: "言語を選択してください",
+    japanese: "日本語",
+    english: "English",
+    backToTitle: "タイトルへ戻る",
+    continue: "つづきから",
+    startFromBegin: "{{name}}をはじめからプレイ",
+    confirmReset: "中断中のゲームデータを削除して新しいゲームを開始しますか？",
+    yes: "はい",
+    cancel: "キャンセル",
   },
   en: {
-    practiceMode: 'Practice Mode',
-    openPractice: 'Open Practice',
-    level1: 'Level 1',
-    level2: 'Level 2',
-    startLevel: 'Start {{name}}',
-    enemyRandom: 'Normal Random',
-    enemySlow: 'Slow Vision',
-    enemySight: 'Normal Vision',
-    enemyPathLen: 'Enemy Path',
-    playerPathLen: 'Player Path',
-    wallDuration: 'Wall Lifetime',
-    startMazeSize: 'Start {{size}} maze',
-    increase: 'Increase {{label}}',
-    decrease: 'Decrease {{label}}',
-    bgmVolume: 'BGM Volume',
-    seVolume: 'SE Volume',
-    resetMaze: 'Reset Maze',
-    resetMazeLabel: 'Reset maze',
-    showAll: 'Show All',
-    showMazeAll: 'Show whole maze',
-    gameClear: 'Game Clear',
-    gameOver: 'Game Over',
-    goal: 'Goal!',
-    steps: 'Steps: {{count}}',
-    bumps: 'Bumps: {{count}}',
-    stage: 'Stage: {{current}}/{{total}}',
-    best: 'Best: {{stage}} stages / {{steps}} steps / {{bumps}} bumps',
-    highScores: 'High Scores',
-    openHighScores: 'View High Scores',
-    noRecord: 'No record',
+    practiceMode: "Practice Mode",
+    openPractice: "Open Practice",
+    level1: "Level 1",
+    level2: "Level 2",
+    startLevel: "Start {{name}}",
+    enemyRandom: "Normal Random",
+    enemySlow: "Slow Vision",
+    enemySight: "Normal Vision",
+    enemyPathLen: "Enemy Path",
+    playerPathLen: "Player Path",
+    wallDuration: "Wall Lifetime",
+    startMazeSize: "Start {{size}} maze",
+    increase: "Increase {{label}}",
+    decrease: "Decrease {{label}}",
+    bgmVolume: "BGM Volume",
+    seVolume: "SE Volume",
+    resetMaze: "Reset Maze",
+    resetMazeLabel: "Reset maze",
+    showAll: "Show All",
+    showMazeAll: "Show whole maze",
+    gameClear: "Game Clear",
+    gameOver: "Game Over",
+    goal: "Goal!",
+    steps: "Steps: {{count}}",
+    bumps: "Bumps: {{count}}",
+    stage: "Stage: {{current}}/{{total}}",
+    best: "Best: {{stage}} stages / {{steps}} steps / {{bumps}} bumps",
+    highScores: "High Scores",
+    openHighScores: "View High Scores",
+    noRecord: "No record",
     // Message shown when a new high score is achieved
-    newRecord: 'New Record!',
-    ok: 'OK',
-    changeLang: 'Language',
-    selectLang: 'Select language',
-    japanese: 'Japanese',
-    english: 'English',
-    backToTitle: 'Back to title',
-    continue: 'Continue',
-    startFromBegin: 'Play {{name}} from start',
-    confirmReset: 'Delete saved game and start new?',
-    yes: 'Yes',
-    cancel: 'Cancel',
+    newRecord: "New Record!",
+    ok: "OK",
+    loadingAd: "Loading ad...",
+    showAd: "Show ad and continue",
+    changeLang: "Language",
+    selectLang: "Select language",
+    japanese: "Japanese",
+    english: "English",
+    backToTitle: "Back to title",
+    continue: "Continue",
+    startFromBegin: "Play {{name}} from start",
+    confirmReset: "Delete saved game and start new?",
+    yes: "Yes",
+    cancel: "Cancel",
   },
 } as const;
 
@@ -104,7 +114,11 @@ type Messages = typeof messages.ja;
 export type MessageKey = keyof Messages;
 
 // 文言を取得しプレースホルダーを差し替える簡易関数
-function translate(lang: Lang, key: MessageKey, params?: Record<string, string | number>) {
+function translate(
+  lang: Lang,
+  key: MessageKey,
+  params?: Record<string, string | number>,
+) {
   let template = messages[lang][key] ?? messages.ja[key];
   if (params) {
     for (const [k, v] of Object.entries(params)) {
@@ -125,14 +139,14 @@ interface LocaleContextValue {
 const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
 
 export function LocaleProvider({ children }: { children: ReactNode }) {
-  const [lang, setLang] = useState<Lang>('ja');
+  const [lang, setLang] = useState<Lang>("ja");
   const [ready, setReady] = useState(false);
   const [firstLaunch, setFirstLaunch] = useState(false);
 
   useEffect(() => {
     (async () => {
       const stored = await AsyncStorage.getItem(STORAGE_KEY);
-      if (stored === 'ja' || stored === 'en') {
+      if (stored === "ja" || stored === "en") {
         setLang(stored);
       } else {
         // 言語未選択なら初回起動とみなす
@@ -160,6 +174,6 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
 
 export function useLocale() {
   const ctx = useContext(LocaleContext);
-  if (!ctx) throw new Error('useLocale は LocaleProvider 内で利用してください');
+  if (!ctx) throw new Error("useLocale は LocaleProvider 内で利用してください");
   return ctx;
 }


### PR DESCRIPTION
## Summary
- インタースティシャル広告を事前に読み込み、OK ボタンのラベルを動的に変更
- 広告表示後に次ステージ番号を黒画面で1秒表示する `StageBanner` を追加
- これに合わせて `useStageEffects`, `useResultActions` などを更新
- 翻訳ファイルに広告関連メッセージを追加

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686b26fc5db0832c88b19bec2e2e6032