### PR TITLE
Add easy difficulty and rename level configs

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -65,7 +65,7 @@ export default function TitleScreen() {
     if (!level) return;
     // ゲーム開始直前にログを出してどのレベルを選んだか記録する
     console.log('[TitleScreen] startLevel', id);
-    if (id === 'level2') {
+    if (id === 'hard') {
       audio.changeBgm(require('../assets/sounds/日没廃校_調整.mp3'));
     } else {
       audio.changeBgm(require('../assets/sounds/降りしきる、白_調整.mp3'));

--- a/app/play.tsx
+++ b/app/play.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "expo-router";
 import { EdgeOverlay } from "@/components/EdgeOverlay";
 import { playStyles } from "@/src/styles/playStyles";
 import { UI } from "@/constants/ui";
+import { LEVELS } from "@/constants/levels";
 
 export default function PlayScreen() {
   const { t } = useLocale();
@@ -43,6 +44,10 @@ export default function PlayScreen() {
     handleRespawn,
     handleExit,
   } = usePlayLogic();
+
+  // レベル設定から周囲の壁表示フラグを取得
+  const levelCfg = LEVELS.find((lv) => lv.id === state.levelId);
+  const showAdjWalls = levelCfg?.showAdjacentWalls ?? false;
 
   // useEffect は指定した値が変わるたびに実行される React の仕組みです。
   // ここではプレイ画面の主な状態とバナー状態をログに出して
@@ -134,6 +139,7 @@ export default function PlayScreen() {
           hitH={state.hitH}
           playerPathLength={state.playerPathLength}
           wallLifetime={state.wallLifetime}
+          adjacentWalls={showAdjWalls}
           // ミニマップを300pxで表示する
           size={300}
         />

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -43,7 +43,7 @@ export default function ResetConfirmScreen() {
     }
     await clearGame({ showError: showSnackbar });
     const bgmFile =
-      levelId === 'level2'
+      levelId === 'hard'
         ? require('../assets/sounds/日没廃校_調整.mp3')
         : require('../assets/sounds/降りしきる、白_調整.mp3');
     // bgmReady が false の場合は pendingBgm に保持し、準備完了後に再生

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -23,6 +23,8 @@ export interface LevelConfig {
   enemyCountsFn?: (stage: number) => EnemyCounts;
   /** 敵スポーン位置をスタートから遠い場所に偏らせるか */
   biasedSpawn?: boolean;
+  /** プレイヤー周囲の壁を常に表示するか */
+  showAdjacentWalls?: boolean;
 }
 
 /**
@@ -32,8 +34,8 @@ export interface LevelConfig {
  */
 export const LEVELS: LevelConfig[] = [
   {
-    id: 'level1',
-    name: 'レベル1',
+    id: 'easy',
+    name: 'イージー',
     // 10×10 マップを使用
     size: 10,
     // 初回は関数から得た設定を使うため 0 で初期化
@@ -46,10 +48,23 @@ export const LEVELS: LevelConfig[] = [
     wallLifetimeFn: levelWallLifetime,
     enemyCountsFn: level1EnemyCounts,
     biasedSpawn: false,
+    showAdjacentWalls: true,
   },
   {
-    id: 'level2',
-    name: 'レベル2',
+    id: 'normal',
+    name: 'ノーマル',
+    size: 10,
+    enemies: { random: 0, slow: 0, sight: 0, fast: 0 },
+    enemyPathLength: 5,
+    playerPathLength: 7,
+    wallLifetime: Infinity,
+    wallLifetimeFn: levelWallLifetime,
+    enemyCountsFn: level1EnemyCounts,
+    biasedSpawn: true,
+  },
+  {
+    id: 'hard',
+    name: 'ハード',
     size: 10,
     enemies: { random: 0, slow: 0, sight: 0, fast: 0 },
     enemyPathLength: 5,

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -10,7 +10,7 @@ import Svg, { Circle, Rect } from "react-native-svg";
 
 import type { Enemy } from "@/src/types/enemy";
 import type { MazeData, Vec2 } from "@/src/types/maze";
-import { renderWalls, renderHitWalls } from "./mini-map/Walls";
+import { renderWalls, renderHitWalls, renderAdjacentWalls } from "./mini-map/Walls";
 import {
   renderPath,
   renderEnemyPaths,
@@ -55,6 +55,8 @@ export interface MiniMapProps {
    * "x,y" 形式の文字列で座標を保持する
    */
   visitedGoals?: Set<string>;
+  /** プレイヤー周囲の壁を常に表示する */
+  adjacentWalls?: boolean;
 }
 
 // MiniMap コンポーネント
@@ -74,6 +76,7 @@ export function MiniMap({
   playerPathLength = Infinity,
   wallLifetime = Infinity,
   visitedGoals,
+  adjacentWalls = false,
 }: MiniMapProps) {
   const cell = size / maze.size; // 各マスの大きさ
   // MazeData から壁検索しやすい形へ変換
@@ -116,6 +119,7 @@ export function MiniMap({
         />
         {renderWalls({ maze, cell, size, showAll })}
         {renderHitWalls({ cell, hitV, hitH, wallLifetime })}
+        {adjacentWalls && renderAdjacentWalls({ maze: mazeSets, pos, cell })}
         {renderPath({ path, cell, playerPathLength })}
         {renderEnemyPaths({ enemyPaths, enemies, cell, showAll })}
         {renderVisitedGoals({ visitedGoals, cell, showResult, showAll })}

--- a/src/components/mini-map/Walls.tsx
+++ b/src/components/mini-map/Walls.tsx
@@ -113,3 +113,47 @@ export function renderHitWalls({ cell, hitV, hitH, wallLifetime }: HitWallProps)
   return lines;
 }
 
+export interface AdjacentWallProps {
+  maze: import("@/src/game/state").MazeSets;
+  pos: import("@/src/types/maze").Vec2;
+  cell: number;
+}
+
+// プレイヤー周囲の壁を描画する
+export function renderAdjacentWalls({ maze, pos, cell }: AdjacentWallProps): React.JSX.Element[] {
+  const lines: React.JSX.Element[] = [];
+  const { x, y } = pos;
+  const last = maze.size - 1;
+  const addV = (vx: number, vy: number) => {
+    lines.push(
+      <Line
+        key={`av${vx},${vy}`}
+        x1={(vx + 1) * cell}
+        y1={vy * cell}
+        x2={(vx + 1) * cell}
+        y2={vy * cell + cell}
+        stroke={WALL_COLOR}
+        strokeWidth={1}
+      />,
+    );
+  };
+  const addH = (hx: number, hy: number) => {
+    lines.push(
+      <Line
+        key={`ah${hx},${hy}`}
+        x1={hx * cell}
+        y1={(hy + 1) * cell}
+        x2={hx * cell + cell}
+        y2={(hy + 1) * cell}
+        stroke={WALL_COLOR}
+        strokeWidth={1}
+      />,
+    );
+  };
+  if (x <= 0 || maze.v_walls.has(`${x - 1},${y}`)) addV(x - 1, y);
+  if (x >= last || maze.v_walls.has(`${x},${y}`)) addV(x, y);
+  if (y <= 0 || maze.h_walls.has(`${x},${y - 1}`)) addH(x, y - 1);
+  if (y >= last || maze.h_walls.has(`${x},${y}`)) addH(x, y);
+  return lines;
+}
+

--- a/src/game/__tests__/highScore.test.ts
+++ b/src/game/__tests__/highScore.test.ts
@@ -18,9 +18,9 @@ const score = (stage: number, steps: number, bumps: number): HighScore => ({
 describe('loadHighScore', () => {
   test('保存済みデータを正しく読み込む', async () => {
     const data = score(2, 10, 1);
-    await AsyncStorage.setItem('highscore:level1', JSON.stringify(data));
+    await AsyncStorage.setItem('highscore:normal', JSON.stringify(data));
 
-    const result = await loadHighScore('level1');
+    const result = await loadHighScore('normal');
     expect(result).toEqual(data);
   });
 });
@@ -30,8 +30,8 @@ describe('saveHighScore', () => {
     const data = score(1, 5, 0);
     const spy = jest.spyOn(AsyncStorage, 'setItem');
 
-    await saveHighScore('level2', data);
-    expect(spy).toHaveBeenCalledWith('highscore:level2', JSON.stringify(data));
+    await saveHighScore('hard', data);
+    expect(spy).toHaveBeenCalledWith('highscore:hard', JSON.stringify(data));
   });
 });
 

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -19,8 +19,9 @@ const messages = {
   ja: {
     practiceMode: "練習モード",
     openPractice: "練習モードを開く",
-    level1: "レベル1",
-    level2: "レベル2",
+    easy: "イージー",
+    normal: "ノーマル",
+    hard: "ハード",
     startLevel: "{{name}}を開始",
     enemyRandom: "等速・ランダム",
     enemySlow: "鈍足・視認",
@@ -70,8 +71,9 @@ const messages = {
   en: {
     practiceMode: "Practice Mode",
     openPractice: "Open Practice",
-    level1: "Level 1",
-    level2: "Level 2",
+    easy: "Easy",
+    normal: "Normal",
+    hard: "Hard",
     startLevel: "Start {{name}}",
     enemyRandom: "Normal Random",
     enemySlow: "Slow Vision",


### PR DESCRIPTION
## Summary
- rename level identifiers to `easy`, `normal`, `hard`
- show walls around the player for easy mode
- update locale strings for new difficulties
- adjust BGM selection and level lookup
- update high score tests

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e172f14f4832c8405c1f9dcd9f41c