### PR TITLE
セーブリセット確認をページ化

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -43,6 +43,7 @@ export default function RootLayout() {
                 <Stack.Screen name="practice" options={{ headerShown: false }} />
                 <Stack.Screen name="scores" options={{ headerShown: false }} />
                 <Stack.Screen name="play" options={{ headerShown: false }} />
+                <Stack.Screen name="reset" options={{ headerShown: false }} />
                 <Stack.Screen name="+not-found" />
               </Stack>
             </GameProvider>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -22,8 +22,6 @@ export default function TitleScreen() {
 
   const [showLang, setShowLang] = React.useState(false);
   const [hasSave, setHasSave] = React.useState(false);
-  const [confirmReset, setConfirmReset] = React.useState(false);
-  const [pendingLevel, setPendingLevel] = React.useState<string | null>(null);
   const [showVolume, setShowVolume] = React.useState(false);
 
   // BGM/SE を制御
@@ -52,10 +50,6 @@ export default function TitleScreen() {
     })();
   }, []);
 
-  // confirmReset の表示状態を監視して開閉をログに残す
-  React.useEffect(() => {
-    console.log('[TitleScreen] confirmReset', confirmReset ? 'open' : 'closed');
-  }, [confirmReset]);
 
   const select = (lang: Lang) => {
     changeLang(lang);
@@ -95,10 +89,8 @@ export default function TitleScreen() {
     // 開始をログ出力
     console.log('[TitleScreen] startLevelFromStart begin', id);
     if (hasSave) {
-      setPendingLevel(id);
-      // 確認モーダルを開くタイミングでログも残す
-      console.log('[TitleScreen] confirmReset open', id);
-      setConfirmReset(true);
+      // 進行中データがある場合は確認ページへ遷移
+      router.push(`/reset?level=${id}`);
     } else {
       confirmStart(id);
     }
@@ -261,36 +253,6 @@ export default function TitleScreen() {
         </View>
       </Modal>
 
-      {/* ───── セーブリセット確認モーダル ───── */}
-      <Modal transparent visible={confirmReset} animationType="fade">
-        <View style={styles.modalWrapper} accessible accessibilityLabel="リセット確認オーバーレイ">
-          <ThemedView style={styles.modalContent}>
-            <ThemedText type="title" lightColor="#fff" darkColor="#fff">
-              {t("confirmReset")}
-            </ThemedText>
-            <PlainButton
-              title={t("yes")}
-              /* モーダルを閉じてから遷移を開始する */
-              onPress={async () => {
-                console.log('[TitleScreen] confirmReset yes', pendingLevel);
-                // モーダルを閉じたことをログに記録
-                console.log('[TitleScreen] confirmReset close');
-                setConfirmReset(false);
-                if (pendingLevel) await confirmStart(pendingLevel);
-              }}
-              accessibilityLabel={t("yes")}
-            />
-            <PlainButton
-              title={t("cancel")}
-              onPress={() => {
-                console.log('[TitleScreen] confirmReset cancel');
-                setConfirmReset(false);
-              }}
-              accessibilityLabel={t("cancel")}
-            />
-          </ThemedView>
-        </View>
-      </Modal>
     </ThemedView>
   );
 }

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+
+import { PlainButton } from '@/components/PlainButton';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { LEVELS } from '@/constants/levels';
+import { clearGame } from '@/src/game/saveGame';
+import { useGame } from '@/src/game/useGame';
+import { useLocale } from '@/src/locale/LocaleContext';
+import { useBgm } from '@/src/hooks/useBgm';
+
+export default function ResetConfirmScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams();
+  const levelId = typeof params.level === 'string' ? params.level : undefined;
+  const { newGame } = useGame();
+  const { t } = useLocale();
+  const { change } = useBgm();
+
+  const start = async () => {
+    if (!levelId) {
+      router.replace('/');
+      return;
+    }
+    const level = LEVELS.find((lv) => lv.id === levelId);
+    if (!level) {
+      router.replace('/');
+      return;
+    }
+    await clearGame();
+    if (levelId === 'level2') {
+      change(require('../assets/sounds/日没廃校_調整.mp3'));
+    } else {
+      change(require('../assets/sounds/降りしきる、白_調整.mp3'));
+    }
+    newGame(
+      level.size,
+      level.enemies,
+      level.enemyPathLength,
+      level.playerPathLength,
+      level.wallLifetime,
+      level.enemyCountsFn,
+      level.wallLifetimeFn,
+      level.biasedSpawn,
+      level.id,
+    );
+    router.replace('/play');
+  };
+
+  return (
+    <ThemedView lightColor="#000" darkColor="#000" style={styles.container}>
+      <ThemedText type="title" lightColor="#fff" darkColor="#fff">
+        {t('confirmReset')}
+      </ThemedText>
+      <PlainButton title={t('yes')} onPress={start} accessibilityLabel={t('yes')} />
+      <PlainButton
+        title={t('backToTitle')}
+        onPress={() => router.replace('/')}
+        accessibilityLabel={t('backToTitle')}
+      />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 20 },
+});


### PR DESCRIPTION
## Summary
- confirmReset モーダルを削除し `/reset` ページを追加
- レベル選択時に保存データがある場合は `/reset` へ遷移
- 追加ページではリセット確定後に新規ゲームを開始しホームへ戻る
- ルーティング設定に reset スクリーンを登録

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686c8e48ef88832c86e750544843acac