### PR TITLE
fix: BGM重複再生の解消

### DIFF
--- a/src/audio/BgmProvider.tsx
+++ b/src/audio/BgmProvider.tsx
@@ -53,10 +53,16 @@ export function BgmProvider({ children }: { children: ReactNode }) {
   };
 
   const change = (file: number) => {
+    // 既にプレイヤーが存在する場合はソースだけを入れ替えることで
+    // 新しいプレイヤーが増えないようにする
     if (playerRef.current) {
-      playerRef.current.remove();
-      playerRef.current = null;
+      playerRef.current.replace(file);
+      playerRef.current.loop = true;
+      playerRef.current.volume = volume;
+      playerRef.current.play();
+      return;
     }
+    // 初回のみプレイヤーを生成
     const p = createAudioPlayer(file);
     p.loop = true;
     p.volume = volume;
@@ -65,7 +71,9 @@ export function BgmProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <BgmContext.Provider value={{ volume, setVolume, pause, resume, change, ready }}>
+    <BgmContext.Provider
+      value={{ volume, setVolume, pause, resume, change, ready }}
+    >
       {children}
     </BgmContext.Provider>
   );


### PR DESCRIPTION
## Summary
- BGM再生処理を`replace()`利用に変更し、重複プレイヤーを作成しないよう修正

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686d6e7cef30832caf3789d21c4c0160