### PR TITLE
fix: SE が遅れる問題を解消

### DIFF
--- a/src/hooks/useMoveHandler.ts
+++ b/src/hooks/useMoveHandler.ts
@@ -56,10 +56,12 @@ export function useMoveHandler({
 
     let wait: number;
     if (!move(dir)) {
-      wait = applyBumpFeedback(borderW, setBorderColor);
+      // 壁にぶつかったら即座に効果音を鳴らす
       playBumpSe();
+      wait = applyBumpFeedback(borderW, setBorderColor);
       setTimeout(() => setBorderColor('transparent'), wait);
     } else {
+      // 移動成功時も先に効果音を鳴らす
       playMoveSe();
       const maxDist = (maze.size - 1) * 2;
       const { wait: w, id } = applyDistanceFeedback(


### PR DESCRIPTION
## Summary
- 壁衝突時と移動成功時の効果音の呼び出し順序を調整

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686d6c46a664832c80d3bae0d9b33df5