### PR TITLE
Fix stage banner loop

### DIFF
--- a/app/play.tsx
+++ b/app/play.tsx
@@ -91,17 +91,20 @@ export default function PlayScreen() {
   // これにより状態更新が遅れた場合でも無限ループを防げる
   // React をインポートしていないので useRef を直接使う
   const prevBanner = useRef(false);
+  // router オブジェクトは再レンダー時に変わらないため
+  // 依存配列から除外して無駄な再実行を防ぐ
+  const { replace } = router;
   useEffect(() => {
     // bannerStage が 0 のときは表示データが無いので遷移しない
     if (showBanner && bannerStage > 0 && !prevBanner.current) {
       prevBanner.current = true;
-      router.replace(`/stage?stage=${bannerStage}`);
+      replace(`/stage?stage=${bannerStage}`);
     } else if (!showBanner && prevBanner.current) {
       // バナーが閉じられたらフラグを戻す
       prevBanner.current = false;
 
     }
-  }, [showBanner, bannerStage, router]);
+  }, [showBanner, bannerStage, replace]);
 
   // 1cm を dp に変換し、UI 位置調整に利用
   const oneCm = cmToDp(1);

--- a/app/stage.tsx
+++ b/app/stage.tsx
@@ -24,12 +24,12 @@ export default function StageScreen() {
     setShowBanner(false);
     setBannerStage(0);
     setOkLocked(false);
-    // 状態更新が完了する前に画面遷移すると
-    // banner のフラグが戻らずループする場合がある
-    // 少し待ってから Play 画面へ戻る
+    // 状態更新が反映される前に遷移すると
+    // バナーが再表示されてしまうことがある
+    // 少し余裕を持って待機してから Play 画面へ戻す
     setTimeout(() => {
       router.replace('/play');
-    }, 50);
+    }, 100);
   }, [router, setShowBanner, setBannerStage, setOkLocked]);
 
   return (


### PR DESCRIPTION
## Summary
- avoid router dependency for banner navigation
- wait longer for navigation back to play screen

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a6bc0944832ca29ad3cd902e7816