### PR TITLE
Add ad respawn when stock zero

### DIFF
--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -82,7 +82,7 @@ export function reducer(state: State, action: Action): State {
         enemies,
         enemyVisited: enemies.map((e) => new Map([[`${e.pos.x},${e.pos.y}`, 1]])),
         enemyPaths: enemies.map((e) => [{ ...e.pos }]),
-        respawnStock: state.respawnStock - 1,
+        respawnStock: Math.max(state.respawnStock - 1, 0),
       };
     }
     case 'move': {

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -1,5 +1,7 @@
 import { useWindowDimensions } from 'react-native';
 import { useRouter } from 'expo-router';
+import { showInterstitial } from '@/src/ads/interstitial';
+import { useHandleError } from '@/src/utils/handleError';
 
 import { useGame } from '@/src/game/useGame';
 import { useSnackbar } from '@/src/hooks/useSnackbar';
@@ -48,11 +50,19 @@ export function usePlayLogic() {
   // ステージ総数。迷路は正方形なので size×size となる
   const totalStages = maze.size * maze.size;
 
+  const handleError = useHandleError();
+
   // 敵のみをリスポーンする処理
-  const handleRespawn = () => {
+  const handleRespawn = async () => {
     if (state.respawnStock <= 0) {
-      showSnackbar('リスポーン回数がありません');
-      return;
+      try {
+        audio.pauseBgm();
+        await showInterstitial();
+      } catch (e) {
+        handleError('広告を表示できませんでした', e);
+      } finally {
+        audio.resumeBgm();
+      }
     }
     respawnEnemies();
   };


### PR DESCRIPTION
## Summary
- show interstitial ads when respawn stock is zero
- prevent negative respawn count in reducer

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68706f15dc6c832c96d1570c97afa89e