### PR TITLE
Add global error handler

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,7 @@ import { RunRecordProvider } from '@/src/hooks/useRunRecords';
 import { BgmProvider } from '@/src/audio/BgmProvider';
 import { SeVolumeProvider } from '@/src/audio/SeVolumeProvider';
 import { useSnackbar } from '@/src/hooks/useSnackbar';
+import { initGlobalErrorHandler } from '@/src/utils/initGlobalErrorHandler';
 
 import { ErrorBoundary } from '@/src/components/ErrorBoundary';
 
@@ -27,6 +28,11 @@ export default function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
+
+  // アプリ全体のエラーハンドラを設定
+  useEffect(() => {
+    initGlobalErrorHandler(showSnackbar);
+  }, [showSnackbar]);
 
   // Google Mobile Ads SDK を初期化する。web 環境や広告無効化時はスキップ
   useEffect(() => {

--- a/src/utils/initGlobalErrorHandler.ts
+++ b/src/utils/initGlobalErrorHandler.ts
@@ -1,0 +1,17 @@
+import { ErrorUtils } from 'react-native';
+
+/**
+ * グローバルエラーハンドラを登録する関数。
+ * React コンポーネント外で発生した予期せぬ例外を捕捉し、
+ * ユーザーへ簡易的なメッセージを表示します。
+ *
+ * @param showSnackbar スナックバー表示用の関数
+ */
+export function initGlobalErrorHandler(showSnackbar: (msg: string) => void) {
+  const defaultHandler = ErrorUtils.getGlobalHandler();
+  ErrorUtils.setGlobalHandler((error: unknown, isFatal?: boolean) => {
+    console.error('Unhandled Error', error);
+    showSnackbar('予期せぬエラーが発生しました');
+    defaultHandler(error, isFatal);
+  });
+}


### PR DESCRIPTION
## Summary
- add global error handler to show snackbar for unhandled errors
- register handler in root layout

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6871b6752c18832cb3b3e1e74bd46b6a