### PR TITLE
Add debug flag for skipping ads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ EXPO_PUBLIC_ADMOB_INTERSTITIAL_ID=ca-app-pub-xxxxxxxxxxxxxxxx/interstitial
 
 # ステージバナーを無効化したいときは true
 EXPO_PUBLIC_DISABLE_STAGE_BANNER=false
+# 広告表示を完全に無効化したいときは true
+EXPO_PUBLIC_DISABLE_ADS=false

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 import mobileAds from 'react-native-google-mobile-ads';
 import { Platform } from 'react-native';
+import { DISABLE_ADS } from '@/src/ads/interstitial';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { GameProvider } from '@/src/game/useGame';
@@ -19,9 +20,9 @@ export default function RootLayout() {
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
 
-  // Google Mobile Ads SDK を初期化する。web 環境では広告 SDK が利用できないため判定する
+  // Google Mobile Ads SDK を初期化する。web 環境や広告無効化時はスキップ
   useEffect(() => {
-    if (Platform.OS !== 'web') {
+    if (!DISABLE_ADS && Platform.OS !== 'web') {
       // OS は Android/iOS のいずれか。ここで初期化しないと広告が表示されないことがある
       mobileAds().initialize();
     }

--- a/src/ads/interstitial.ts
+++ b/src/ads/interstitial.ts
@@ -7,13 +7,16 @@ const TEST_ID = TestIds.INTERSTITIAL;
 // 本番用ID。環境変数が無ければテストIDを使用
 export const AD_UNIT_ID = process.env.EXPO_PUBLIC_ADMOB_INTERSTITIAL_ID ?? TEST_ID;
 
+// 環境変数 EXPO_PUBLIC_DISABLE_ADS が 'true' のとき広告関連処理を無効化する
+export const DISABLE_ADS = process.env.EXPO_PUBLIC_DISABLE_ADS === 'true';
+
 /**
  * インタースティシャル広告を読み込みつつ表示する関数
  * 広告が閉じられると解決します
  */
 export async function showInterstitial() {
-  // Web 環境では広告が表示できないためすぐ解決します
-  if (Platform.OS === 'web') {
+  // Web 環境や広告無効化フラグが立っている場合はすぐ解決します
+  if (Platform.OS === 'web' || DISABLE_ADS) {
     return Promise.resolve();
   }
 
@@ -54,7 +57,7 @@ export async function showInterstitial() {
  * 広告だけを事前に読み込む関数。成功時は InterstitialAd を返す
  */
 export async function loadInterstitial(): Promise<InterstitialAd | null> {
-  if (Platform.OS === 'web') return Promise.resolve(null);
+  if (Platform.OS === 'web' || DISABLE_ADS) return Promise.resolve(null);
   const ad = InterstitialAd.createForAdRequest(AD_UNIT_ID);
   return new Promise((resolve) => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -83,7 +86,7 @@ export async function loadInterstitial(): Promise<InterstitialAd | null> {
  * 読み込み済み広告を表示する関数
  */
 export async function showLoadedInterstitial(ad: InterstitialAd) {
-  if (Platform.OS === 'web') return Promise.resolve();
+  if (Platform.OS === 'web' || DISABLE_ADS) return Promise.resolve();
   return new Promise<void>((resolve) => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     const unsubscribe = ad.addAdEventsListener(({ type }) => {

--- a/src/hooks/useStageEffects.ts
+++ b/src/hooks/useStageEffects.ts
@@ -2,6 +2,7 @@ import {
   loadInterstitial,
   showLoadedInterstitial,
   type InterstitialAd,
+  DISABLE_ADS,
 } from "@/src/ads/interstitial";
 import { useCallback } from "react";
 
@@ -31,7 +32,7 @@ export function useStageEffects({
     async (stage: number): Promise<InterstitialAd | null> => {
       const shouldShow = shouldShowAd(stage);
       console.log("loadAdIfNeeded", { stage, shouldShow });
-      if (!shouldShow) return null;
+      if (!shouldShow || DISABLE_ADS) return null;
       return loadInterstitial();
     },
     [],
@@ -40,7 +41,7 @@ export function useStageEffects({
   // 広告表示処理をメモ化。BGM 制御や通知を依存として指定
   const showAd = useCallback(
     async (ad: InterstitialAd | null): Promise<boolean> => {
-      if (!ad) return false;
+      if (!ad || DISABLE_ADS) return false;
       try {
         pauseBgm();
         await showLoadedInterstitial(ad);


### PR DESCRIPTION
## Summary
- add `EXPO_PUBLIC_DISABLE_ADS` to `.env.example`
- skip AdMob initialization when ads are disabled
- guard all interstitial functions and hooks with the disable flag

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686c954d188c832cb3de00ac8f648a95