### PR TITLE
Fix BGM pause only when ads show

### DIFF
--- a/app/game-result.tsx
+++ b/app/game-result.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
@@ -7,7 +7,8 @@ import { PlainButton } from '@/components/PlainButton';
 import { useRunRecords } from '@/src/hooks/useRunRecords';
 import { useLocale } from '@/src/locale/LocaleContext';
 import { useBgm } from '@/src/hooks/useBgm';
-import { showInterstitial } from '@/src/ads/interstitial';
+// 広告表示に必要な関数と無効化フラグ
+import { showInterstitial, DISABLE_ADS } from '@/src/ads/interstitial';
 import { useHandleError } from '@/src/utils/handleError';
 import { UI } from '@/constants/ui';
 
@@ -22,14 +23,16 @@ export default function GameResultScreen() {
 
   /** ホームへ戻るボタンの処理。広告を見てから遷移する */
   const handleBack = async () => {
+    // 広告が表示されるときだけ音を止める
+    const needMute = !DISABLE_ADS && Platform.OS !== 'web';
     try {
-      pauseBgm();
+      if (needMute) pauseBgm();
       await showInterstitial();
     } catch (e) {
       // 広告が表示できなかった場合はユーザーへ知らせる
       handleError('広告を表示できませんでした', e);
     } finally {
-      resumeBgm();
+      if (needMute) resumeBgm();
       router.replace('/');
     }
   };

--- a/app/play.tsx
+++ b/app/play.tsx
@@ -1,4 +1,4 @@
-import { View, Pressable, useWindowDimensions } from "react-native";
+import { View, Pressable, useWindowDimensions, Platform } from "react-native";
 
 // React から必要なフックを個別にインポート
 import { useEffect, useRef, useMemo } from "react";
@@ -12,7 +12,8 @@ import type { MazeData as MazeView } from "@/src/types/maze";
 import { useLocale } from "@/src/locale/LocaleContext";
 import { usePlayLogic } from "@/src/hooks/usePlayLogic";
 import { useBgm } from "@/src/hooks/useBgm";
-import { showInterstitial } from "@/src/ads/interstitial";
+// 広告表示に使う関数と無効化フラグを読み込む
+import { showInterstitial, DISABLE_ADS } from "@/src/ads/interstitial";
 import { useHandleError } from "@/src/utils/handleError";
 import { ResultModal } from "@/components/ResultModal";
 import { useRouter } from "expo-router";
@@ -169,8 +170,10 @@ export default function PlayScreen() {
       incReveal();
       return;
     }
+    // 広告が出る可能性があるときだけ BGM を止める
+    const needMute = !DISABLE_ADS && Platform.OS !== "web";
     try {
-      pauseBgm();
+      if (needMute) pauseBgm();
       await showInterstitial();
       setDebugAll(true);
       incReveal();
@@ -178,7 +181,7 @@ export default function PlayScreen() {
       // 広告表示に失敗したらメッセージを出しておく
       handleError("広告を表示できませんでした", e);
     } finally {
-      resumeBgm();
+      if (needMute) resumeBgm();
     }
   };
 

--- a/components/PlayMenu.tsx
+++ b/components/PlayMenu.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Modal, Pressable, StyleSheet, Switch, View } from 'react-native';
+import { Modal, Pressable, StyleSheet, Switch, View, Platform } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { PlainButton } from '@/components/PlainButton';
 import { ThemedText } from '@/components/ThemedText';
 import { UI } from '@/constants/ui';
 import { useBgm } from '@/src/hooks/useBgm';
-import { showInterstitial } from '@/src/ads/interstitial';
+// 広告関連の関数とフラグをインポート
+import { showInterstitial, DISABLE_ADS } from '@/src/ads/interstitial';
 import { useHandleError } from '@/src/utils/handleError';
 import { useRunRecords } from '@/src/hooks/useRunRecords';
 
@@ -80,8 +81,10 @@ export function PlayMenu({
         incReveal();
         return;
       }
+      // 広告を表示するときだけ BGM を一時停止する
+      const needMute = !DISABLE_ADS && Platform.OS !== 'web';
       try {
-        pauseBgm();
+        if (needMute) pauseBgm();
         await showInterstitial();
         setDebugAll(true);
         incReveal();
@@ -89,7 +92,7 @@ export function PlayMenu({
         // 広告が出なかった場合はエラーメッセージを表示
         handleError('広告を表示できませんでした', e);
       } finally {
-        resumeBgm();
+        if (needMute) resumeBgm();
       }
     } else {
       setDebugAll(false);

--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -1,6 +1,7 @@
-import { useWindowDimensions } from 'react-native';
+import { useWindowDimensions, Platform } from 'react-native';
 import { useRouter } from 'expo-router';
-import { showInterstitial } from '@/src/ads/interstitial';
+// 広告関連の関数とフラグをまとめて読み込む
+import { showInterstitial, DISABLE_ADS } from '@/src/ads/interstitial';
 import { useHandleError } from '@/src/utils/handleError';
 
 import { useGame } from '@/src/game/useGame';
@@ -56,13 +57,15 @@ export function usePlayLogic() {
   // 敵のみをリスポーンする処理
   const handleRespawn = async () => {
     if (state.respawnStock <= 0) {
+      // 広告表示がある場合のみ BGM を止める
+      const needMute = !DISABLE_ADS && Platform.OS !== 'web';
       try {
-        audio.pauseBgm();
+        if (needMute) audio.pauseBgm();
         await showInterstitial();
       } catch (e) {
         handleError('広告を表示できませんでした', e);
       } finally {
-        audio.resumeBgm();
+        if (needMute) audio.resumeBgm();
       }
     }
     respawnEnemies();


### PR DESCRIPTION
## Summary
- avoid muting BGM when ads are disabled or running on web
- update play screen, play menu, respawn logic and game result accordingly

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871e371c878832caf007451f47e4c58