### PR TITLE
Fix debug flag after game over

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -222,6 +222,8 @@ export function useResultActions({
       setGameClear(false);
       setNewRecord(false);
       setAdShown(false);
+      // ゲームオーバー後は可視化状態を引き継がないようリセット
+      setDebugAll(false);
       // 4. OK ボタンのロック状態も解除
       okLockedRef.current = false;
       setOkLocked(false);


### PR DESCRIPTION
## Summary
- reset visualization flag when pressing OK on Game Over

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6871850004f8832caa4edba957211f2b