### PR TITLE
Add environment toggle for StageBanner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ IOS_ADMOB_APP_ID=ca-app-pub-xxxxxxxxxxxxxxxx~iosappid
 # - 本番広告を表示したいときはここに本番IDを記入
 # - テスト広告だけで良い場合は行ごと削除するか空欄にします
 EXPO_PUBLIC_ADMOB_INTERSTITIAL_ID=ca-app-pub-xxxxxxxxxxxxxxxx/interstitial
+
+# ステージバナーを無効化したいときは true
+EXPO_PUBLIC_DISABLE_STAGE_BANNER=false

--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ mazesense/
 pnpm exec node scripts/update-maze-import.js
 ```
 
+## デバッグ用オプション
+
+ステージ開始時に表示される黒画面のバナーをスキップしたい場合は
+`.env` に次の行を追加します。
+
+```bash
+EXPO_PUBLIC_DISABLE_STAGE_BANNER=true
+```
+
+値を `false` または未設定にすると通常通りバナーが表示されます。
+
 ## β版の配布について
 
 現在のバージョンはテスト目的の β 版です。TestFlight もしくは Google Play の内部

--- a/components/StageBanner.tsx
+++ b/components/StageBanner.tsx
@@ -2,6 +2,11 @@ import React, { useEffect } from "react";
 import { Modal, StyleSheet, View } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 
+// 環境変数 EXPO_PUBLIC_DISABLE_STAGE_BANNER が 'true' のとき
+// ステージバナーを表示せず即座に onFinish を呼び出す
+const DISABLE_STAGE_BANNER =
+  process.env.EXPO_PUBLIC_DISABLE_STAGE_BANNER === "true";
+
 /**
  * ステージ番号を表示するオーバーレイコンポーネント
  * visible が true の間だけ表示し、2 秒後に onFinish を呼び出す
@@ -15,12 +20,19 @@ export function StageBanner({
   stage: number;
   onFinish: () => void;
 }) {
+  // ステージバナーを無効化している場合、表示要求があれば即終了する
+  useEffect(() => {
+    if (DISABLE_STAGE_BANNER && visible) {
+      onFinish();
+    }
+  }, [visible, onFinish]);
+
   useEffect(() => {
     // 表示状態やステージ番号が変わるたびにログを出す
     console.log(
       `[StageBanner] visible=${visible}, stage=${stage}`
     );
-    if (!visible) return;
+    if (!visible || DISABLE_STAGE_BANNER) return;
     // 初期化処理がすぐ終わっても最低 2 秒は表示する
     // 2000 は 2 秒をミリ秒で表した数値
     const id = setTimeout(() => {
@@ -33,7 +45,7 @@ export function StageBanner({
     };
   }, [visible, stage, onFinish]);
 
-  if (!visible) return null;
+  if (!visible || DISABLE_STAGE_BANNER) return null;
   return (
     <Modal
       transparent


### PR DESCRIPTION
## Summary
- toggle StageBanner via `EXPO_PUBLIC_DISABLE_STAGE_BANNER`
- document debug option and env var
- update sample `.env`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686c7f913850832ca758250a0cac3eb9