### PR TITLE
Add debug flag to unlock levels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ EXPO_PUBLIC_ADMOB_INTERSTITIAL_ID=ca-app-pub-xxxxxxxxxxxxxxxx/interstitial
 EXPO_PUBLIC_DISABLE_STAGE_BANNER=false
 # 広告表示を完全に無効化したいときは true
 EXPO_PUBLIC_DISABLE_ADS=false
+
+# デバッグ時に全難易度を解放する場合は true
+EXPO_PUBLIC_UNLOCK_ALL_LEVELS=false

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ EXPO_PUBLIC_DISABLE_STAGE_BANNER=true
 
 値を `false` または未設定にすると通常通りバナーが表示されます。
 
+難易度解放の状態に関係なくすべてのゲームモードを試したい場合は以下を設定します。
+
+```bash
+EXPO_PUBLIC_UNLOCK_ALL_LEVELS=true
+```
+
+通常は `false` のままで構いません。
+
 ## β版の配布について
 
 現在のバージョンはテスト目的の β 版です。TestFlight もしくは Google Play の内部

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -18,6 +18,11 @@ import { useAudioControls } from "@/src/hooks/useAudioControls";
 import { useLevelUnlock } from "@/src/hooks/useLevelUnlock";
 import { UI } from "@/constants/ui";
 
+// EXPO_PUBLIC_UNLOCK_ALL_LEVELS が 'true' のとき
+// クリア状況に関わらず全難易度を選択可能にする
+const UNLOCK_ALL_LEVELS =
+  process.env.EXPO_PUBLIC_UNLOCK_ALL_LEVELS === "true";
+
 export default function TitleScreen() {
   const router = useRouter();
   const { newGame, loadState } = useGame();
@@ -121,6 +126,8 @@ export default function TitleScreen() {
 
   // 各レベルが選択可能かを判定する関数
   const getLockReason = (id: string): string | null => {
+    // フラグが有効なら常に null を返して全レベル解放
+    if (UNLOCK_ALL_LEVELS) return null;
     if (id === 'normal' && !isCleared('easy')) return t('needClearEasy');
     if (id === 'hard' && !isCleared('normal')) return t('needClearNormal');
     return null;


### PR DESCRIPTION
## Summary
- add `EXPO_PUBLIC_UNLOCK_ALL_LEVELS` example in `.env.example`
- update README with debug flag usage
- allow choosing any difficulty when the flag is true

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6871750c9334832cbadbe0f6d735ef7a