### PR TITLE
fix banner glitch

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -129,7 +129,10 @@ export default function PlayScreen() {
         accLabel={t("backToTitle")}
         disabled={okLocked}
       />
+      {/* key にステージ番号を使い毎回新規マウントすることで */}
+      {/* 前回のバナーがちらつく問題を防ぐ */}
       <StageBanner
+        key={bannerStage}
         visible={showBanner}
         stage={bannerStage}
         onFinish={handleBannerFinish}

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -246,11 +246,13 @@ export function useResultActions({
       nextStage();
       pendingNextStageRef.current = false;
     }
+    // 番号を初期化して前ステージの残像を防ぐ
+    setBannerStage(0);
     // バナー表示後に OK ボタンのラベルを戻す
     setOkLabel(t("ok"));
     okLockedRef.current = false;
     setOkLocked(false);
-  }, [nextStage, setShowBanner, setOkLabel, setOkLocked, t]);
+  }, [nextStage, setShowBanner, setBannerStage, setOkLabel, setOkLocked, t]);
 
   // リセット処理
   const handleReset = () => {


### PR DESCRIPTION
## Summary
- ステージバナーの終了時に番号をリセットし残像を防止
- key を付与して毎回新しいバナーを生成

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686c372dcb08832cb874e3db668a034c