### PR TITLE
ゲームオーバー時の状態リセット

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -195,12 +195,29 @@ export function useResultActions({
     if (gameOver) {
       // ゲームオーバー時はランをリセットしてタイトルへ戻る
       resetRun();
+      // 表示フラグを戻して次のゲームに影響しないようにする
+      setShowResult(false);
+      setGameOver(false);
+      setStageClear(false);
+      setGameClear(false);
+      setNewRecord(false);
+      setAdShown(false);
+      okLockedRef.current = false;
+      setOkLocked(false);
       router.replace("/");
       // 早期 return で以降の処理を行わない
       return;
     } else if (gameClear) {
       // ゲームクリア時も同様にタイトルへ戻る
       resetRun();
+      setShowResult(false);
+      setGameOver(false);
+      setStageClear(false);
+      setGameClear(false);
+      setNewRecord(false);
+      setAdShown(false);
+      okLockedRef.current = false;
+      setOkLocked(false);
       router.replace("/");
       return;
     }


### PR DESCRIPTION
## Summary
- ゲームオーバー後に新規ゲームを開始すると `gameOver` フラグが残ったままになる不具合を修正

## Testing
- `pnpm lint` *(fails: expo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1c79e228832c9836e9f4b6797783