### PR TITLE
ステージ遷移の無限ループ防止

### DIFF
--- a/app/stage.tsx
+++ b/app/stage.tsx
@@ -32,10 +32,10 @@ export default function StageScreen() {
     // バナーが再表示されてしまうことがある
     // 少し余裕を持って待機してから Play 画面へ戻す
     setTimeout(() => {
-
-      router.replace('/play');
+      // ref から router を参照して常に同じ関数を使う
+      routerRef.current.replace('/play');
     }, 100);
-  }, [router, setShowBanner, setBannerStage, setOkLocked]);
+  }, [setShowBanner, setBannerStage, setOkLocked]);
 
 
   return (


### PR DESCRIPTION
## Summary
- StageScreen で `handleFinish` の依存から `router` を外し、`useRef` で保持した `routerRef` を利用
- これにより `StageBanner` の `useEffect` が毎回実行されるのを防ぎ更新深度超過エラーを回避

## Testing
- `pnpm lint`
- `pnpm test` *(失敗: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871aa3d5f00832c93378f0d6101e05c