### PR TITLE
Add UI constants for home screen

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -140,7 +140,13 @@ export default function TitleScreen() {
 
   return (
     <ThemedView lightColor="#000" darkColor="#000" style={styles.container}>
-      <ThemedText type="title" lightColor="#fff" darkColor="#fff">
+      {/* タイトルの文字サイズを定数から調整できるように */}
+      <ThemedText
+        type="title"
+        lightColor="#fff"
+        darkColor="#fff"
+        style={styles.title}
+      >
         Maze Sense
       </ThemedText>
 
@@ -211,7 +217,13 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    gap: UI.screenGap,
+    // 選択肢間の余白をホーム画面用定数から参照
+    gap: UI.titleScreen.optionGap,
+  },
+  // タイトル文字のサイズを変更しやすくするためのスタイル
+  title: {
+    fontSize: UI.titleScreen.titleFontSize,
+    lineHeight: UI.titleScreen.titleFontSize,
   },
   modalWrapper: {
     flex: 1,

--- a/constants/ui.ts
+++ b/constants/ui.ts
@@ -59,6 +59,15 @@ export const UI = {
     bumpWidth: 50,
     bumpShowTime: 300,
   },
+  // -------------------
+  // ホーム(タイトル)画面専用の設定
+  // -------------------
+  titleScreen: {
+    // タイトル文字のサイズ
+    titleFontSize: 32,
+    // ボタンなど縦並び要素の余白
+    optionGap: 20,
+  },
 } as const;
 
 export type UIValues = typeof UI;


### PR DESCRIPTION
## Summary
- tweak UI constants to allow customization of the title screen
- use new constants in `app/index.tsx`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6870be556c20832ca9103b5f92d51afa