### PR TITLE
広告なしでは即次ステージへ進むボタン表示

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -91,7 +91,8 @@ export function useResultActions({
       setOkLabel(t("loadingAd"));
       loadAdIfNeeded(state.stage).then((ad) => {
         loadedAdRef.current = ad;
-        setOkLabel(ad ? t("showAd") : t("ok"));
+        // 広告が無ければ最初から「次のステージへ」と表示する
+        setOkLabel(ad ? t("showAd") : t("nextStage"));
         okLockedRef.current = false;
         setOkLocked(false);
       });
@@ -180,12 +181,15 @@ export function useResultActions({
     // ステージクリア直後で広告未表示なら広告を表示
     if (wasStageClear && !adShown) {
       setAdShown(true);
-      await showAd(loadedAdRef.current);
+      const shown = await showAd(loadedAdRef.current);
       loadedAdRef.current = null;
-      setOkLabel(t("nextStage"));
-      okLockedRef.current = false;
-      setOkLocked(false);
-      return;
+      // 広告が表示されたときのみボタンラベルを変更して処理を終了
+      if (shown) {
+        setOkLabel(t("nextStage"));
+        okLockedRef.current = false;
+        setOkLocked(false);
+        return;
+      }
     }
 
     // リザルト関連のフラグをリセット


### PR DESCRIPTION
## Summary
- ステージクリア時に広告が無い場合は最初から「次のステージへ」ボタンを表示するよう変更
- 広告表示が失敗したときはそのまま次の処理へ進むよう `handleOk` を調整

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b44968be8832c9497934e3cef6993