### PR TITLE
fix modal confirm order

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -241,9 +241,10 @@ export default function TitleScreen() {
             </ThemedText>
             <PlainButton
               title={t("yes")}
-              onPress={() => {
-                if (pendingLevel) confirmStart(pendingLevel);
+              /* まずモーダルを閉じてからゲーム開始処理を await */
+              onPress={async () => {
                 setConfirmReset(false);
+                if (pendingLevel) await confirmStart(pendingLevel);
               }}
               accessibilityLabel={t("yes")}
             />


### PR DESCRIPTION
## Summary
- handle reset modal: close first then await start

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686c5e16e670832cacb372e87edba457