### PR TITLE
ステージ1開始時にバナー表示

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -77,6 +77,17 @@ export function useResultActions({
   // バナー表示中かどうかを判定するフラグ。表示中はリザルト判定を行わない
   const bannerActiveRef = useRef(false);
 
+  // ゲーム開始直後にステージ1バナーを表示する
+  // 条件: ステージ1かつ移動回数0であること
+  // ステージ開始時のバナー表示判定
+  useEffect(() => {
+    if (state.stage === 1 && state.steps === 0 && !showBanner && bannerStage === 0) {
+      setBannerStage(1);
+      setShowBanner(true);
+      bannerActiveRef.current = true;
+    }
+  }, [state.stage, state.steps, showBanner, bannerStage, setBannerStage, setShowBanner]);
+
   // ゴール到達や捕まったときの処理をまとめる
   useEffect(() => {
     // バナー表示中は旧ステージの判定をスキップする


### PR DESCRIPTION
## Summary
- ステージ1開始直後にバナーを表示するよう useResultActions を更新

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686c498e5cf8832c8df9ca88c7ae9b7c