### PR TITLE
ステージバナーのログ追加

### DIFF
--- a/components/StageBanner.tsx
+++ b/components/StageBanner.tsx
@@ -16,12 +16,22 @@ export function StageBanner({
   onFinish: () => void;
 }) {
   useEffect(() => {
+    // 表示状態やステージ番号が変わるたびにログを出す
+    console.log(
+      `[StageBanner] visible=${visible}, stage=${stage}`
+    );
     if (!visible) return;
     // 初期化処理がすぐ終わっても最低 2 秒は表示する
     // 2000 は 2 秒をミリ秒で表した数値
-    const id = setTimeout(onFinish, 2000);
-    return () => clearTimeout(id);
-  }, [visible, onFinish]);
+    const id = setTimeout(() => {
+      console.log(`[StageBanner] onFinish stage=${stage}`);
+      onFinish();
+    }, 2000);
+    return () => {
+      console.log(`[StageBanner] cleanup stage=${stage}`);
+      clearTimeout(id);
+    };
+  }, [visible, stage, onFinish]);
 
   if (!visible) return null;
   return (


### PR DESCRIPTION
## Summary
- StageBannerのuseEffect内にログを追加

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686c523a039c832cbe3a5f11d6776afb