### PR TITLE
Add ErrorBoundary

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,12 +14,15 @@ import { LocaleProvider } from '@/src/locale/LocaleContext';
 import { ResultStateProvider } from '@/src/hooks/useResultState';
 import { BgmProvider } from '@/src/audio/BgmProvider';
 import { SeVolumeProvider } from '@/src/audio/SeVolumeProvider';
+import { useSnackbar } from '@/src/hooks/useSnackbar';
+import { ErrorBoundary } from '@/src/components/ErrorBoundary';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
+  const { show: showSnackbar } = useSnackbar();
 
   // Google Mobile Ads SDK を初期化する。web 環境や広告無効化時はスキップ
   useEffect(() => {
@@ -35,27 +38,29 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <BgmProvider>
-        <SeVolumeProvider>
-          <LocaleProvider>
-            <ResultStateProvider>
-              <GameProvider>
-              <Stack>
-                <Stack.Screen name="index" options={{ headerShown: false }} />
-                <Stack.Screen name="practice" options={{ headerShown: false }} />
-                <Stack.Screen name="scores" options={{ headerShown: false }} />
-                <Stack.Screen name="play" options={{ headerShown: false }} />
-                <Stack.Screen name="stage" options={{ headerShown: false }} />
-                <Stack.Screen name="reset" options={{ headerShown: false }} />
-                <Stack.Screen name="+not-found" />
-              </Stack>
-            </GameProvider>
-            </ResultStateProvider>
-          </LocaleProvider>
-          <StatusBar style="auto" />
-        </SeVolumeProvider>
-      </BgmProvider>
-    </ThemeProvider>
+    <ErrorBoundary onError={showSnackbar}>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <BgmProvider>
+          <SeVolumeProvider>
+            <LocaleProvider>
+              <ResultStateProvider>
+                <GameProvider>
+                <Stack>
+                  <Stack.Screen name="index" options={{ headerShown: false }} />
+                  <Stack.Screen name="practice" options={{ headerShown: false }} />
+                  <Stack.Screen name="scores" options={{ headerShown: false }} />
+                  <Stack.Screen name="play" options={{ headerShown: false }} />
+                  <Stack.Screen name="stage" options={{ headerShown: false }} />
+                  <Stack.Screen name="reset" options={{ headerShown: false }} />
+                  <Stack.Screen name="+not-found" />
+                </Stack>
+              </GameProvider>
+              </ResultStateProvider>
+            </LocaleProvider>
+            <StatusBar style="auto" />
+          </SeVolumeProvider>
+        </BgmProvider>
+      </ThemeProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+interface ErrorBoundaryProps {
+  /** エラー発生時に呼び出されるコールバック */
+  onError: (msg: string) => void;
+  children?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  /** エラー発生を示すフラグ */
+  hasError: boolean;
+}
+
+/**
+ * React.Component を継承したエラーバウンダリ
+ * ここで画面全体の例外を捕捉し簡易的なメッセージを表示する
+ */
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // 詳細をコンソールに出力しデバッグしやすくする
+    console.error(error, info);
+    // 呼び出し元にエラーを通知する
+    this.props.onError('予期せぬエラーが発生しました');
+    // フォールバック UI を表示するためフラグを立てる
+    this.setState({ hasError: true });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // シンプルなエラーメッセージだけを表示
+      return (
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <Text>エラーが発生しました</Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- add `ErrorBoundary` component with fallback UI
- wrap entire app with `ErrorBoundary` so unexpected errors show a snackbar

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686da92cd294832cbb2cbb4d8300b127