### PR TITLE
Implement dynamic respawn limit

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -81,7 +81,8 @@ export default function TitleScreen() {
       level.biasedSpawn,
       level.biasedGoal,
       level.id,
-      level.stagePerMap
+      level.stagePerMap,
+      level.respawnMax
     );
     // 画面遷移開始をログ
     console.log('[TitleScreen] navigate begin');

--- a/app/play.tsx
+++ b/app/play.tsx
@@ -101,10 +101,12 @@ export default function PlayScreen() {
   const mapTop = height / 3 - 80 - oneCm;
   // リザルトパネルは DPad と同じ位置に表示する
   const resultTop = dpadTop;
-  // リセットボタンの色。残り回数に応じて白から黒へ変化させる。
-  // 0 回のときは押しやすいように線だけ表示するため色を固定
+  // リセットボタンの色。残り回数の割合で明るさを変える
+  // 在庫 0 回でも薄く表示してボタン自体は見えるようにする
   const isEmpty = state.respawnStock <= 0;
-  const gray = Math.round((state.respawnStock / 3) * 255);
+  const gray = Math.round(
+    (state.respawnStock / state.respawnMax) * 255,
+  );
   const resetColor = isEmpty ? UI.colors.icon : `rgb(${gray},${gray},${gray})`;
   const resetIcon = isEmpty ? 'refresh-outline' : 'refresh';
 

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -36,6 +36,7 @@ export default function PracticeScreen() {
       true,
       'practice',
       3,
+      3,
     );
     router.replace('/play');
   };

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -81,6 +81,7 @@ export default function ResetConfirmScreen() {
       level.biasedGoal,
       level.id,
       level.stagePerMap,
+      level.respawnMax,
     );
     router.replace('/play');
   };

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -36,6 +36,8 @@ export interface LevelConfig {
   showAdjacentWallsFn?: (stage: number) => boolean;
   /** 何ステージごとに迷路を更新するか */
   stagePerMap?: number;
+  /** 敵をリスポーンできる最大回数 */
+  respawnMax?: number;
 }
 
 /**
@@ -58,6 +60,7 @@ export const LEVELS: LevelConfig[] = [
     biasedGoal: true,
     showAdjacentWallsFn: (stage) => stage <= 5,
     stagePerMap: 5,
+    respawnMax: 3,
   },
   {
     id: 'easy',
@@ -75,6 +78,7 @@ export const LEVELS: LevelConfig[] = [
     biasedSpawn: true,
     biasedGoal: false,
     showAdjacentWallsFn: (stage) => stage <= 30,
+    respawnMax: 3,
   },
   {
     id: 'normal',
@@ -89,6 +93,7 @@ export const LEVELS: LevelConfig[] = [
     enemyCountsFn: level1EnemyCounts,
     biasedSpawn: true,
     biasedGoal: false,
+    respawnMax: 2,
   },
   {
     id: 'hard',
@@ -103,5 +108,6 @@ export const LEVELS: LevelConfig[] = [
     enemyCountsFn: level1EnemyCounts,
     biasedSpawn: false,
     biasedGoal: true,
+    respawnMax: 1,
   },
 ];

--- a/src/game/__tests__/createFirstStage.test.ts
+++ b/src/game/__tests__/createFirstStage.test.ts
@@ -13,5 +13,6 @@ describe('createFirstStage', () => {
     };
     const state = createFirstStage(maze);
     expect(state.respawnStock).toBe(3);
+    expect(state.respawnMax).toBe(3);
   });
 });

--- a/src/game/saveGame.ts
+++ b/src/game/saveGame.ts
@@ -33,6 +33,7 @@ export interface StoredState {
   biasedGoal: boolean;
   levelId?: string;
   respawnStock: number;
+  respawnMax: number;
   stagePerMap: number;
 }
 
@@ -64,6 +65,7 @@ export function encodeState(state: State): StoredState {
     biasedGoal: state.biasedGoal,
     levelId: state.levelId,
     respawnStock: state.respawnStock,
+    respawnMax: state.respawnMax,
     stagePerMap: state.stagePerMap,
   };
 }
@@ -106,6 +108,7 @@ export function decodeState(data: StoredState): State {
     biasedGoal: level?.biasedGoal ?? true,
     levelId: data.levelId,
     respawnStock: data.respawnStock,
+    respawnMax: level?.respawnMax ?? data.respawnMax,
     stagePerMap: level?.stagePerMap ?? 3,
   };
 }

--- a/src/game/state/core.ts
+++ b/src/game/state/core.ts
@@ -68,6 +68,8 @@ export interface GameState {
   stagePerMap: number;
   /** 敵をリスポーンできる残り回数 */
   respawnStock: number;
