### PR TITLE
Add global unhandled rejection handler

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,6 +17,7 @@ import { BgmProvider } from '@/src/audio/BgmProvider';
 import { SeVolumeProvider } from '@/src/audio/SeVolumeProvider';
 import { useSnackbar } from '@/src/hooks/useSnackbar';
 import { initGlobalErrorHandler } from '@/src/utils/initGlobalErrorHandler';
+import { initUnhandledRejectionHandler } from '@/src/utils/initUnhandledRejectionHandler';
 
 import { ErrorBoundary } from '@/src/components/ErrorBoundary';
 
@@ -32,6 +33,7 @@ export default function RootLayout() {
   // アプリ全体のエラーハンドラを設定
   useEffect(() => {
     initGlobalErrorHandler(showSnackbar);
+    initUnhandledRejectionHandler(showSnackbar);
   }, [showSnackbar]);
 
   // Google Mobile Ads SDK を初期化する。web 環境や広告無効化時はスキップ

--- a/src/utils/initUnhandledRejectionHandler.ts
+++ b/src/utils/initUnhandledRejectionHandler.ts
@@ -1,0 +1,8 @@
+export function initUnhandledRejectionHandler(showSnackbar: (msg: string) => void) {
+  const original = (global as any).onunhandledrejection;
+  (global as any).onunhandledrejection = (event: PromiseRejectionEvent) => {
+    console.error('Unhandled Promise Rejection', event.reason);
+    showSnackbar('予期せぬエラーが発生しました');
+    if (typeof original === 'function') original(event);
+  };
+}


### PR DESCRIPTION
## Summary
- catch unhandled promise rejections globally
- initialize new handler in RootLayout

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6871bca13c70832c879dc1ca6d67c658