### PR TITLE
Fix next stage timing

### DIFF
--- a/src/game/__tests__/resultActions.test.ts
+++ b/src/game/__tests__/resultActions.test.ts
@@ -70,16 +70,17 @@ jest.mock('@/src/hooks/useHighScore', () => ({
   }),
 }));
 
-const showAdIfNeeded = jest.fn(async () => {
-  // 広告表示時点でリザルト関連フラグが全て false になっているか確認
+const loadAdIfNeeded = jest.fn();
+const showAd = jest.fn(async () => {
+  // 広告表示時の状態を確認する
   expect(showResult).toBe(false);
   expect(stageClear).toBe(true);
-  // テストでは広告が表示された想定で true を返す
+  // 広告が表示された想定で true を返す
   return true;
 });
 
 jest.mock('@/src/hooks/useStageEffects', () => ({
-  useStageEffects: () => ({ showAdIfNeeded }),
+  useStageEffects: () => ({ loadAdIfNeeded, showAd }),
 }));
 
 import { useResultActions } from '@/src/hooks/useResultActions';
@@ -110,7 +111,7 @@ describe('handleOk の広告表示後処理', () => {
 
     await actions.handleOk();
 
-    expect(showAdIfNeeded).toHaveBeenCalledWith(2);
+    expect(showAd).toHaveBeenCalledWith(null);
     expect(nextStage).not.toHaveBeenCalled();
     expect(showResult).toBe(true);
     expect(stageClear).toBe(true);
@@ -137,7 +138,7 @@ describe('handleOk の広告表示後処理', () => {
 
     await actions.handleOk();
 
-    expect(showAdIfNeeded).not.toHaveBeenCalled();
+    expect(showAd).not.toHaveBeenCalled();
     expect(nextStage).toHaveBeenCalled();
     expect(showResult).toBe(false);
     expect(stageClear).toBe(false);
@@ -149,7 +150,7 @@ describe('handleOk の広告表示後処理', () => {
     const router = { replace: jest.fn() };
 
     // このテストでは広告を表示しない想定で false を返す
-    showAdIfNeeded.mockResolvedValueOnce(false);
+    showAd.mockResolvedValueOnce(false);
 
     const actions = useResultActions({
       state: { stage: 3 } as any,
@@ -164,7 +165,7 @@ describe('handleOk の広告表示後処理', () => {
 
     await actions.handleOk();
 
-    expect(showAdIfNeeded).toHaveBeenCalledWith(3);
+    expect(showAd).toHaveBeenCalledWith(null);
     // 広告が無いのでそのまま次ステージへ
     expect(nextStage).toHaveBeenCalled();
     expect(showResult).toBe(false);
@@ -193,7 +194,7 @@ describe('handleOk の広告表示後処理', () => {
     await actions.handleOk();
 
     // 広告やステージ遷移は呼ばれない
-    expect(showAdIfNeeded).not.toHaveBeenCalled();
+    expect(showAd).not.toHaveBeenCalled();
     expect(nextStage).not.toHaveBeenCalled();
 
     // リザルト関連フラグは false のまま
@@ -229,7 +230,7 @@ describe('handleOk の広告表示後処理', () => {
     await actions.handleOk();
     await Promise.resolve();
 
-    expect(showAdIfNeeded).toHaveBeenCalledWith(2);
+    expect(showAd).toHaveBeenCalledWith(null);
     expect(nextStage).not.toHaveBeenCalled();
     expect(showResult).toBe(true);
     expect(stageClear).toBe(true);

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -78,8 +78,6 @@ export function useResultActions({
   const okLockedRef = useRef(false);
   // バナー表示中かどうかを判定するフラグ。表示中はリザルト判定を行わない
   const bannerActiveRef = useRef(false);
-  // バナー終了後に次ステージを読み込むかどうかを判定するフラグ
-  const nextStageRef = useRef(false);
 
   // ゲーム開始直後にステージ1バナーを表示する
   // 条件: ステージ1かつ移動回数0であること
@@ -220,14 +218,16 @@ export function useResultActions({
       }
     }
 
-    // 次ステージ番号を表示しながら内部状態を初期化する
-    // 先にバナーを表示することで画面遷移をスムーズにする
+    // 次ステージ番号を表示するため事前に値をセット
     setBannerStage(state.stage + 1);
+    // ステージクリア時はここでステージを進める
+    if (wasStageClear) {
+      nextStage();
+    }
+    // バナー表示で演出を行う
     setShowBanner(true);
-    // バナー表示中は判定をスキップするためフラグを立てる
+    // バナー表示中は判定をスキップする
     bannerActiveRef.current = true;
-    // ステージクリアしている場合はバナー終了後に次ステージを読み込む
-    nextStageRef.current = wasStageClear;
 
 
     // リザルト関連のフラグをリセットする
@@ -264,12 +264,7 @@ export function useResultActions({
     setOkLabel(t("ok"));
     okLockedRef.current = false;
     setOkLocked(false);
-    // 次ステージ読み込みが予約されていればここで実行
-    if (nextStageRef.current) {
-      nextStage();
-      nextStageRef.current = false;
-    }
-  }, [setShowBanner, setOkLabel, setOkLocked, t, nextStage]);
+  }, [setShowBanner, setOkLabel, setOkLocked, t]);
 
   // モーダルのフェードアウトが終わった後に番号をリセットする
   const handleBannerDismiss = useCallback(() => {


### PR DESCRIPTION
## Summary
- advance game stage inside `handleOk` before showing stage banner
- clean up next stage flag handling
- update tests for new `handleOk` logic

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686cd197a74c832cbf4e124825a485c8