### PR TITLE
可視化ボタンの表示色を広告有無で変更

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -108,6 +108,13 @@ export default function PlayScreen() {
   const resetColor = isEmpty ? UI.colors.icon : `rgb(${gray},${gray},${gray})`;
   const resetIcon = isEmpty ? 'refresh-outline' : 'refresh';
 
+  // 可視化ボタンの色設定
+  // 広告なしで利用できるときは濃い白、それ以外は半透明の白にする
+  const revealColor =
+    revealUsed === 0 || debugAll
+      ? UI.colors.revealFree
+      : UI.colors.revealAd;
+
   // 全表示ボタンの処理
   // debugAll が true なら広告なしで OFF にする
   // OFF → ON は初回のみ無償、それ以降は広告視聴が必要
@@ -174,7 +181,7 @@ export default function PlayScreen() {
         <MaterialIcons
           name={debugAll ? "visibility-off" : "visibility"}
           size={24}
-          color={UI.colors.icon}
+          color={revealColor}
         />
       </Pressable>
       <View style={[playStyles.miniMapWrapper, { top: mapTop }]}>

--- a/components/PlayMenu.tsx
+++ b/components/PlayMenu.tsx
@@ -110,6 +110,11 @@ export function PlayMenu({
             <Switch
               value={debugAll}
               onValueChange={handleToggle}
+              thumbColor={
+                revealUsed === 0 || debugAll
+                  ? UI.colors.revealFree
+                  : UI.colors.revealAd
+              }
               accessibilityLabel={
                 revealUsed === 0
                   ? labelShowMaze

--- a/constants/ui.ts
+++ b/constants/ui.ts
@@ -38,6 +38,9 @@ export const UI = {
     mapWall: 'gray',
     mapStroke: 'white',
     bump: 'red',
+    // 可視化ボタンの明度調整用カラー
+    revealFree: '#fff',
+    revealAd: 'rgba(255,255,255,0.5)',
   },
   feedback: {
     bumpWidth: 50,


### PR DESCRIPTION
## Summary
- UI 定数に `revealFree` と `revealAd` を追加
- 可視化ボタンの色を使用条件に合わせて変更
- メニュー内スイッチにも同様の色を適用

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687088e1cdb4832c8897d582f306219e