### PR TITLE
Add error handling helper

### DIFF
--- a/src/audio/BgmProvider.tsx
+++ b/src/audio/BgmProvider.tsx
@@ -11,7 +11,7 @@ import React, {
   useState,
   type ReactNode,
 } from "react";
-import { useSnackbar } from "@/src/hooks/useSnackbar";
+import { useHandleError } from "@/src/utils/handleError";
 
 interface BgmContextValue {
   volume: number;
@@ -29,7 +29,7 @@ export function BgmProvider({ children }: { children: ReactNode }) {
   const playerRef = useRef<AudioPlayer | null>(null);
   const [volume, setVolume] = useState(1);
   const [ready, setReady] = useState(false);
-  const { show: showSnackbar } = useSnackbar();
+  const handleError = useHandleError();
 
   useEffect(() => {
     // マウント時は音声モードの設定だけを行い、BGM は再生しない
@@ -38,8 +38,7 @@ export function BgmProvider({ children }: { children: ReactNode }) {
         await setAudioModeAsync({ playsInSilentMode: true });
       } catch (e) {
         // 設定に失敗した場合はユーザーへ通知し詳細をログ出力
-        showSnackbar("オーディオ設定に失敗しました");
-        console.error("setAudioModeAsync error", e);
+        handleError("オーディオ設定に失敗しました", e);
       } finally {
         setReady(true);
       }
@@ -47,7 +46,7 @@ export function BgmProvider({ children }: { children: ReactNode }) {
     return () => {
       playerRef.current?.remove();
     };
-  }, [showSnackbar]);
+  }, [handleError]);
 
   useEffect(() => {
     if (playerRef.current) playerRef.current.volume = volume;
@@ -63,8 +62,7 @@ export function BgmProvider({ children }: { children: ReactNode }) {
       if (playerRef.current?.paused) playerRef.current.play();
     } catch (e) {
       // 再生に失敗した場合はユーザーへ知らせてログに残す
-      showSnackbar("BGM の再生に失敗しました");
-      console.error("BGM resume error", e);
+      handleError("BGM の再生に失敗しました", e);
     }
   };
 
@@ -87,8 +85,7 @@ export function BgmProvider({ children }: { children: ReactNode }) {
       playerRef.current = p;
     } catch (e) {
       // プレイヤー作成や再生でエラーが起きた場合の処理
-      showSnackbar("BGM の再生に失敗しました");
-      console.error("BGM change error", e);
+      handleError("BGM の再生に失敗しました", e);
     }
   };
 

--- a/src/game/__tests__/resultActions.test.ts
+++ b/src/game/__tests__/resultActions.test.ts
@@ -104,7 +104,6 @@ describe('handleOk の広告表示後処理', () => {
       nextStage,
       resetRun,
       router,
-      showSnackbar: jest.fn(),
       pauseBgm: jest.fn(),
       resumeBgm: jest.fn(),
     });
@@ -131,7 +130,6 @@ describe('handleOk の広告表示後処理', () => {
       nextStage,
       resetRun,
       router,
-      showSnackbar: jest.fn(),
       pauseBgm: jest.fn(),
       resumeBgm: jest.fn(),
     });
@@ -158,7 +156,6 @@ describe('handleOk の広告表示後処理', () => {
       nextStage,
       resetRun,
       router,
-      showSnackbar: jest.fn(),
       pauseBgm: jest.fn(),
       resumeBgm: jest.fn(),
     });
@@ -186,7 +183,6 @@ describe('handleOk の広告表示後処理', () => {
       nextStage,
       resetRun,
       router,
-      showSnackbar: jest.fn(),
       pauseBgm: jest.fn(),
       resumeBgm: jest.fn(),
     });
@@ -222,7 +218,6 @@ describe('handleOk の広告表示後処理', () => {
       nextStage,
       resetRun,
       router,
-      showSnackbar: jest.fn(),
       pauseBgm: jest.fn(),
       resumeBgm: jest.fn(),
     });

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -15,7 +15,6 @@ interface Options {
   nextStage: () => void;
   resetRun: () => void;
   router: ReturnType<typeof useRouter>;
-  showSnackbar: (msg: string) => void;
   pauseBgm: () => void;
   resumeBgm: () => void;
 }
@@ -29,7 +28,6 @@ export function useResultActions({
   nextStage,
   resetRun,
   router,
-  showSnackbar,
   pauseBgm,
   resumeBgm,
 }: Options) {
@@ -73,7 +71,6 @@ export function useResultActions({
   const { loadAdIfNeeded, showAd } = useStageEffects({
     pauseBgm,
     resumeBgm,
-    showSnackbar,
   });
   const okLockedRef = useRef(false);
   // バナー表示中かどうかを判定するフラグ。表示中はリザルト判定を行わない

--- a/src/hooks/useSE.ts
+++ b/src/hooks/useSE.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { createAudioPlayer, type AudioPlayer } from 'expo-audio';
 import { useSeVolume } from '@/src/audio/SeVolumeProvider';
-import { useSnackbar } from '@/src/hooks/useSnackbar';
+import { useHandleError } from '@/src/utils/handleError';
 
 /**
  * 効果音(SE)を管理するためのフック。
@@ -13,7 +13,7 @@ export function useSE(soundFile: number) {
   // グローバルな SE 音量を取得
   const { volume, setVolume } = useSeVolume();
   // ユーザーへメッセージを表示するための関数
-  const { show: showSnackbar } = useSnackbar();
+  const handleError = useHandleError();
 
   // 初期化時に効果音を読み込む
   useEffect(() => {
@@ -24,8 +24,7 @@ export function useSE(soundFile: number) {
       playerRef.current = p;
     } catch (e) {
       // プレイヤー生成に失敗したらユーザーへ通知
-      showSnackbar("BGM の再生に失敗しました");
-      console.error("createAudioPlayer error", e);
+      handleError("BGM の再生に失敗しました", e);
     }
     return () => {
       playerRef.current?.remove();
@@ -51,8 +50,7 @@ export function useSE(soundFile: number) {
       playerRef.current.play();
     } catch (e) {
       // 再生に失敗した場合のエラーハンドリング
-      showSnackbar("BGM の再生に失敗しました");
-      console.error("SE play error", e);
+      handleError("BGM の再生に失敗しました", e);
     }
   };
 

--- a/src/hooks/useStageEffects.ts
+++ b/src/hooks/useStageEffects.ts
@@ -5,22 +5,19 @@ import {
   DISABLE_ADS,
 } from "@/src/ads/interstitial";
 import { useCallback } from "react";
+import { useHandleError } from "@/src/utils/handleError";
 
 interface Options {
   pauseBgm: () => void;
   resumeBgm: () => void;
-  showSnackbar: (msg: string) => void;
 }
 
 /**
  * ステージ間で行う広告表示や BGM 停止をまとめたフック。
  * 副作用が多くなる処理を切り出して使いやすくします。
  */
-export function useStageEffects({
-  pauseBgm,
-  resumeBgm,
-  showSnackbar,
-}: Options) {
+export function useStageEffects({ pauseBgm, resumeBgm }: Options) {
+  const handleError = useHandleError();
   /**
    * ステージ番号に応じて広告を表示する
    * 9 の倍数または 1 ステージ目で実行
@@ -46,14 +43,13 @@ export function useStageEffects({
         pauseBgm();
         await showLoadedInterstitial(ad);
       } catch (e) {
-        console.error("interstitial error", e);
-        showSnackbar("広告を表示できませんでした");
+        handleError("広告を表示できませんでした", e);
       } finally {
         resumeBgm();
       }
       return true;
     },
-    [pauseBgm, resumeBgm, showSnackbar],
+    [pauseBgm, resumeBgm, handleError],
   );
 
   // 読み込みと表示をまとめた処理もメモ化

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -7,7 +7,7 @@ import React, {
   type ReactNode,
 } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { useSnackbar } from '@/src/hooks/useSnackbar';
+import { useHandleError } from '@/src/utils/handleError';
 
 export type Lang = "ja" | "en";
 
@@ -148,7 +148,7 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
   const [lang, setLang] = useState<Lang>("ja");
   const [ready, setReady] = useState(false);
   const [firstLaunch, setFirstLaunch] = useState(false);
-  const { show: showSnackbar } = useSnackbar();
+  const handleError = useHandleError();
 
   useEffect(() => {
     (async () => {
@@ -161,22 +161,20 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
           setFirstLaunch(true);
         }
       } catch (e) {
-        console.error(e);
-        showSnackbar('言語設定の読み込みに失敗しました');
+        handleError('言語設定の読み込みに失敗しました', e);
       } finally {
         // エラーの有無に関わらず ready にする
         setReady(true);
       }
     })();
-  }, [showSnackbar]);
+  }, [handleError]);
 
   const changeLang = async (l: Lang) => {
     setLang(l);
     try {
       await AsyncStorage.setItem(STORAGE_KEY, l);
     } catch (e) {
-      console.error(e);
-      showSnackbar('言語設定を保存できませんでした');
+      handleError('言語設定を保存できませんでした', e);
     }
     setFirstLaunch(false);
   };

--- a/src/utils/handleError.ts
+++ b/src/utils/handleError.ts
@@ -1,0 +1,14 @@
+import { useSnackbar } from '@/src/hooks/useSnackbar';
+
+/**
+ * 例外発生時の共通処理を提供するカスタムフック。
+ * メッセージを画面に表示し、詳細をコンソールへ出力します。
+ */
+export function useHandleError() {
+  const { show } = useSnackbar();
+
+  return (message: string, error: unknown) => {
+    console.error(message, error);
+    show(message);
+  };
+}


### PR DESCRIPTION
## Summary
- add `useHandleError` custom hook to centralize console logging and snackbar messages
- refactor BgmProvider, useSE, LocaleContext, useStageEffects to use the new helper
- remove unused snackbar option from `useResultActions` and update tests

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686db436f944832cb6235d3d377ed637