### PR TITLE
広告表示用フックの最適化

### DIFF
--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useEffect,
   useState,
+  useCallback,
   type ReactNode,
 } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -164,8 +165,12 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
     setFirstLaunch(false);
   };
 
-  const t = (key: MessageKey, params?: Record<string, string | number>) =>
-    translate(lang, key, params);
+  // 翻訳関数をメモ化して無駄な再レンダリングを防ぐ
+  const t = useCallback(
+    (key: MessageKey, params?: Record<string, string | number>) =>
+      translate(lang, key, params),
+    [lang],
+  );
 
   return (
     <LocaleContext.Provider value={{ lang, t, changeLang, ready, firstLaunch }}>


### PR DESCRIPTION
## Summary
- `useStageEffects` の各処理を `useCallback` でメモ化
- `LocaleContext` の `t` 関数を `useCallback` 化
- Lint とテストコマンドを実行

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b30f45af0832cab0c2148293c5cbd