### PR TITLE
Result panel inline display

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -44,12 +44,11 @@ export default function PlayScreen() {
   } = usePlayLogic();
 
   const dpadTop = height * (2 / 3);
-  // ミニマップは ResultModal と重ならないよう少し上に配置する
+  // ミニマップはリザルトパネルと重ならないよう少し上に配置する
   // mapTop は画面高さの 1/3 から 80px 引いた位置
   const mapTop = height / 3 - 80;
-  // ResultModal はミニマップ下端より 10px 下に表示する
-  // MiniMap のサイズは 300px のため、mapTop + 310 が位置となる
-  const resultTop = mapTop + 310;
+  // リザルトパネルは DPad と同じ位置に表示する
+  const resultTop = dpadTop;
   // リセットボタンの色。使用回数に応じて白から黒へ変化させる
   const gray = Math.round((state.respawnStock / 3) * 255);
   const resetColor = `rgb(${gray},${gray},${gray})`;
@@ -109,9 +108,11 @@ export default function PlayScreen() {
           size={300}
         />
       </View>
-      <View style={[playStyles.dpadWrapper, { top: dpadTop }]}>
-        <DPad onPress={handleMove} disabled={locked} />
-      </View>
+      {!showResult && (
+        <View style={[playStyles.dpadWrapper, { top: dpadTop }]}>
+          <DPad onPress={handleMove} disabled={locked} />
+        </View>
+      )}
       <ResultModal
         visible={showResult}
         top={resultTop}

--- a/components/ResultModal.tsx
+++ b/components/ResultModal.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { Modal, StyleSheet, View } from 'react-native';
-import { ThemedText } from '@/components/ThemedText';
-import { ThemedView } from '@/components/ThemedView';
-import { PlainButton } from '@/components/PlainButton';
-import { useLocale } from '@/src/locale/LocaleContext';
-import { UI } from '@/constants/ui';
-import type { HighScore } from '@/src/game/highScore';
+import React from "react";
+import { StyleSheet } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { ThemedView } from "@/components/ThemedView";
+import { PlainButton } from "@/components/PlainButton";
+import { useLocale } from "@/src/locale/LocaleContext";
+import { UI } from "@/constants/ui";
+import type { HighScore } from "@/src/game/highScore";
 
-/** 結果表示モーダル */
+/** ゲーム画面に直接表示するリザルトパネル */
 export function ResultModal({
   visible,
   top,
@@ -35,55 +35,45 @@ export function ResultModal({
   accLabel: string;
   disabled?: boolean;
 }) {
-  // 画面の文言を取得するためにロケールフックを利用
   const { t } = useLocale();
+  if (!visible) return null;
+
   return (
-    <Modal
-      transparent
-      visible={visible}
-      animationType="fade"
-      presentationStyle="overFullScreen"
+    <ThemedView
+      style={[styles.content, { marginTop: top }]}
+      accessible
+      accessibilityLabel="結果表示パネル"
     >
-      <View style={styles.wrapper} accessible accessibilityLabel="結果表示オーバーレイ">
-        <ThemedView style={[styles.content, { marginTop: top }]}>
-          <ThemedText type="title">{title}</ThemedText>
-          <ThemedText>{steps}</ThemedText>
-          <ThemedText>{bumps}</ThemedText>
-          <ThemedText>{stageText}</ThemedText>
-          {highScore && (
-            <ThemedText>
-              {t('best', {
-                stage: highScore.stage,
-                steps: highScore.steps,
-                bumps: highScore.bumps,
-              })}
-            </ThemedText>
-          )}
-          {newRecord && <ThemedText>{t('newRecord')}</ThemedText>}
-          <PlainButton
-            title={okLabel}
-            onPress={onOk}
-            accessibilityLabel={accLabel}
-            disabled={disabled}
-          />
-        </ThemedView>
-      </View>
-    </Modal>
+      <ThemedText type="title">{title}</ThemedText>
+      <ThemedText>{steps}</ThemedText>
+      <ThemedText>{bumps}</ThemedText>
+      <ThemedText>{stageText}</ThemedText>
+      {highScore && (
+        <ThemedText>
+          {t("best", {
+            stage: highScore.stage,
+            steps: highScore.steps,
+            bumps: highScore.bumps,
+          })}
+        </ThemedText>
+      )}
+      {newRecord && <ThemedText>{t("newRecord")}</ThemedText>}
+      <PlainButton
+        title={okLabel}
+        onPress={onOk}
+        accessibilityLabel={accLabel}
+        disabled={disabled}
+      />
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
-  wrapper: {
-    flex: 1,
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-    backgroundColor: UI.colors.overlay,
-  },
   content: {
     backgroundColor: UI.colors.modalBg,
     padding: 20,
     borderRadius: 8,
-    alignItems: 'center',
+    alignItems: "center",
     gap: UI.dpadSpacing,
     width: UI.modalWidth,
   },


### PR DESCRIPTION
## Summary
- show result panel directly on gameplay screen
- hide DPad when showing results

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686c27ff6458832c99b8b8fa2a972122