### PR TITLE
Improve vibration error handling

### DIFF
--- a/src/game/__tests__/feedback.test.ts
+++ b/src/game/__tests__/feedback.test.ts
@@ -25,7 +25,11 @@ describe('applyDistanceFeedback', () => {
     const fakeId = {} as NodeJS.Timeout;
     intervalSpy.mockReturnValue(fakeId);
 
-    const result = applyDistanceFeedback({ x: 0, y: 0 }, { x: 0, y: 1 });
+    const result = applyDistanceFeedback(
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { showError: jest.fn() },
+    );
 
     expect(result.wait).toBe(400);
     expect(result.id).toBe(fakeId);
@@ -47,7 +51,7 @@ describe('applyDistanceFeedback', () => {
     const result = applyDistanceFeedback(
       { x: 0, y: 0 },
       { x: 0, y: 8 },
-      { maxDist: 8 }
+      { maxDist: 8, showError: jest.fn() }
     );
 
     expect(result.wait).toBe(100);
@@ -66,7 +70,7 @@ describe('applyDistanceFeedback', () => {
     const result = applyDistanceFeedback(
       { x: 0, y: 0 },
       { x: 0, y: 9 },
-      { maxDist: 8 }
+      { maxDist: 8, showError: jest.fn() }
     );
 
     expect(result.wait).toBe(100);
@@ -96,7 +100,7 @@ describe('applyBumpFeedback', () => {
     const fakeId = {} as NodeJS.Timeout;
     intervalSpy.mockReturnValue(fakeId);
 
-    const wait = applyBumpFeedback(border, setColor);
+    const wait = applyBumpFeedback(border, setColor, { showError: jest.fn() });
 
     expect(wait).toBe(300);
     expect(setColor).toHaveBeenCalledWith('red');

--- a/src/game/feedback.ts
+++ b/src/game/feedback.ts
@@ -7,18 +7,25 @@ import type { Vec2 } from '@/src/types/maze';
 import { distance } from './math';
 
 // Expo Haptics の呼び出しが失敗してもアプリが止まらないようにする
-async function safeImpact(style: Haptics.ImpactFeedbackStyle) {
+// 第二引数にメッセージ表示用の関数を渡すと、失敗時にユーザーへ通知できる
+async function safeImpact(
+  style: Haptics.ImpactFeedbackStyle,
+  showError?: (msg: string) => void,
+) {
   try {
     await Haptics.impactAsync(style);
   } catch (e) {
     // 初心者向け: エラー内容を表示しておくと原因調査に役立つ
     console.error('Haptics.impactAsync failed:', e);
+    showError?.('振動エラーが発生しました');
   }
 }
 
 export interface FeedbackOptions {
   /** 最大距離。未指定ならゴール座標から算出した値を使う */
   maxDist?: number;
+  /** エラー表示用の関数 */
+  showError?: (msg: string) => void;
 }
 
 export interface DistanceFeedbackResult {
@@ -62,7 +69,7 @@ export function applyDistanceFeedback(
   const { style, duration } = impact;
 
   // 振動処理は失敗することがあるので try/catch 付きの関数を使う
-  void safeImpact(style);
+  void safeImpact(style, opts.showError);
   const id = setInterval(() => {
     // setInterval でも同様に安全なラッパーを使用
     void safeImpact(style);
@@ -92,7 +99,7 @@ export function applyBumpFeedback(
 
   setColor(UI.colors.bump);
   // 壁にぶつかったときも安全に振動させる
-  void safeImpact(Haptics.ImpactFeedbackStyle.Heavy);
+  void safeImpact(Haptics.ImpactFeedbackStyle.Heavy, opts.showError);
   const id = setInterval(() => {
     void safeImpact(Haptics.ImpactFeedbackStyle.Heavy);
   }, 50);

--- a/src/hooks/useMoveHandler.ts
+++ b/src/hooks/useMoveHandler.ts
@@ -12,6 +12,8 @@ interface Options {
   playMoveSe: () => void;
   playBumpSe: () => void;
   width: number;
+  /** エラー表示用の関数 */
+  showError: (msg: string) => void;
 }
 
 /**
@@ -24,6 +26,7 @@ export function useMoveHandler({
   playMoveSe,
   playBumpSe,
   width,
+  showError,
 }: Options) {
   // 壁衝突時に表示する枠線の色
   const [borderColor, setBorderColor] = useState('transparent');
@@ -58,7 +61,7 @@ export function useMoveHandler({
     if (!move(dir)) {
       // 壁にぶつかったら即座に効果音を鳴らす
       playBumpSe();
-      wait = applyBumpFeedback(borderW, setBorderColor);
+      wait = applyBumpFeedback(borderW, setBorderColor, { showError });
       setTimeout(() => setBorderColor('transparent'), wait);
     } else {
       // 移動成功時も先に効果音を鳴らす
@@ -67,7 +70,7 @@ export function useMoveHandler({
       const { wait: w, id } = applyDistanceFeedback(
         next,
         { x: maze.goal[0], y: maze.goal[1] },
-        { maxDist },
+        { maxDist, showError },
       );
       wait = w;
       intervalRef.current = id;

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -45,6 +45,7 @@ export function usePlayLogic() {
     playMoveSe: audio.playMoveSe,
     playBumpSe: audio.playBumpSe,
     width,
+    showError: showSnackbar,
   });
 
   // ステージ総数。迷路は正方形なので size×size となる


### PR DESCRIPTION
## Summary
- add snackbar notification to haptics errors
- pass the new error handler through `useMoveHandler`
- update unit tests for new parameters

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871be0f82e4832ca46964ca94fa7afa