### PR TITLE
Add final stage debug flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ EXPO_PUBLIC_DISABLE_ADS=false
 
 # デバッグ時に全難易度を解放する場合は true
 EXPO_PUBLIC_UNLOCK_ALL_LEVELS=false
+
+# 最終ステージからスタートしたいときは true
+EXPO_PUBLIC_START_AT_FINAL_STAGE=false

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ EXPO_PUBLIC_UNLOCK_ALL_LEVELS=true
 
 通常は `false` のままで構いません。
 
+ゲーム開始時にいきなり最終ステージへ進みたい場合は次の設定を追加します。
+
+```bash
+EXPO_PUBLIC_START_AT_FINAL_STAGE=true
+```
+
+デバッグ目的でのみ使用してください。
+
 ## β版の配布について
 
 現在のバージョンはテスト目的の β 版です。TestFlight もしくは Google Play の内部

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -13,6 +13,10 @@ import {
   type State,
 } from './state';
 
+// 環境変数 EXPO_PUBLIC_START_AT_FINAL_STAGE が 'true' のとき
+// ゲーム開始時に最終ステージまで一気に進める
+const START_FINAL = process.env.EXPO_PUBLIC_START_AT_FINAL_STAGE === 'true';
+
 const GameContext = createContext<
   | {
       state: GameState;
@@ -74,7 +78,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     levelId?: string,
     stagePerMap?: number,
     respawnMax?: number,
-  ) =>
+  ) => {
     send({
       type: 'newMaze',
       maze: loadMaze(size),
@@ -92,6 +96,14 @@ export function GameProvider({ children }: { children: ReactNode }) {
       stagePerMap,
       respawnMax,
     });
+    // フラグが有効なら最終ステージまで進める
+    if (START_FINAL) {
+      const total = size * size;
+      for (let i = 1; i < total; i++) {
+        send({ type: 'nextStage' });
+      }
+    }
+  };
   const nextStage = () => send({ type: 'nextStage' });
   const resetRun = () => send({ type: 'resetRun' });
   const respawnEnemies = () => send({ type: 'respawnEnemies', playerPos: state.pos });


### PR DESCRIPTION
## Summary
- support `EXPO_PUBLIC_START_AT_FINAL_STAGE` env var
- document the new flag in README and `.env.example`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687179f8ac34832c85ae85ae9672aba9