### PR TITLE
Fix infinite loop in error handler

### DIFF
--- a/src/utils/handleError.ts
+++ b/src/utils/handleError.ts
@@ -1,4 +1,5 @@
 import { useSnackbar } from '@/src/hooks/useSnackbar';
+import { useCallback } from 'react';
 
 /**
  * 例外発生時の共通処理を提供するカスタムフック。
@@ -7,8 +8,12 @@ import { useSnackbar } from '@/src/hooks/useSnackbar';
 export function useHandleError() {
   const { show } = useSnackbar();
 
-  return (message: string, error: unknown) => {
-    console.error(message, error);
-    show(message);
-  };
+  // useCallback でラップし、毎回新しい関数が生成されないようにする
+  return useCallback(
+    (message: string, error: unknown) => {
+      console.error(message, error);
+      show(message);
+    },
+    [show],
+  );
 }


### PR DESCRIPTION
## Summary
- stabilize `useHandleError` with `useCallback` to prevent re-renders

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68718c928ed0832c8f029006a8f6c8a8