### PR TITLE
feat: add snackbar error handling

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -4,6 +4,7 @@ import { PlainButton } from "@/components/PlainButton";
 import { useRouter } from "expo-router";
 import { useGame } from "@/src/game/useGame";
 import { loadGame, clearGame } from "@/src/game/saveGame";
+import { useSnackbar } from "@/src/hooks/useSnackbar";
 import {
   useLocale,
   type Lang,
@@ -19,6 +20,7 @@ export default function TitleScreen() {
   const router = useRouter();
   const { newGame, loadState } = useGame();
   const { t, firstLaunch, changeLang } = useLocale();
+  const { show: showSnackbar } = useSnackbar();
 
   const [showLang, setShowLang] = React.useState(false);
   const [hasSave, setHasSave] = React.useState(false);
@@ -45,10 +47,10 @@ export default function TitleScreen() {
   // セーブデータ有無を確認
   React.useEffect(() => {
     (async () => {
-      const data = await loadGame();
+      const data = await loadGame({ showError: showSnackbar });
       setHasSave(!!data);
     })();
-  }, []);
+  }, [showSnackbar]);
 
 
   const select = (lang: Lang) => {
@@ -101,7 +103,7 @@ export default function TitleScreen() {
   const confirmStart = async (id: string) => {
     // 開始をログ出力
     console.log('[TitleScreen] confirmStart begin', id);
-    await clearGame();
+    await clearGame({ showError: showSnackbar });
     setHasSave(false);
     await startLevel(id);
     // 処理完了をログ出力
@@ -111,7 +113,7 @@ export default function TitleScreen() {
   const resumeGame = async () => {
     // 開始をログ出力
     console.log('[TitleScreen] resumeGame begin');
-    const data = await loadGame();
+    const data = await loadGame({ showError: showSnackbar });
     if (!data) {
       console.log('[TitleScreen] resumeGame no data');
       return;

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -7,6 +7,7 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { LEVELS } from '@/constants/levels';
 import { clearGame } from '@/src/game/saveGame';
+import { useSnackbar } from '@/src/hooks/useSnackbar';
 import { useGame } from '@/src/game/useGame';
 import { useLocale } from '@/src/locale/LocaleContext';
 import { useBgm } from '@/src/hooks/useBgm';
@@ -18,6 +19,7 @@ export default function ResetConfirmScreen() {
   const { newGame } = useGame();
   const { t } = useLocale();
   const { change } = useBgm();
+  const { show: showSnackbar } = useSnackbar();
 
   const start = async () => {
     if (!levelId) {
@@ -29,7 +31,7 @@ export default function ResetConfirmScreen() {
       router.replace('/');
       return;
     }
-    await clearGame();
+    await clearGame({ showError: showSnackbar });
     if (levelId === 'level2') {
       change(require('../assets/sounds/日没廃校_調整.mp3'));
     } else {

--- a/src/game/highScore.ts
+++ b/src/game/highScore.ts
@@ -12,12 +12,20 @@ const PREFIX = 'highscore:';
  * ハイスコアを取得する非同期関数。
  * データが無い場合は null を返す。
  */
-export async function loadHighScore(levelId: string): Promise<HighScore | null> {
+export interface HighScoreOptions {
+  showError?: (msg: string) => void;
+}
+
+export async function loadHighScore(
+  levelId: string,
+  opts?: HighScoreOptions,
+): Promise<HighScore | null> {
   try {
     const json = await AsyncStorage.getItem(PREFIX + levelId);
     return json ? (JSON.parse(json) as HighScore) : null;
-  } catch {
-    // エラー時は null を返す
+  } catch (e) {
+    console.error('loadHighScore error', e);
+    opts?.showError?.('ハイスコアを読み込めませんでした');
     return null;
   }
 }
@@ -25,11 +33,16 @@ export async function loadHighScore(levelId: string): Promise<HighScore | null> 
 /**
  * ハイスコアを保存する非同期関数。
  */
-export async function saveHighScore(levelId: string, score: HighScore): Promise<void> {
+export async function saveHighScore(
+  levelId: string,
+  score: HighScore,
+  opts?: HighScoreOptions,
+): Promise<void> {
   try {
     await AsyncStorage.setItem(PREFIX + levelId, JSON.stringify(score));
-  } catch {
-    // 保存に失敗しても無視する
+  } catch (e) {
+    console.error('saveHighScore error', e);
+    opts?.showError?.('ハイスコアを保存できませんでした');
   }
 }
 

--- a/src/game/saveGame.ts
+++ b/src/game/saveGame.ts
@@ -99,32 +99,40 @@ export function decodeState(data: StoredState): State {
 }
 
 // データを保存する
-export async function saveGame(state: State) {
+export interface SaveLoadOptions {
+  showError?: (msg: string) => void;
+}
+
+export async function saveGame(state: State, opts?: SaveLoadOptions) {
   try {
     const data = encodeState(state);
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-  } catch {
-    // 失敗時は無視
+  } catch (e) {
+    console.error('saveGame error', e);
+    opts?.showError?.('セーブデータを保存できませんでした');
   }
 }
 
 // 保存データを読み込む
-export async function loadGame(): Promise<State | null> {
+export async function loadGame(opts?: SaveLoadOptions): Promise<State | null> {
   try {
     const json = await AsyncStorage.getItem(STORAGE_KEY);
     if (!json) return null;
     const data = JSON.parse(json) as StoredState;
     return decodeState(data);
-  } catch {
+  } catch (e) {
+    console.error('loadGame error', e);
+    opts?.showError?.('セーブデータの読み込みに失敗しました');
     return null;
   }
 }
 
 // 保存データを削除する
-export async function clearGame() {
+export async function clearGame(opts?: SaveLoadOptions) {
   try {
     await AsyncStorage.removeItem(STORAGE_KEY);
-  } catch {
-    // 失敗しても無視
+  } catch (e) {
+    console.error('clearGame error', e);
+    opts?.showError?.('セーブデータを削除できませんでした');
   }
 }

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useReducer, useRef, type ReactNode } from 'react';
+import { useSnackbar } from '@/src/hooks/useSnackbar';
 import { canMove } from './maze';
 import { loadMaze } from './loadMaze';
 import { saveGame } from './saveGame';
@@ -38,6 +39,7 @@ const GameContext = createContext<
 >(undefined);
 
 export function GameProvider({ children }: { children: ReactNode }) {
+  const { show: showSnackbar } = useSnackbar();
   // useReducer 第3引数を使って初期迷路を読み込む
   const [state, dispatch] = useReducer(reducer, loadMaze(10), createFirstStage);
   // 初回の useEffect 実行をスキップするためのフラグ
@@ -86,8 +88,8 @@ export function GameProvider({ children }: { children: ReactNode }) {
       first.current = false;
       return;
     }
-    saveGame(state);
-  }, [state]);
+    saveGame(state, { showError: showSnackbar });
+  }, [state, showSnackbar]);
 
   return (
     <GameContext.Provider

--- a/src/hooks/useHighScore.ts
+++ b/src/hooks/useHighScore.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
+import { useSnackbar } from '@/src/hooks/useSnackbar';
 import {
   loadHighScore,
   saveHighScore,
@@ -11,6 +12,7 @@ import {
  * levelId が変わるたびにスコアを読み込み直す。
  */
 export function useHighScore(levelId: string | null | undefined) {
+  const { show: showSnackbar } = useSnackbar();
   // 現在保存されているハイスコア
   const [highScore, setHighScore] = useState<HighScore | null>(null);
   // 新記録かどうかを示すフラグ
@@ -24,11 +26,11 @@ export function useHighScore(levelId: string | null | undefined) {
       return;
     }
     (async () => {
-      const hs = await loadHighScore(levelId);
+      const hs = await loadHighScore(levelId, { showError: showSnackbar });
       setHighScore(hs);
       setNewRecord(false);
     })();
-  }, [levelId]);
+  }, [levelId, showSnackbar]);
 
   /**
    * 現在のスコアを渡して、より良い記録なら保存する。
@@ -36,16 +38,16 @@ export function useHighScore(levelId: string | null | undefined) {
    */
   const updateScore = useCallback(async (score: HighScore, finalStage: boolean) => {
     if (!levelId) return;
-    const old = await loadHighScore(levelId);
+    const old = await loadHighScore(levelId, { showError: showSnackbar });
     const better = isBetterScore(old, score);
     if (better) {
-      await saveHighScore(levelId, score);
+      await saveHighScore(levelId, score, { showError: showSnackbar });
       setHighScore(score);
     } else {
       setHighScore(old);
     }
     setNewRecord(better && finalStage);
-  }, [levelId]);
+  }, [levelId, showSnackbar]);
 
   return { highScore, newRecord, setNewRecord, updateScore } as const;
 }


### PR DESCRIPTION
## Summary
- improve error handling for save/load/high score operations
- display snackbar messages on failure
- integrate snackbar in Title and Reset screens

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d009f40cc832c9a36724d1dcd91f4