### PR TITLE
Fix text string warning

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -154,7 +154,7 @@ export default function TitleScreen() {
               {t("volumeSettings")}
             </ThemedText>
 
-            // ────── BGM 音量行（置換） ──────
+            {/* ────── BGM 音量行（置換） ────── */}
             <View style={styles.volumeRow}>
               <ThemedText lightColor="#fff" darkColor="#fff">
                 {t('bgmVolume')}:
@@ -183,7 +183,7 @@ export default function TitleScreen() {
               </View>
             </View>
 
-            // ────── SE 音量行（置換） ──────
+            {/* ────── SE 音量行（置換） ────── */}
             <View style={styles.volumeRow}>
               <ThemedText lightColor="#fff" darkColor="#fff">
                 {t('seVolume')}:


### PR DESCRIPTION
## Summary
- fix comments inside JSX that caused `Text strings must be rendered within a <Text> component` warning

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b5710fc10832c8827d2b438c7b267