### PR TITLE
Update ad timing logic

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -75,6 +75,7 @@ export function useResultActions({
   const { loadAdIfNeeded, showAd } = useStageEffects({
     pauseBgm,
     resumeBgm,
+    levelId: state.levelId,
   });
   const okLockedRef = useRef(false);
   // バナー表示中かどうかを判定するフラグ。表示中はリザルト判定を行わない

--- a/src/hooks/useStageEffects.ts
+++ b/src/hooks/useStageEffects.ts
@@ -10,29 +10,28 @@ import { useHandleError } from "@/src/utils/handleError";
 interface Options {
   pauseBgm: () => void;
   resumeBgm: () => void;
+  /** レベル識別子。'tutorial' のときチュートリアル扱い */
+  levelId?: string;
 }
 
 /**
  * ステージ間で行う広告表示や BGM 停止をまとめたフック。
  * 副作用が多くなる処理を切り出して使いやすくします。
  */
-export function useStageEffects({ pauseBgm, resumeBgm }: Options) {
+export function useStageEffects({ pauseBgm, resumeBgm, levelId }: Options) {
   const handleError = useHandleError();
-  /**
-   * ステージ番号に応じて広告を表示する
-   * 9 の倍数または 1 ステージ目で実行
-   */
-  const shouldShowAd = (stage: number) => stage % 9 === 0 || stage === 1;
-
   // 広告読み込み処理をメモ化
   const loadAdIfNeeded = useCallback(
     async (stage: number): Promise<InterstitialAd | null> => {
-      const shouldShow = shouldShowAd(stage);
+      // 広告を出す条件:
+      // チュートリアルでは5の倍数、その他では6の倍数ステージのクリア時
+      const shouldShow =
+        levelId === 'tutorial' ? stage % 5 === 0 : stage % 6 === 0;
       console.log("loadAdIfNeeded", { stage, shouldShow });
       if (!shouldShow || DISABLE_ADS) return null;
       return loadInterstitial();
     },
-    [],
+    [levelId],
   );
 
   // 広告表示処理をメモ化。BGM 制御や通知を依存として指定


### PR DESCRIPTION
## Summary
- show ads on tutorial stages every 5th clear
- show ads on other stages every 6th clear
- pass level id to the stage effects hook

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687027f6d880832cacf1cdb80195992d