### PR TITLE
ステージ移行処理の調整

### DIFF
--- a/src/game/__tests__/resultActions.test.ts
+++ b/src/game/__tests__/resultActions.test.ts
@@ -56,7 +56,7 @@ jest.mock('@/src/hooks/useHighScore', () => ({
   }),
 }));
 
-const showAdIfNeeded = jest.fn(async () => {
+const showAd = jest.fn(async () => {
   // 広告表示時点でリザルト関連フラグが全て false になっているか確認
   expect(showResult).toBe(false);
   expect(stageClear).toBe(true);
@@ -65,7 +65,7 @@ const showAdIfNeeded = jest.fn(async () => {
 });
 
 jest.mock('@/src/hooks/useStageEffects', () => ({
-  useStageEffects: () => ({ showAdIfNeeded }),
+  useStageEffects: () => ({ showAd }),
 }));
 
 import { useResultActions } from '@/src/hooks/useResultActions';
@@ -96,7 +96,7 @@ describe('handleOk の広告表示後処理', () => {
 
     await actions.handleOk();
 
-    expect(showAdIfNeeded).toHaveBeenCalledWith(2);
+    expect(showAd).toHaveBeenCalled();
     expect(nextStage).not.toHaveBeenCalled();
     expect(showResult).toBe(true);
     expect(stageClear).toBe(true);
@@ -123,7 +123,7 @@ describe('handleOk の広告表示後処理', () => {
 
     await actions.handleOk();
 
-    expect(showAdIfNeeded).not.toHaveBeenCalled();
+    expect(showAd).not.toHaveBeenCalled();
     expect(nextStage).toHaveBeenCalled();
     expect(showResult).toBe(false);
     expect(stageClear).toBe(false);
@@ -135,7 +135,7 @@ describe('handleOk の広告表示後処理', () => {
     const router = { replace: jest.fn() };
 
     // このテストでは広告を表示しない想定で false を返す
-    showAdIfNeeded.mockResolvedValueOnce(false);
+    showAd.mockResolvedValueOnce(false);
 
     const actions = useResultActions({
       state: { stage: 3 } as any,
@@ -150,7 +150,7 @@ describe('handleOk の広告表示後処理', () => {
 
     await actions.handleOk();
 
-    expect(showAdIfNeeded).toHaveBeenCalledWith(3);
+    expect(showAd).toHaveBeenCalled();
     // 広告が無いのでそのまま次ステージへ
     expect(nextStage).toHaveBeenCalled();
     expect(showResult).toBe(false);
@@ -179,7 +179,7 @@ describe('handleOk の広告表示後処理', () => {
     await actions.handleOk();
 
     // 広告やステージ遷移は呼ばれない
-    expect(showAdIfNeeded).not.toHaveBeenCalled();
+    expect(showAd).not.toHaveBeenCalled();
     expect(nextStage).not.toHaveBeenCalled();
 
     // リザルト関連フラグは false のまま
@@ -215,7 +215,7 @@ describe('handleOk の広告表示後処理', () => {
     await actions.handleOk();
     await Promise.resolve();
 
-    expect(showAdIfNeeded).toHaveBeenCalledWith(2);
+    expect(showAd).toHaveBeenCalled();
     expect(nextStage).not.toHaveBeenCalled();
     expect(showResult).toBe(true);
     expect(stageClear).toBe(true);

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -79,8 +79,6 @@ export function useResultActions({
   // ステージ1バナーを一度だけ表示したかを記録するフラグ
   // useRef を使うことで表示済みかどうかを状態として保持する
   const bannerShownRef = useRef(false);
-  // バナー終了後に次ステージを読み込むかどうかを判定するフラグ
-  const nextStageRef = useRef(false);
 
   // ゲーム開始直後にステージ1バナーを表示する
   // 条件: ステージ1かつ移動回数0であること
@@ -219,14 +217,18 @@ export function useResultActions({
       }
     }
 
+    // ステージをクリアしていれば先に次のステージを読み込む
+    // "ステージ" はゲームの進行段階を指す用語
+    if (wasStageClear) {
+      nextStage();
+    }
+
     // 次ステージ番号を表示しながら内部状態を初期化する
     // 先にバナーを表示することで画面遷移をスムーズにする
     setBannerStage(state.stage + 1);
     setShowBanner(true);
     // バナー表示中は判定をスキップするためフラグを立てる
     bannerActiveRef.current = true;
-    // ステージクリアしている場合はバナー終了後に次ステージを読み込む
-    nextStageRef.current = wasStageClear;
 
 
     // リザルト関連のフラグをリセットする
@@ -263,12 +265,7 @@ export function useResultActions({
     setOkLabel(t("ok"));
     okLockedRef.current = false;
     setOkLocked(false);
-    // 次ステージ読み込みが予約されていればここで実行
-    if (nextStageRef.current) {
-      nextStage();
-      nextStageRef.current = false;
-    }
-  }, [setShowBanner, setOkLabel, setOkLocked, t, nextStage]);
+  }, [setShowBanner, setOkLabel, setOkLocked, t]);
 
   // モーダルのフェードアウトが終わった後に番号をリセットする
   const handleBannerDismiss = useCallback(() => {


### PR DESCRIPTION
## 変更点
- ステージクリア時に `handleOk` 内で即 `nextStage()` を実行するよう変更
- `nextStageRef` を削除し `handleBannerFinish` を簡素化
- ユニットテストを現仕様に合わせ修正

## テスト
- `pnpm lint` 実行でエラーが無いことを確認

------
https://chatgpt.com/codex/tasks/task_e_686ccf9336b0832cbce7c71e825d89c1