### PR TITLE
Fix StageBanner loop

### DIFF
--- a/components/StageBanner.tsx
+++ b/components/StageBanner.tsx
@@ -22,14 +22,20 @@ export function StageBanner({
 }) {
   // onFinish が複数回実行されないようフラグを保持する
   const calledRef = React.useRef(false);
+  // 最新の onFinish を参照するための ref
+  const finishRef = React.useRef(onFinish);
+  // onFinish が更新されたら参照を更新する
+  useEffect(() => {
+    finishRef.current = onFinish;
+  }, [onFinish]);
 
   // ステージバナーを無効化している場合、表示要求があれば即終了する
   useEffect(() => {
     if (DISABLE_STAGE_BANNER && visible && !calledRef.current) {
       calledRef.current = true;
-      onFinish();
+      finishRef.current();
     }
-  }, [visible, onFinish]);
+  }, [visible]);
 
   useEffect(() => {
     // 表示状態やステージ番号が変わるたびにログを出す
@@ -42,14 +48,14 @@ export function StageBanner({
       console.log(`[StageBanner] onFinish stage=${stage}`);
       if (!calledRef.current) {
         calledRef.current = true;
-        onFinish();
+        finishRef.current();
       }
     }, 2000);
     return () => {
       console.log(`[StageBanner] cleanup stage=${stage}`);
       clearTimeout(id);
     };
-  }, [visible, stage, onFinish]);
+  }, [visible, stage]);
 
   if (!visible || DISABLE_STAGE_BANNER) return null;
   return (


### PR DESCRIPTION
## Summary
- StageBanner の `onFinish` 参照を useRef で保持し、依存関係変化による再実行を防止
- `useEffect` の依存配列を整理して無限ループを解消

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6871985bd46c832c854f8122c3568a44