+  /** リスポーン回数の上限 */
+  respawnMax: number;
 }
 
 // Provider が保持する全体の状態
@@ -94,7 +96,8 @@ export function initState(
   biasedGoal: boolean = true,
   levelId?: string,
   stagePerMap: number = 3,
-  respawnStock: number = 3,
+  respawnMax: number = 3,
+  respawnStock: number = respawnMax,
   totalSteps: number = 0,
   totalBumps: number = 0,
 ): State {
@@ -132,6 +135,7 @@ export function initState(
     levelId,
     stagePerMap,
     respawnStock,
+    respawnMax,
     totalSteps,
     totalBumps,
   };

--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -23,6 +23,7 @@ export type Action =
       biasedGoal?: boolean;
       levelId?: string;
       stagePerMap?: number;
+      respawnMax?: number;
     }
   | { type: 'nextStage' }
   | { type: 'resetRun' }
@@ -48,6 +49,7 @@ export function reducer(state: State, action: Action): State {
         state.biasedGoal,
         state.levelId,
         state.stagePerMap,
+        state.respawnMax,
         state.respawnStock,
         state.totalSteps,
         state.totalBumps,
@@ -64,6 +66,7 @@ export function reducer(state: State, action: Action): State {
         action.biasedSpawn ?? state.biasedSpawn,
         action.levelId,
         action.stagePerMap ?? state.stagePerMap,
+        action.respawnMax ?? state.respawnMax,
         action.biasedGoal ?? state.biasedGoal,
       );
     case 'nextStage':

--- a/src/game/state/stage.ts
+++ b/src/game/state/stage.ts
@@ -21,6 +21,7 @@ export function createFirstStage(
   biasedSpawn: boolean = true,
   levelId?: string,
   stagePerMap: number = 3,
+  respawnMax: number = 3,
   biasedGoal: boolean = true,
 ): State {
   const visited = new Set<string>();
@@ -56,7 +57,9 @@ export function createFirstStage(
     biasedGoal,
     levelId,
     stagePerMap,
-    3, // 新規ゲーム開始時のリスポーン回数は常に最大(3)
+    respawnMax,
+    respawnMax, // 新規ゲーム開始時は最大回数でスタート
+    0,
     0,
   );
 }
@@ -89,7 +92,7 @@ export function nextStageState(state: State): State {
   const hitV = changeMap ? new Map<string, number>() : new Map(state.hitV);
   const hitH = changeMap ? new Map<string, number>() : new Map(state.hitH);
   const nextWallLife = state.wallLifetimeFn?.(state.stage + 1) ?? state.wallLifetime;
-  const stock = Math.min(state.respawnStock + 1, 3);
+  const stock = Math.min(state.respawnStock + 1, state.respawnMax);
   return initState(
     maze,
     state.stage + 1,
@@ -107,6 +110,7 @@ export function nextStageState(state: State): State {
     state.biasedGoal,
     state.levelId,
     state.stagePerMap,
+    state.respawnMax,
     stock,
     state.totalSteps,
     state.totalBumps,
@@ -126,6 +130,7 @@ export function restartRun(state: State): State {
     state.biasedSpawn,
     state.levelId,
     state.stagePerMap,
+    state.respawnMax,
     state.biasedGoal,
   );
 }

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -30,6 +30,7 @@ const GameContext = createContext<
         biasedGoal?: boolean,
         levelId?: string,
         stagePerMap?: number,
+        respawnMax?: number,
       ) => void;
       nextStage: () => void;
       resetRun: () => void;
@@ -68,6 +69,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     biasedGoal?: boolean,
     levelId?: string,
     stagePerMap?: number,
+    respawnMax?: number,
   ) =>
     send({
       type: 'newMaze',
@@ -82,6 +84,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
       biasedGoal,
       levelId,
       stagePerMap,
+      respawnMax,
     });
   const nextStage = () => send({ type: 'nextStage' });
   const resetRun = () => send({ type: 'resetRun' });


### PR DESCRIPTION
## Summary
- add respawnMax option to level config
- adjust game state to track max respawn count
- store respawnMax in save data
- vary reset button color by remaining stock
- pass respawnMax on new game creation

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68708a617000832ca7055cb5ed9748b3