### PR TITLE
改善: BGM切替時のフェード処理

### DIFF
--- a/src/audio/BgmProvider.tsx
+++ b/src/audio/BgmProvider.tsx
@@ -27,9 +27,35 @@ const BgmContext = createContext<BgmContextValue | undefined>(undefined);
 
 export function BgmProvider({ children }: { children: ReactNode }) {
   const playerRef = useRef<AudioPlayer | null>(null);
+  // 現在再生中の BGM ファイル番号を保持
+  const currentFileRef = useRef<number | null>(null);
   const [volume, setVolume] = useState(1);
   const [ready, setReady] = useState(false);
   const handleError = useHandleError();
+
+  // 一定時間待つためのユーティリティ
+  const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  /**
+   * 音量を段階的に変化させるヘルパー関数
+   * @param player 対象プレイヤー
+   * @param from   開始音量
+   * @param to     終了音量
+   * @param dur    フェードにかけるミリ秒
+   */
+  const fadeVolume = async (
+    player: AudioPlayer,
+    from: number,
+    to: number,
+    dur: number
+  ) => {
+    const steps = 10;
+    const step = dur / steps;
+    for (let i = 1; i <= steps; i++) {
+      player.volume = from + ((to - from) * i) / steps;
+      await wait(step);
+    }
+  };
 
   useEffect(() => {
     // マウント時は音声モードの設定だけを行い、BGM は再生しない
@@ -67,26 +93,39 @@ export function BgmProvider({ children }: { children: ReactNode }) {
   };
 
   const change = (file: number) => {
-    try {
-      // 既にプレイヤーが存在する場合はソースだけを入れ替えることで
-      // 新しいプレイヤーが増えないようにする
-      if (playerRef.current) {
-        playerRef.current.replace(file);
-        playerRef.current.loop = true;
-        playerRef.current.volume = volume;
-        playerRef.current.play();
-        return;
+    const run = async () => {
+      try {
+        // 同じファイルなら再読み込みせずそのまま
+        if (playerRef.current && currentFileRef.current === file) {
+          if (playerRef.current.paused) playerRef.current.play();
+          return;
+        }
+
+        if (playerRef.current) {
+          // フェードアウト後に BGM を切り替える
+          const orig = playerRef.current.volume;
+          await fadeVolume(playerRef.current, orig, 0, 500);
+          playerRef.current.replace(file);
+          playerRef.current.loop = true;
+          playerRef.current.volume = 0;
+          playerRef.current.play();
+          await fadeVolume(playerRef.current, 0, volume, 500);
+        } else {
+          // 初回のみプレイヤーを生成
+          const p = createAudioPlayer(file);
+          p.loop = true;
+          p.volume = volume;
+          p.play();
+          playerRef.current = p;
+        }
+        currentFileRef.current = file;
+      } catch (e) {
+        // プレイヤー作成や再生でエラーが起きた場合の処理
+        handleError("BGM の再生に失敗しました", e);
       }
-      // 初回のみプレイヤーを生成
-      const p = createAudioPlayer(file);
-      p.loop = true;
-      p.volume = volume;
-      p.play();
-      playerRef.current = p;
-    } catch (e) {
-      // プレイヤー作成や再生でエラーが起きた場合の処理
-      handleError("BGM の再生に失敗しました", e);
-    }
+    };
+
+    run();
   };
 
   return (


### PR DESCRIPTION
## Summary
- BGM変更処理を改良し、同じ曲の場合は再生位置を維持
- 異なるBGMへ切り替える際はフェードアウト・インを実装

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecf046f10832ca3342ef06efc6cd1