### PR TITLE
Add overlay style for stage banner

### DIFF
--- a/components/ResultModal.tsx
+++ b/components/ResultModal.tsx
@@ -38,7 +38,12 @@ export function ResultModal({
   // 画面の文言を取得するためにロケールフックを利用
   const { t } = useLocale();
   return (
-    <Modal transparent visible={visible} animationType="fade">
+    <Modal
+      transparent
+      visible={visible}
+      animationType="fade"
+      presentationStyle="overFullScreen"
+    >
       <View style={styles.wrapper} accessible accessibilityLabel="結果表示オーバーレイ">
         <ThemedView style={[styles.content, { marginTop: top }]}>
           <ThemedText type="title">{title}</ThemedText>

--- a/components/StageBanner.tsx
+++ b/components/StageBanner.tsx
@@ -25,7 +25,12 @@ export function StageBanner({
 
   if (!visible) return null;
   return (
-    <Modal transparent visible animationType="fade">
+    <Modal
+      transparent
+      visible
+      animationType="fade"
+      presentationStyle="overFullScreen"
+    >
       <View
         style={styles.wrapper}
         accessible


### PR DESCRIPTION
## Summary
- show the stage banner immediately by layering over the result modal

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686b5a46b98c832cb0ba663ea687b2a5