### PR TITLE
Update levels per doc

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -79,6 +79,7 @@ export default function TitleScreen() {
       level.enemyCountsFn,
       level.wallLifetimeFn,
       level.biasedSpawn,
+      level.biasedGoal,
       level.id,
       level.stagePerMap
     );

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -33,6 +33,7 @@ export default function PracticeScreen() {
       undefined,
       undefined,
       true,
+      true,
       'practice',
       3,
     );

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -78,6 +78,7 @@ export default function ResetConfirmScreen() {
       level.enemyCountsFn,
       level.wallLifetimeFn,
       level.biasedSpawn,
+      level.biasedGoal,
       level.id,
       level.stagePerMap,
     );

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -1,5 +1,9 @@
 import type { EnemyCounts } from '@/src/types/enemy';
-import { level1EnemyCounts, levelWallLifetime } from '@/src/game/level1';
+import {
+  level1EnemyCounts,
+  normalWallLifetime,
+  hardWallLifetime,
+} from '@/src/game/level1';
 import { tutorialEnemyCounts } from '@/src/game/tutorial';
 
 // 各レベルの設定をまとめた型
@@ -24,6 +28,8 @@ export interface LevelConfig {
   enemyCountsFn?: (stage: number) => EnemyCounts;
   /** 敵スポーン位置をスタートから遠い場所に偏らせるか */
   biasedSpawn?: boolean;
+  /** ゴールをスタートから遠ざけるかどうか */
+  biasedGoal?: boolean;
   /** プレイヤー周囲の壁を常に表示するか */
   showAdjacentWalls?: boolean;
   /** ステージごとに周囲表示の有無を決める関数 */
@@ -48,6 +54,7 @@ export const LEVELS: LevelConfig[] = [
     wallLifetime: Infinity,
     enemyCountsFn: tutorialEnemyCounts,
     biasedSpawn: false,
+    biasedGoal: true,
     showAdjacentWallsFn: (stage) => stage <= 5,
     stagePerMap: 5,
   },
@@ -63,10 +70,10 @@ export const LEVELS: LevelConfig[] = [
     playerPathLength: 7,
     // 壁表示は無限大
     wallLifetime: Infinity,
-    wallLifetimeFn: levelWallLifetime,
     enemyCountsFn: level1EnemyCounts,
-    biasedSpawn: false,
-    showAdjacentWalls: true,
+    biasedSpawn: true,
+    biasedGoal: false,
+    showAdjacentWallsFn: (stage) => stage <= 30,
   },
   {
     id: 'normal',
@@ -76,9 +83,10 @@ export const LEVELS: LevelConfig[] = [
     enemyPathLength: 5,
     playerPathLength: 7,
     wallLifetime: Infinity,
-    wallLifetimeFn: levelWallLifetime,
+    wallLifetimeFn: normalWallLifetime,
     enemyCountsFn: level1EnemyCounts,
     biasedSpawn: true,
+    biasedGoal: false,
   },
   {
     id: 'hard',
@@ -88,8 +96,9 @@ export const LEVELS: LevelConfig[] = [
     enemyPathLength: 5,
     playerPathLength: 7,
     wallLifetime: Infinity,
-    wallLifetimeFn: levelWallLifetime,
+    wallLifetimeFn: hardWallLifetime,
     enemyCountsFn: level1EnemyCounts,
-    biasedSpawn: true,
+    biasedSpawn: false,
+    biasedGoal: true,
   },
 ];

--- a/src/game/__tests__/levelWallLifetime.test.ts
+++ b/src/game/__tests__/levelWallLifetime.test.ts
@@ -1,16 +1,31 @@
-import { levelWallLifetime } from '../level1';
+import { normalWallLifetime, hardWallLifetime } from '../level1';
 
-describe('levelWallLifetime', () => {
-  test('90以下ではInfinityを返す', () => {
-    expect(levelWallLifetime(90)).toBe(Infinity);
+describe('normalWallLifetime', () => {
+  test('51以下はInfinity', () => {
+    expect(normalWallLifetime(51)).toBe(Infinity);
   });
-  test('91では16を返す', () => {
-    expect(levelWallLifetime(91)).toBe(16);
+  test('52以上は20', () => {
+    expect(normalWallLifetime(52)).toBe(20);
   });
-  test('100では16を返す', () => {
-    expect(levelWallLifetime(100)).toBe(16);
+});
+
+describe('hardWallLifetime', () => {
+  test('ステージ10ではInfinity', () => {
+    expect(hardWallLifetime(10)).toBe(Infinity);
   });
-  test('101以上ではInfinityを返す', () => {
-    expect(levelWallLifetime(101)).toBe(Infinity);
+  test('ステージ30では20', () => {
+    expect(hardWallLifetime(30)).toBe(20);
+  });
+  test('ステージ60では15', () => {
+    expect(hardWallLifetime(60)).toBe(15);
+  });
+  test('ステージ80では10', () => {
+    expect(hardWallLifetime(80)).toBe(10);
+  });
+  test('ステージ95では1', () => {
+    expect(hardWallLifetime(95)).toBe(1);
+  });
+  test('101以上はInfinity', () => {
+    expect(hardWallLifetime(101)).toBe(Infinity);
   });
 });

--- a/src/game/__tests__/tutorialEnemyCounts.test.ts
+++ b/src/game/__tests__/tutorialEnemyCounts.test.ts
@@ -5,19 +5,15 @@ describe('tutorialEnemyCounts', () => {
     expect(tutorialEnemyCounts(1)).toEqual({ random: 0, slow: 0, sight: 0, fast: 0 });
   });
 
-  test('ステージ4はランダム1体', () => {
-    expect(tutorialEnemyCounts(4)).toEqual({ random: 1, slow: 0, sight: 0, fast: 0 });
+  test('ステージ16ではランダム1体', () => {
+    expect(tutorialEnemyCounts(16)).toEqual({ random: 1, slow: 0, sight: 0, fast: 0 });
   });
 
-  test('ステージ9は鈍足視認1体', () => {
-    expect(tutorialEnemyCounts(9)).toEqual({ random: 0, slow: 1, sight: 0, fast: 0 });
+  test('ステージ22では鈍足視認1体', () => {
+    expect(tutorialEnemyCounts(22)).toEqual({ random: 0, slow: 1, sight: 0, fast: 0 });
   });
 
-  test('ステージ12はランダム1体', () => {
-    expect(tutorialEnemyCounts(12)).toEqual({ random: 1, slow: 0, sight: 0, fast: 0 });
-  });
-
-  test('ステージ20以降は鈍足視認1体', () => {
-    expect(tutorialEnemyCounts(20)).toEqual({ random: 0, slow: 1, sight: 0, fast: 0 });
+  test('ステージ25以降は鈍足視認1体', () => {
+    expect(tutorialEnemyCounts(25)).toEqual({ random: 0, slow: 1, sight: 0, fast: 0 });
   });
 });

--- a/src/game/level1.ts
+++ b/src/game/level1.ts
@@ -111,10 +111,22 @@ export function level1EnemyCounts(stage: number): EnemyCounts {
 }
 
 /**
- * レベル1・2 共通の壁寿命設定を返します。
- * ステージ91〜100では壁の表示が16ターンで消えます。
- * それ以外では無限大 (Infinity) を返します。
+ * ノーマル用の壁寿命設定です。
+ * 52ステージ目以降は20ターンで壁が消えます。
  */
-export function levelWallLifetime(stage: number): number {
-  return stage >= 91 && stage <= 100 ? 16 : Infinity;
+export function normalWallLifetime(stage: number): number {
+  return stage >= 52 ? 20 : Infinity;
+}
+
+/**
+ * ハード用の壁寿命設定です。
+ * ステージ範囲ごとに寿命が短くなります。
+ */
+export function hardWallLifetime(stage: number): number {
+  if (stage <= 21) return Infinity;
+  if (stage <= 51) return 20;
+  if (stage <= 72) return 15;
+  if (stage <= 90) return 10;
+  if (stage <= 100) return 1;
+  return Infinity;
 }

--- a/src/game/saveGame.ts
+++ b/src/game/saveGame.ts
@@ -30,6 +30,7 @@ export interface StoredState {
   playerPathLength: number | null;
   wallLifetime: number | null;
   biasedSpawn: boolean;
+  biasedGoal: boolean;
   levelId?: string;
   respawnStock: number;
   stagePerMap: number;
@@ -60,6 +61,7 @@ export function encodeState(state: State): StoredState {
     playerPathLength: state.playerPathLength,
     wallLifetime: state.wallLifetime,
     biasedSpawn: state.biasedSpawn,
+    biasedGoal: state.biasedGoal,
     levelId: state.levelId,
     respawnStock: state.respawnStock,
     stagePerMap: state.stagePerMap,
@@ -101,6 +103,7 @@ export function decodeState(data: StoredState): State {
     wallLifetime: data.wallLifetime === null ? Infinity : data.wallLifetime,
     wallLifetimeFn: level?.wallLifetimeFn,
     biasedSpawn: data.biasedSpawn,
+    biasedGoal: level?.biasedGoal ?? true,
     levelId: data.levelId,
     respawnStock: data.respawnStock,
     stagePerMap: level?.stagePerMap ?? 3,

--- a/src/game/state/core.ts
+++ b/src/game/state/core.ts
@@ -60,6 +60,8 @@ export interface GameState {
   wallLifetimeFn?: (stage: number) => number;
   /** スポーン位置をスタートから遠い場所に偏らせるか */
   biasedSpawn: boolean;
+  /** ゴールをスタートから遠ざけるかどうか */
+  biasedGoal: boolean;
   /** 現在のレベル識別子。練習モードは undefined */
   levelId?: string;
   /** 何ステージごとに新しい迷路へ切り替えるか */
@@ -89,6 +91,7 @@ export function initState(
   enemyCountsFn?: (stage: number) => EnemyCounts,
   wallLifetimeFn?: (stage: number) => number,
   biasedSpawn: boolean = true,
+  biasedGoal: boolean = true,
   levelId?: string,
   stagePerMap: number = 3,
   respawnStock: number = 3,
@@ -125,6 +128,7 @@ export function initState(
     wallLifetime: life,
     wallLifetimeFn,
     biasedSpawn,
+    biasedGoal,
     levelId,
     stagePerMap,
     respawnStock,

--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -20,6 +20,7 @@ export type Action =
       enemyCountsFn?: (stage: number) => EnemyCounts;
       wallLifetimeFn?: (stage: number) => number;
       biasedSpawn?: boolean;
+      biasedGoal?: boolean;
       levelId?: string;
       stagePerMap?: number;
     }
@@ -44,6 +45,7 @@ export function reducer(state: State, action: Action): State {
         state.enemyCountsFn,
         state.wallLifetimeFn,
         state.biasedSpawn,
+        state.biasedGoal,
         state.levelId,
         state.stagePerMap,
         state.respawnStock,
@@ -62,6 +64,7 @@ export function reducer(state: State, action: Action): State {
         action.biasedSpawn ?? state.biasedSpawn,
         action.levelId,
         action.stagePerMap ?? state.stagePerMap,
+        action.biasedGoal ?? state.biasedGoal,
       );
     case 'nextStage':
       return nextStageState(state);

--- a/src/game/state/stage.ts
+++ b/src/game/state/stage.ts
@@ -21,13 +21,16 @@ export function createFirstStage(
   biasedSpawn: boolean = true,
   levelId?: string,
   stagePerMap: number = 3,
+  biasedGoal: boolean = true,
 ): State {
   const visited = new Set<string>();
   const start = randomCell(base.size);
   const candidates = allCells(base.size).filter(
     (c) => c.x !== start.x || c.y !== start.y,
   );
-  const goal = biasedPickGoal(start, candidates);
+  const goal = biasedGoal
+    ? biasedPickGoal(start, candidates)
+    : candidates[Math.floor(Math.random() * candidates.length)];
   const maze: MazeData = {
     ...base,
     start: [start.x, start.y],
@@ -50,6 +53,7 @@ export function createFirstStage(
     enemyCountsFn,
     wallLifetimeFn,
     biasedSpawn,
+    biasedGoal,
     levelId,
     stagePerMap,
     0,
@@ -73,7 +77,9 @@ export function nextStageState(state: State): State {
   if (cells.length === 0) {
     return { ...state, finalStage: true };
   }
-  const goal = biasedPickGoal(start, cells);
+  const goal = state.biasedGoal
+    ? biasedPickGoal(start, cells)
+    : cells[Math.floor(Math.random() * cells.length)];
   const maze: MazeData = {
     ...base,
     start: [start.x, start.y],
@@ -98,6 +104,7 @@ export function nextStageState(state: State): State {
     state.enemyCountsFn,
     state.wallLifetimeFn,
     state.biasedSpawn,
+    state.biasedGoal,
     state.levelId,
     state.stagePerMap,
     stock,
@@ -119,5 +126,6 @@ export function restartRun(state: State): State {
     state.biasedSpawn,
     state.levelId,
     state.stagePerMap,
+    state.biasedGoal,
   );
 }

--- a/src/game/tutorial.ts
+++ b/src/game/tutorial.ts
@@ -4,16 +4,12 @@ import type { EnemyCounts } from '@/src/types/enemy';
  * チュートリアル専用の敵出現数を返す関数です。
  * ステージ番号に応じて次のように敵を配置します。
  *
- * - 1〜2: 敵なし
- * - 3〜8: 等速ランダム 1 体
- * - 9〜10: 鈍足視認 1 体
- * - 11〜12: 等速ランダム 1 体
- * - 13〜25: 鈍足視認 1 体
- */
+ * - 1〜15: 敵なし
+ * - 16〜20: 等速ランダム 1 体
+ * - 21〜25: 鈍足視認 1 体
+*/
 export function tutorialEnemyCounts(stage: number): EnemyCounts {
-  if (stage <= 2) return { random: 0, slow: 0, sight: 0, fast: 0 };
-  if (stage <= 8) return { random: 1, slow: 0, sight: 0, fast: 0 };
-  if (stage <= 10) return { random: 0, slow: 1, sight: 0, fast: 0 };
-  if (stage <= 12) return { random: 1, slow: 0, sight: 0, fast: 0 };
+  if (stage <= 15) return { random: 0, slow: 0, sight: 0, fast: 0 };
+  if (stage <= 20) return { random: 1, slow: 0, sight: 0, fast: 0 };
   return { random: 0, slow: 1, sight: 0, fast: 0 };
 }

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -27,6 +27,7 @@ const GameContext = createContext<
         enemyCountsFn?: (stage: number) => EnemyCounts,
         wallLifetimeFn?: (stage: number) => number,
         biasedSpawn?: boolean,
+        biasedGoal?: boolean,
         levelId?: string,
         stagePerMap?: number,
       ) => void;
@@ -64,6 +65,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     enemyCountsFn?: (stage: number) => EnemyCounts,
     wallLifetimeFn?: (stage: number) => number,
     biasedSpawn?: boolean,
+    biasedGoal?: boolean,
     levelId?: string,
     stagePerMap?: number,
   ) =>
@@ -77,6 +79,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
       enemyCountsFn,
       wallLifetimeFn,
       biasedSpawn,
+      biasedGoal,
       levelId,
       stagePerMap,
     });


### PR DESCRIPTION
## Summary
- adjust level configurations with new goal bias and wall lifetimes
- update tutorial enemy spawn logic
- support biasedGoal flag throughout game state
- add tests for new wall lifetime logic

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edc1d6b74832c97e9bcfe5ca7b9bd