### PR TITLE
Improve error display with stack trace

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,11 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['react-native-reanimated/plugin'],
+    plugins: [
+      // どのファイルでエラーが起きたか表示するためのプラグイン
+      '@babel/plugin-transform-react-jsx-source',
+      // Reanimated 用プラグインは必ず最後に置く
+      'react-native-reanimated/plugin',
+    ],
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
         "@types/react": "~19.0.10",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@babel/plugin-transform-react-jsx-source": "^7.24.7",
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -10,6 +10,8 @@ interface ErrorBoundaryProps {
 interface ErrorBoundaryState {
   /** エラー発生を示すフラグ */
   hasError: boolean;
+  /** コンポーネントスタック情報。どのファイルで起きたか確認できる */
+  info?: React.ErrorInfo;
 }
 
 /**
@@ -28,18 +30,24 @@ export class ErrorBoundary extends React.Component<
     // 呼び出し元にエラーを通知する
     this.props.onError('予期せぬエラーが発生しました');
     // フォールバック UI を表示するためフラグを立てる
-    this.setState({ hasError: true });
+    this.setState({ hasError: true, info });
   }
 
   render() {
-    if (this.state.hasError) {
-      // シンプルなエラーメッセージだけを表示
-      return (
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-          <Text>エラーが発生しました</Text>
-        </View>
-      );
-    }
+      if (this.state.hasError) {
+        // エラー時にはコンポーネントスタックを併せて表示し
+        // どのファイルで発生したか確認しやすくする
+        return (
+          <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+            <Text>エラーが発生しました</Text>
+            {this.state.info ? (
+              <Text style={{ marginTop: 8, fontSize: 12, color: '#f00' }}>
+                {this.state.info.componentStack}
+              </Text>
+            ) : null}
+          </View>
+        );
+      }
     return this.props.children;
   }
 }


### PR DESCRIPTION
## Summary
- add `@babel/plugin-transform-react-jsx-source`
- show component stack in `ErrorBoundary`
- enable JSX source plugin via Babel config

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6871d28f515c832c8e8a8de983bdd43e