### PR TITLE
ステージ記録リセット条件を修正

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -43,7 +43,8 @@ export function useResultActions({
   );
 
   // 各ステージの記録を保持するコンテキスト
-  const { addRecord, reset } = useRunRecords();
+  // records は記録の配列で、各ステージの歩数などを保持する
+  const { records, addRecord, reset } = useRunRecords();
 
   const {
     showResult,
@@ -119,10 +120,15 @@ export function useResultActions({
 
   // ステージ1開始時は前回の記録をリセットする
   useEffect(() => {
-    if (state.stage === 1 && state.steps === 0 && state.totalSteps === 0) {
+    if (
+      state.stage === 1 &&
+      state.steps === 0 &&
+      state.totalSteps === 0 &&
+      records.length === 0
+    ) {
       reset();
     }
-  }, [state.stage, state.steps, state.totalSteps, reset]);
+  }, [state.stage, state.steps, state.totalSteps, records.length, reset]);
 
   // ゴール到達や捕まったときの処理をまとめる
   useEffect(() => {


### PR DESCRIPTION
## Summary
- `useRunRecords()` から `records` を参照するように変更
- ステージ1開始時の記録リセット条件に `records.length === 0` を追加

## Testing
- `pnpm lint`
- `pnpm test` *(失敗: jest が見つからず実行不可)*

------
https://chatgpt.com/codex/tasks/task_e_6871ea9bdb78832c8684235161f1510b