### PR TITLE
新規ゲーム開始時のリスポーン在庫を最大に設定

### DIFF
--- a/src/game/__tests__/createFirstStage.test.ts
+++ b/src/game/__tests__/createFirstStage.test.ts
@@ -1,0 +1,17 @@
+import { createFirstStage } from '../state/stage';
+import type { MazeData } from '@/src/types/maze';
+
+describe('createFirstStage', () => {
+  test('新規ゲーム開始時のリスポーン回数は3になる', () => {
+    const maze: MazeData = {
+      id: 'test',
+      size: 10,
+      start: [0, 0],
+      goal: [9, 9],
+      v_walls: [],
+      h_walls: [],
+    };
+    const state = createFirstStage(maze);
+    expect(state.respawnStock).toBe(3);
+  });
+});

--- a/src/game/state/stage.ts
+++ b/src/game/state/stage.ts
@@ -56,7 +56,7 @@ export function createFirstStage(
     biasedGoal,
     levelId,
     stagePerMap,
-    0,
+    3, // 新規ゲーム開始時のリスポーン回数は常に最大(3)
     0,
   );
 }


### PR DESCRIPTION
## Summary
- createFirstStage 初期化時の respawnStock を 3 に変更
- 新しいテスト createFirstStage.test.ts を追加

## Testing
- `pnpm lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706134cb4c832cb6fb0dee764d7a30