### PR TITLE
fix: result modal width constant

### DIFF
--- a/components/ResultModal.tsx
+++ b/components/ResultModal.tsx
@@ -77,7 +77,8 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     alignItems: 'center',
     gap: UI.dpadSpacing,
-    width: UI.modalWidth,
+    // 結果画面の横幅。狭すぎると文字が折り返されるため調整可
+    width: UI.resultModalWidth,
     alignSelf: 'center',
   },
   text: {

--- a/constants/ui.ts
+++ b/constants/ui.ts
@@ -32,6 +32,9 @@ export const UI = {
   modalPadding: 24,
   miniMapSize: 300,
   modalWidth: 250,
+  // リザルトパネル専用の横幅
+  // テキストが折り返されないよう適宜調整する
+  resultModalWidth: 300,
   borderAnimationMax: 50,
   // 文字サイズを一箇所で管理する
   fonts: {


### PR DESCRIPTION
## Summary
- add `resultModalWidth` constant
- use the new constant in `ResultModal`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6870c2d2c7ac832c86801b57989eaaca