### PR TITLE
Update audio sources and add bump sound

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -27,7 +27,17 @@ export default function TitleScreen() {
   const [showVolume, setShowVolume] = React.useState(false);
 
   // BGM/SE を制御
-  const audio = useAudioControls(require("../assets/sounds/歩く音200ms_2.mp3"));
+  const audio = useAudioControls(
+    require("../assets/sounds/歩く音200ms_調整.mp3"),
+    require("../assets/sounds/弓と矢_調整.mp3")
+  );
+
+  // タイトル画面では常に基本BGMに戻す
+  React.useEffect(() => {
+    audio.changeBgm(require("../assets/sounds/降りしきる、白_調整.mp3"));
+    // audio インスタンスは固定のため依存なし
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // 初回起動時：言語選択モーダル
   React.useEffect(() => {
@@ -50,6 +60,11 @@ export default function TitleScreen() {
   const startLevel = (id: string) => {
     const level = LEVELS.find((l) => l.id === id);
     if (!level) return;
+    if (id === 'level2') {
+      audio.changeBgm(require('../assets/sounds/日没廃校_調整.mp3'));
+    } else {
+      audio.changeBgm(require('../assets/sounds/降りしきる、白_調整.mp3'));
+    }
     newGame(
       level.size,
       level.enemies,

--- a/src/audio/BgmProvider.tsx
+++ b/src/audio/BgmProvider.tsx
@@ -17,6 +17,8 @@ interface BgmContextValue {
   setVolume: (v: number) => void;
   pause: () => void;
   resume: () => void;
+  /** 再生する BGM を変更する */
+  change: (file: number) => void;
   ready: boolean;
 }
 
@@ -32,7 +34,7 @@ export function BgmProvider({ children }: { children: ReactNode }) {
     (async () => {
       await setAudioModeAsync({ playsInSilentMode: true });
       const p = createAudioPlayer(
-        require("../../assets/sounds/降りしきる、白.mp3")
+        require("../../assets/sounds/降りしきる、白_調整.mp3")
       );
       p.loop = true;
       p.volume = volume;
@@ -58,8 +60,19 @@ export function BgmProvider({ children }: { children: ReactNode }) {
     if (playerRef.current?.paused) playerRef.current.play();
   };
 
+  const change = (file: number) => {
+    if (playerRef.current) {
+      playerRef.current.remove();
+    }
+    const p = createAudioPlayer(file);
+    p.loop = true;
+    p.volume = volume;
+    p.play();
+    playerRef.current = p;
+  };
+
   return (
-    <BgmContext.Provider value={{ volume, setVolume, pause, resume, ready }}>
+    <BgmContext.Provider value={{ volume, setVolume, pause, resume, change, ready }}>
       {children}
     </BgmContext.Provider>
   );

--- a/src/hooks/useAudioControls.ts
+++ b/src/hooks/useAudioControls.ts
@@ -6,14 +6,17 @@ import { useSE } from '@/src/hooks/useSE';
  * BGM と SE の音量調整や再生をまとめて扱うフック。
  * Play 画面以外でも再利用できるよう独立させています。
  */
-export function useAudioControls(soundFile: number) {
+export function useAudioControls(moveFile: number, bumpFile: number) {
   const {
     volume: bgmVolume,
     setVolume: setBgmVolume,
     pause: pauseBgm,
     resume: resumeBgm,
+    change: changeBgm,
   } = useBgm();
-  const { volume: seVolume, setVolume: setSeVolume, play } = useSE(soundFile);
+  const { volume: seVolume, setVolume: setSeVolume, play: playMove } =
+    useSE(moveFile);
+  const { play: playBump } = useSE(bumpFile);
 
   // 効果音を再生したことを示すフラグ
   const [audioReady, setAudioReady] = useState(false);
@@ -28,20 +31,25 @@ export function useAudioControls(soundFile: number) {
   const incSe = () => {
     const newVol = Math.min(1, Math.round((seVolume + 0.1) * 10) / 10);
     setSeVolume(newVol);
-    play(newVol);
+    playMove(newVol);
   };
   /** SE 音量を下げ、変更後の音量で効果音を鳴らす */
   const decSe = () => {
     const newVol = Math.max(0, Math.round((seVolume - 0.1) * 10) / 10);
     setSeVolume(newVol);
-    play(newVol);
+    playMove(newVol);
   };
 
   /** 移動音を再生し audioReady を一時的に立てる */
   const playMoveSe = () => {
-    play();
+    playMove();
     setAudioReady(true);
     setTimeout(() => setAudioReady(false), 200);
+  };
+
+  /** 壁衝突音を再生する */
+  const playBumpSe = () => {
+    playBump();
   };
 
   return {
@@ -52,8 +60,10 @@ export function useAudioControls(soundFile: number) {
     incSe,
     decSe,
     playMoveSe,
+    playBumpSe,
     pauseBgm,
     resumeBgm,
+    changeBgm,
     audioReady,
   } as const;
 }

--- a/src/hooks/useMoveHandler.ts
+++ b/src/hooks/useMoveHandler.ts
@@ -10,6 +10,7 @@ interface Options {
   maze: MazeData;
   move: (dir: Dir) => boolean;
   playMoveSe: () => void;
+  playBumpSe: () => void;
   width: number;
 }
 
@@ -21,6 +22,7 @@ export function useMoveHandler({
   maze,
   move,
   playMoveSe,
+  playBumpSe,
   width,
 }: Options) {
   // 壁衝突時に表示する枠線の色
@@ -55,6 +57,7 @@ export function useMoveHandler({
     let wait: number;
     if (!move(dir)) {
       wait = applyBumpFeedback(borderW, setBorderColor);
+      playBumpSe();
       setTimeout(() => setBorderColor('transparent'), wait);
     } else {
       playMoveSe();

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -18,7 +18,10 @@ export function usePlayLogic() {
   const { show: showSnackbar } = useSnackbar();
 
   // BGM・SE 操作は専用フックに委譲
-  const audio = useAudioControls(require('../../assets/sounds/歩く音200ms_2.mp3'));
+  const audio = useAudioControls(
+    require('../../assets/sounds/歩く音200ms_調整.mp3'),
+    require('../../assets/sounds/弓と矢_調整.mp3')
+  );
 
   // リザルト表示やメニュー操作の管理
   const result = useResultActions({
@@ -38,6 +41,7 @@ export function usePlayLogic() {
     maze,
     move,
     playMoveSe: audio.playMoveSe,
+    playBumpSe: audio.playBumpSe,
     width,
   });
 


### PR DESCRIPTION
## Summary
- replace default BGM with `降りしきる、白_調整.mp3`
- switch to `日没廃校_調整.mp3` when starting level2
- update movement SE and add bump SE
- play bump SE on wall collision
- expose function to change BGM dynamically

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4fc08330832c989d7bec3004024f