### PR TITLE
Adjust UI positions by 1cm

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -14,6 +14,7 @@ import { EdgeOverlay } from "@/components/EdgeOverlay";
 import { playStyles } from "@/src/styles/playStyles";
 import { UI } from "@/constants/ui";
 import { LEVELS } from "@/constants/levels";
+import { cmToDp } from "@/src/utils/layout";
 
 export default function PlayScreen() {
   const { t } = useLocale();
@@ -80,10 +81,14 @@ export default function PlayScreen() {
     }
   }, [showBanner, bannerStage, router]);
 
-  const dpadTop = height * (2 / 3);
-  // ミニマップはリザルトパネルと重ならないよう少し上に配置する
-  // mapTop は画面高さの 1/3 から 80px 引いた位置
-  const mapTop = height / 3 - 80;
+  // 1cm を dp に変換し、UI 位置調整に利用
+  const oneCm = cmToDp(1);
+
+  // DPad は画面下 1/3 の位置から 1cm 上へずらす
+  const dpadTop = height * (2 / 3) - oneCm;
+  // ミニマップも同様に 1cm 上へ移動させる
+  // mapTop は画面高さの 1/3 から 80px 引いた位置を基準とする
+  const mapTop = height / 3 - 80 - oneCm;
   // リザルトパネルは DPad と同じ位置に表示する
   const resultTop = dpadTop;
   // リセットボタンの色。使用回数に応じて白から黒へ変化させる

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,0 +1,11 @@
+import { PixelRatio } from 'react-native';
+
+/**
+ * 与えられたセンチメートル値を dp に変換する関数。
+ * dp は 'density-independent pixel' の略で、
+ * 画面密度に依存せず同じ物理サイズを保つ単位です。
+ * 1 inch = 2.54cm、1dp = 1/160 inch を利用して計算します。
+ */
+export function cmToDp(cm: number): number {
+  return PixelRatio.roundToNearestPixel((cm / 2.54) * 160);
+}


### PR DESCRIPTION
## Summary
- add `cmToDp` helper for cm to dp conversion
- shift MiniMap, DPad and result modal 1cm upward

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68706036a94c832caba17f56ba3be99f