### PR TITLE
Fix next stage load after banner

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -79,6 +79,8 @@ export function useResultActions({
   // ステージ1バナーを一度だけ表示したかを記録するフラグ
   // useRef を使うことで表示済みかどうかを状態として保持する
   const bannerShownRef = useRef(false);
+  // バナー終了後に次ステージを読み込むかどうかを判定するフラグ
+  const nextStageRef = useRef(false);
 
   // ゲーム開始直後にステージ1バナーを表示する
   // 条件: ステージ1かつ移動回数0であること
@@ -223,11 +225,8 @@ export function useResultActions({
     setShowBanner(true);
     // バナー表示中は判定をスキップするためフラグを立てる
     bannerActiveRef.current = true;
-
-    // ステージクリア時はここで即座に次ステージを開始する
-    if (wasStageClear) {
-      nextStage();
-    }
+    // ステージクリアしている場合はバナー終了後に次ステージを読み込む
+    nextStageRef.current = wasStageClear;
 
 
     // リザルト関連のフラグをリセットする
@@ -264,7 +263,12 @@ export function useResultActions({
     setOkLabel(t("ok"));
     okLockedRef.current = false;
     setOkLocked(false);
-  }, [setShowBanner, setOkLabel, setOkLocked, t]);
+    // 次ステージ読み込みが予約されていればここで実行
+    if (nextStageRef.current) {
+      nextStage();
+      nextStageRef.current = false;
+    }
+  }, [setShowBanner, setOkLabel, setOkLocked, t, nextStage]);
 
   // モーダルのフェードアウトが終わった後に番号をリセットする
   const handleBannerDismiss = useCallback(() => {


### PR DESCRIPTION
## Summary
- delay loading the next stage until the stage banner finishes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686c91e9c87c832c912dd6aea3ca0fe3