### PR TITLE
fix: return to title on game over

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -196,9 +196,13 @@ export function useResultActions({
       // ゲームオーバー時はランをリセットしてタイトルへ戻る
       resetRun();
       router.replace("/");
+      // 早期 return で以降の処理を行わない
+      return;
     } else if (gameClear) {
+      // ゲームクリア時も同様にタイトルへ戻る
       resetRun();
       router.replace("/");
+      return;
     }
 
     // ステージクリア直後で広告未表示なら広告を表示


### PR DESCRIPTION
## Summary
- ensure `handleOk` exits immediately on game over and game clear

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686db97618cc832c8b0557f0cdc3de06