### PR TITLE
Fix stage clear transition

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -76,8 +76,6 @@ export function useResultActions({
   const okLockedRef = useRef(false);
   // バナー表示中かどうかを判定するフラグ。表示中はリザルト判定を行わない
   const bannerActiveRef = useRef(false);
-  // バナー表示後に次のステージへ進むかどうかを保持するフラグ
-  const pendingNextStageRef = useRef(false);
 
   // ゴール到達や捕まったときの処理をまとめる
   useEffect(() => {
@@ -205,10 +203,9 @@ export function useResultActions({
     // バナー表示中は判定をスキップするためフラグを立てる
     bannerActiveRef.current = true;
 
-
-    // ステージクリア時はバナー後に次ステージへ進む
+    // ステージクリア時はここで即座に次ステージを開始する
     if (wasStageClear) {
-      pendingNextStageRef.current = true;
+      nextStage();
     }
 
 
@@ -242,17 +239,13 @@ export function useResultActions({
   const handleBannerFinish = useCallback(() => {
     setShowBanner(false);
     bannerActiveRef.current = false;
-    if (pendingNextStageRef.current) {
-      nextStage();
-      pendingNextStageRef.current = false;
-    }
     // 番号を初期化して前ステージの残像を防ぐ
     setBannerStage(0);
     // バナー表示後に OK ボタンのラベルを戻す
     setOkLabel(t("ok"));
     okLockedRef.current = false;
     setOkLocked(false);
-  }, [nextStage, setShowBanner, setBannerStage, setOkLabel, setOkLocked, t]);
+  }, [setShowBanner, setBannerStage, setOkLabel, setOkLocked, t]);
 
   // リセット処理
   const handleReset = () => {


### PR DESCRIPTION
## Summary
- start next stage immediately when clearing a stage
- drop unused pendingNextStageRef
- update banner finish logic

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686c3c7b9024832ca355fd015b8bd9d2