### PR TITLE
Handle banner reset after modal fade

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -38,6 +38,7 @@ export default function PlayScreen() {
     showBanner,
     bannerStage,
     handleBannerFinish,
+    handleBannerDismiss,
     handleMove,
     handleOk,
     handleRespawn,
@@ -158,6 +159,7 @@ export default function PlayScreen() {
         visible={showBanner}
         stage={bannerStage}
         onFinish={handleBannerFinish}
+        onDismiss={handleBannerDismiss}
       />
     </View>
   );

--- a/components/StageBanner.tsx
+++ b/components/StageBanner.tsx
@@ -15,10 +15,12 @@ export function StageBanner({
   visible,
   stage,
   onFinish,
+  onDismiss,
 }: {
   visible: boolean;
   stage: number;
   onFinish: () => void;
+  onDismiss?: () => void;
 }) {
   // ステージバナーを無効化している場合、表示要求があれば即終了する
   useEffect(() => {
@@ -52,6 +54,7 @@ export function StageBanner({
       visible
       animationType="fade"
       presentationStyle="overFullScreen"
+      onDismiss={onDismiss}
     >
       <View
         style={styles.wrapper}

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -260,13 +260,16 @@ export function useResultActions({
   const handleBannerFinish = useCallback(() => {
     setShowBanner(false);
     bannerActiveRef.current = false;
-    // 番号を初期化して前ステージの残像を防ぐ
-    setBannerStage(0);
     // バナー表示後に OK ボタンのラベルを戻す
     setOkLabel(t("ok"));
     okLockedRef.current = false;
     setOkLocked(false);
-  }, [setShowBanner, setBannerStage, setOkLabel, setOkLocked, t]);
+  }, [setShowBanner, setOkLabel, setOkLocked, t]);
+
+  // モーダルのフェードアウトが終わった後に番号をリセットする
+  const handleBannerDismiss = useCallback(() => {
+    setBannerStage(0);
+  }, [setBannerStage]);
 
   // リセット処理
   const handleReset = () => {
@@ -310,6 +313,7 @@ export function useResultActions({
     showBanner,
     bannerStage,
     handleBannerFinish,
+    handleBannerDismiss,
     handleOk,
     handleReset,
     handleExit,


### PR DESCRIPTION
## Summary
- add `onDismiss` support in StageBanner
- call `setBannerStage(0)` after modal fade-out
- wire up handleBannerDismiss in PlayScreen

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686c83594700832c8a76ffdee6cf49cf