### PR TITLE
Fix StageBanner infinite loop

### DIFF
--- a/app/stage.tsx
+++ b/app/stage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
 import { StageBanner } from '@/components/StageBanner';
@@ -10,19 +10,24 @@ export default function StageScreen() {
   const { handleBannerFinish, handleBannerDismiss } = usePlayLogic();
   const stageNum = Number(stage) || 1;
 
+  // StageBanner に渡すコールバックは useCallback で固定する
+  // これにより再レンダー時も参照が変わらず、
+  // StageBanner の useEffect が無限ループするのを防ぐ
+  const handleFinish = useCallback(() => {
+    handleBannerFinish();
+    handleBannerDismiss();
+    // 状態更新が反映される前に遷移すると再度バナーが表示されてしまうため
+    // わずかに遅らせてから Play 画面へ戻る
+    setTimeout(() => {
+      router.replace('/play');
+    }, 0);
+  }, [handleBannerFinish, handleBannerDismiss, router]);
+
   return (
     <StageBanner
       visible
       stage={stageNum}
-      onFinish={() => {
-        handleBannerFinish();
-        handleBannerDismiss();
-        // 状態更新が反映される前に遷移すると再度バナーが表示されてしまうため
-        // わずかに遅らせてから Play 画面へ戻る
-        setTimeout(() => {
-          router.replace('/play');
-        }, 0);
-      }}
+      onFinish={handleFinish}
     />
   );
 }


### PR DESCRIPTION
## Summary
- StageScreenのonFinish関数をuseCallbackで固定

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68718df31e10832c8a4f137018791eae