### PR TITLE
合計ステップと衝突数をハイスコアに反映

### DIFF
--- a/src/game/saveGame.ts
+++ b/src/game/saveGame.ts
@@ -12,6 +12,8 @@ export interface StoredState {
   pos: State['pos'];
   steps: number;
   bumps: number;
+  totalSteps?: number;
+  totalBumps?: number;
   path: State['path'];
   hitV: [string, number | null][];
   hitH: [string, number | null][];
@@ -39,6 +41,8 @@ export function encodeState(state: State): StoredState {
     pos: state.pos,
     steps: state.steps,
     bumps: state.bumps,
+    totalSteps: state.totalSteps,
+    totalBumps: state.totalBumps,
     path: state.path,
     hitV: Array.from(state.hitV.entries()),
     hitH: Array.from(state.hitH.entries()),
@@ -69,6 +73,8 @@ export function decodeState(data: StoredState): State {
     pos: data.pos,
     steps: data.steps,
     bumps: data.bumps,
+    totalSteps: data.totalSteps ?? 0,
+    totalBumps: data.totalBumps ?? 0,
     path: data.path,
     hitV: new Map(
       data.hitV.map(([k, v]) => [k, v === null ? Infinity : v]),

--- a/src/game/state/core.ts
+++ b/src/game/state/core.ts
@@ -23,6 +23,10 @@ export interface GameState {
   pos: Vec2;
   steps: number;
   bumps: number;
+  /** ゲーム全体で移動した総歩数 */
+  totalSteps: number;
+  /** ゲーム全体でぶつかった回数 */
+  totalBumps: number;
   path: Vec2[];
   /** 衝突した縦壁と残りターン数 */
   hitV: Map<string, number>;
@@ -85,6 +89,8 @@ export function initState(
   biasedSpawn: boolean = true,
   levelId?: string,
   respawnStock: number = 3,
+  totalSteps: number = 0,
+  totalBumps: number = 0,
 ): State {
   const maze = prepMaze(m);
   const enemies = createEnemies(enemyCounts, maze, biasedSpawn);
@@ -118,5 +124,7 @@ export function initState(
     biasedSpawn,
     levelId,
     respawnStock,
+    totalSteps,
+    totalBumps,
   };
 }

--- a/src/game/state/moveHandlers.ts
+++ b/src/game/state/moveHandlers.ts
@@ -106,12 +106,16 @@ export function updatePlayerPathIfMoved(state: State, newPos: { x: number; y: nu
 export function handleMoveAction(state: State, dir: Dir): State {
   const player = handlePlayerMove(state, dir);
   const enemyResult = updateEnemies(state, player.pos);
+  const stepDiff = player.steps - state.steps;
+  const bumpDiff = player.bumps - state.bumps;
 
   return {
     ...state,
     pos: player.pos,
     steps: player.steps,
     bumps: player.bumps,
+    totalSteps: state.totalSteps + stepDiff,
+    totalBumps: state.totalBumps + bumpDiff,
     path: updatePlayerPathIfMoved(state, player.pos, player.steps),
     hitV: player.hitV,
     hitH: player.hitH,

--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -44,6 +44,9 @@ export function reducer(state: State, action: Action): State {
         state.wallLifetimeFn,
         state.biasedSpawn,
         state.levelId,
+        state.respawnStock,
+        state.totalSteps,
+        state.totalBumps,
       );
     case 'newMaze':
       return createFirstStage(

--- a/src/game/state/stage.ts
+++ b/src/game/state/stage.ts
@@ -51,6 +51,8 @@ export function createFirstStage(
     biasedSpawn,
     levelId,
     3,
+    0,
+    0,
   );
 }
 
@@ -97,6 +99,8 @@ export function nextStageState(state: State): State {
     state.biasedSpawn,
     state.levelId,
     stock,
+    state.totalSteps,
+    state.totalBumps,
   );
 }
 

--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -121,8 +121,8 @@ export function useResultActions({
       if (state.levelId) {
         const current = {
           stage: state.stage,
-          steps: state.steps,
-          bumps: state.bumps,
+          steps: state.totalSteps,
+          bumps: state.totalBumps,
         };
         updateScore(current, state.finalStage);
       } else {
@@ -139,8 +139,8 @@ export function useResultActions({
       if (state.levelId) {
         const current = {
           stage: state.stage - 1,
-          steps: state.steps,
-          bumps: state.bumps,
+          steps: state.totalSteps,
+          bumps: state.totalBumps,
         };
         updateScore(current, false);
       } else {
@@ -154,8 +154,8 @@ export function useResultActions({
     state.finalStage,
     state.stage,
     maze.size,
-    state.steps,
-    state.bumps,
+    state.totalSteps,
+    state.totalBumps,
     showBanner,
     state.levelId,
     updateScore,


### PR DESCRIPTION
## Summary
- ゲーム状態に`totalSteps`と`totalBumps`を追加
- 移動処理で累計値を更新
- ステージ遷移時やセーブデータにも累計値を保存
- ハイスコア計算を累計値に変更

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db6f62174832ca063c2dfbb5915ce