### PR TITLE
fix: remove duplicate snackbar hook

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,7 +26,6 @@ export default function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
-  const { show: showSnackbar } = useSnackbar();
 
   // Google Mobile Ads SDK を初期化する。web 環境や広告無効化時はスキップ
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove a duplicate call to `useSnackbar` in `app/_layout.tsx`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686db424fc28832c9da6410d99844357