### PR TITLE
ステージ初期化タイミングをバナー表示中に変更

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -35,6 +35,8 @@ export default function PlayScreen() {
     okLocked,
     okLabel,
     showBanner,
+    bannerStage,
+    handleBannerFinish,
     handleMove,
     handleOk,
     handleRespawn,
@@ -128,8 +130,8 @@ export default function PlayScreen() {
       />
       <StageBanner
         visible={showBanner}
-        stage={state.stage + 1}
-        onFinish={() => {}}
+        stage={bannerStage}
+        onFinish={handleBannerFinish}
       />
     </View>
   );

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -56,6 +56,8 @@ export function useResultActions({
     setAdShown,
     showBanner,
     setShowBanner,
+    bannerStage,
+    setBannerStage,
   } = useResultState();
 
   const { t } = useLocale();
@@ -204,16 +206,22 @@ export function useResultActions({
       showResult,
     });
 
-    // 次ステージ番号を一瞬表示してから進む
+    // 次ステージ番号を表示しながら内部状態を初期化する
+    setBannerStage(state.stage + 1);
     setShowBanner(true);
-    setTimeout(() => {
-      if (wasStageClear) {
-        nextStage();
-      }
-      setShowBanner(false);
-      okLockedRef.current = false;
-      setOkLocked(false);
-    }, 2000);
+    if (wasStageClear) {
+      nextStage();
+    }
+  };
+
+  /**
+   * ステージバナーが閉じた後に呼ばれる処理
+   * ロック解除など後片付けをここで行う
+   */
+  const handleBannerFinish = () => {
+    setShowBanner(false);
+    okLockedRef.current = false;
+    setOkLocked(false);
   };
 
   // リセット処理
@@ -252,6 +260,8 @@ export function useResultActions({
     okLocked,
     okLabel,
     showBanner,
+    bannerStage,
+    handleBannerFinish,
     handleOk,
     handleReset,
     handleExit,

--- a/src/hooks/useResultState.ts
+++ b/src/hooks/useResultState.ts
@@ -16,6 +16,8 @@ export function useResultState() {
   const [adShown, setAdShown] = useState(false);
   // ステージ番号を表示する黒画面の表示フラグ
   const [showBanner, setShowBanner] = useState(false);
+  // バナーに表示する次のステージ番号
+  const [bannerStage, setBannerStage] = useState(0);
 
   return {
     showResult,
@@ -36,5 +38,7 @@ export function useResultState() {
     setAdShown,
     showBanner,
     setShowBanner,
+    bannerStage,
+    setBannerStage,
   } as const;
 }


### PR DESCRIPTION
## Summary
- 次ステージへ進む際に初期化処理をバナー表示中に実行
- バナー用のステージ番号を `useResultState` で保持
- バナー閉じ後の後片付け処理を追加
- `PlayScreen` から新処理を呼び出す

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686b420d8d84832cbb6d94a5e0b0ad64