### PR TITLE
fix: skip saving initial stage

### DIFF
--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -94,6 +94,14 @@ export function GameProvider({ children }: { children: ReactNode }) {
       first.current = false;
       return;
     }
+    // ステージ 1 で手数が 0 のときはセーブ不要なので保存処理をしない
+    if (
+      state.stage === 1 &&
+      state.steps === 0 &&
+      state.totalSteps === 0
+    ) {
+      return;
+    }
     saveGame(state, { showError: showSnackbar });
   }, [state, showSnackbar]);
 


### PR DESCRIPTION
## Summary
- skip saving when still on stage 1 with no progress

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704d0da6f8832ca872c2a0132b9555