### PR TITLE
Adjust result modal style

### DIFF
--- a/components/PlainButton.tsx
+++ b/components/PlainButton.tsx
@@ -11,10 +11,12 @@ interface PlainButtonProps {
    * 外から追加のスタイルを渡したいとき用
    */
   style?: PressableProps['style'];
+  /** 背景色と文字色の組み合わせを変えるオプション */
+  variant?: 'dark' | 'light';
 }
 
 /**
- * 黒背景・白文字のシンプルなボタン
+ * 背景と文字色が選べるシンプルなボタン
  * 初心者でも分かりやすいように Pressable と Text を組み合わせている
  */
 export function PlainButton({
@@ -23,7 +25,14 @@ export function PlainButton({
   accessibilityLabel,
   disabled = false,
   style,
+  variant = 'dark',
 }: PlainButtonProps) {
+  // variant の値に応じてボタンと文字の色を切り替える
+  const variantStyle =
+    variant === 'light'
+      ? { backgroundColor: '#fff', color: '#000' }
+      : { backgroundColor: UI.colors.buttonBg, color: UI.colors.buttonText };
+
   return (
     <Pressable
       accessibilityLabel={accessibilityLabel ?? title}
@@ -31,12 +40,13 @@ export function PlainButton({
       disabled={disabled}
       style={(state) => [
         styles.button,
+        { backgroundColor: variantStyle.backgroundColor },
         state.pressed && styles.pressed,
         disabled && styles.disabled,
         typeof style === 'function' ? style(state) : style,
       ]}
     >
-      <Text style={styles.text}>{title}</Text>
+      <Text style={[styles.text, { color: variantStyle.color }]}>{title}</Text>
     </Pressable>
   );
 }

--- a/components/ResultModal.tsx
+++ b/components/ResultModal.tsx
@@ -40,16 +40,16 @@ export function ResultModal({
 
   return (
     <ThemedView
-      style={[styles.content, { marginTop: top }]}
+      style={[styles.content, { top }]}
       accessible
       accessibilityLabel="結果表示パネル"
     >
-      <ThemedText type="title">{title}</ThemedText>
-      <ThemedText>{steps}</ThemedText>
-      <ThemedText>{bumps}</ThemedText>
-      <ThemedText>{stageText}</ThemedText>
+      <ThemedText type="title" style={styles.text}>{title}</ThemedText>
+      <ThemedText style={styles.text}>{steps}</ThemedText>
+      <ThemedText style={styles.text}>{bumps}</ThemedText>
+      <ThemedText style={styles.text}>{stageText}</ThemedText>
       {highScore && (
-        <ThemedText>
+        <ThemedText style={styles.text}>
           {t("best", {
             stage: highScore.stage,
             steps: highScore.steps,
@@ -57,12 +57,13 @@ export function ResultModal({
           })}
         </ThemedText>
       )}
-      {newRecord && <ThemedText>{t("newRecord")}</ThemedText>}
+      {newRecord && <ThemedText style={styles.text}>{t("newRecord")}</ThemedText>}
       <PlainButton
         title={okLabel}
         onPress={onOk}
         accessibilityLabel={accLabel}
         disabled={disabled}
+        variant="light"
       />
     </ThemedView>
   );
@@ -70,11 +71,16 @@ export function ResultModal({
 
 const styles = StyleSheet.create({
   content: {
-    backgroundColor: UI.colors.modalBg,
+    position: 'absolute',
+    backgroundColor: '#000',
     padding: 20,
     borderRadius: 8,
-    alignItems: "center",
+    alignItems: 'center',
     gap: UI.dpadSpacing,
     width: UI.modalWidth,
+    alignSelf: 'center',
+  },
+  text: {
+    color: '#fff',
   },
 });


### PR DESCRIPTION
## Summary
- reposition and recolor ResultModal for better visibility
- add `variant` prop to PlainButton for light or dark buttons

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686c2c9da0c4832ca30b30c735f1ba89