### PR TITLE
Change newGame to object options

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -79,22 +79,22 @@ export default function TitleScreen() {
     } else {
       audio.changeBgm(require('../assets/sounds/降りしきる、白_調整.mp3'));
     }
-    newGame(
-      level.size,
-      level.enemies,
-      level.enemyPathLength,
-      level.playerPathLength,
-      level.wallLifetime,
-      level.enemyCountsFn,
-      level.wallLifetimeFn,
-      level.showAdjacentWalls,
-      level.showAdjacentWallsFn,
-      level.biasedSpawn,
-      level.biasedGoal,
-      level.id,
-      level.stagePerMap,
-      level.respawnMax
-    );
+    newGame({
+      size: level.size,
+      counts: level.enemies,
+      enemyPathLength: level.enemyPathLength,
+      playerPathLength: level.playerPathLength,
+      wallLifetime: level.wallLifetime,
+      enemyCountsFn: level.enemyCountsFn,
+      wallLifetimeFn: level.wallLifetimeFn,
+      showAdjacentWalls: level.showAdjacentWalls,
+      showAdjacentWallsFn: level.showAdjacentWallsFn,
+      biasedSpawn: level.biasedSpawn,
+      biasedGoal: level.biasedGoal,
+      levelId: level.id,
+      stagePerMap: level.stagePerMap,
+      respawnMax: level.respawnMax,
+    });
     // 画面遷移開始をログ
     devLog('[TitleScreen] navigate begin');
     await router.replace("/play");

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -25,22 +25,18 @@ export default function PracticeScreen() {
   const [wallLife, setWallLife] = React.useState<number>(Infinity);
 
   const start = (size: number) => {
-    newGame(
+    newGame({
       size,
-      { random, slow, sight, fast: 0 },
-      pathLen,
-      playerLen,
-      wallLife,
-      undefined,
-      undefined,
-      true,
-      undefined,
-      true,
-      true,
-      'practice',
-      3,
-      3,
-    );
+      counts: { random, slow, sight, fast: 0 },
+      enemyPathLength: pathLen,
+      playerPathLength: playerLen,
+      wallLifetime: wallLife,
+      biasedSpawn: true,
+      biasedGoal: true,
+      levelId: 'practice',
+      stagePerMap: 3,
+      respawnMax: 3,
+    });
     router.replace('/play');
   };
 

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -70,22 +70,22 @@ export default function ResetConfirmScreen() {
     } else {
       setPendingBgm(bgmFile);
     }
-    newGame(
-      level.size,
-      level.enemies,
-      level.enemyPathLength,
-      level.playerPathLength,
-      level.wallLifetime,
-      level.enemyCountsFn,
-      level.wallLifetimeFn,
-      level.showAdjacentWalls,
-      level.showAdjacentWallsFn,
-      level.biasedSpawn,
-      level.biasedGoal,
-      level.id,
-      level.stagePerMap,
-      level.respawnMax,
-    );
+    newGame({
+      size: level.size,
+      counts: level.enemies,
+      enemyPathLength: level.enemyPathLength,
+      playerPathLength: level.playerPathLength,
+      wallLifetime: level.wallLifetime,
+      enemyCountsFn: level.enemyCountsFn,
+      wallLifetimeFn: level.wallLifetimeFn,
+      showAdjacentWalls: level.showAdjacentWalls,
+      showAdjacentWallsFn: level.showAdjacentWallsFn,
+      biasedSpawn: level.biasedSpawn,
+      biasedGoal: level.biasedGoal,
+      levelId: level.id,
+      stagePerMap: level.stagePerMap,
+      respawnMax: level.respawnMax,
+    });
     router.replace('/play');
   };
 

--- a/src/game/state/core.ts
+++ b/src/game/state/core.ts
@@ -2,6 +2,7 @@ import { wallSet } from '../maze';
 import { selectEnemyBehavior } from '../enemy';
 import type { MazeData, Vec2 } from '@/src/types/maze';
 import type { Enemy, EnemyCounts } from '@/src/types/enemy';
+import type { NewGameOptions } from '@/src/types/game';
 import { createEnemies } from './enemy';
 import { addAdjacentWalls } from './utils';
 
@@ -89,27 +90,30 @@ export function initState(
   stage: number,
   visitedGoals: Set<string>,
   finalStage: boolean,
+  options: NewGameOptions = {},
   hitV: Map<string, number> = new Map(),
   hitH: Map<string, number> = new Map(),
-  enemyCounts: EnemyCounts = { random: 0, slow: 0, sight: 0, fast: 0 },
-  enemyPathLength: number = 4,
-  playerPathLength: number = Infinity,
-  wallLifetime: number = Infinity,
-  enemyCountsFn?: (stage: number) => EnemyCounts,
-  wallLifetimeFn?: (stage: number) => number,
-  showAdjacentWalls: boolean = false,
-  showAdjacentWallsFn?: (stage: number) => boolean,
-  biasedSpawn: boolean = true,
-  biasedGoal: boolean = true,
-  levelId?: string,
-  stagePerMap: number = 3,
-  respawnMax: number = 3,
-  respawnStock: number = respawnMax,
+  respawnStock: number = options.respawnMax ?? 3,
   totalSteps: number = 0,
   totalBumps: number = 0,
 ): State {
+  const {
+    counts = { random: 0, slow: 0, sight: 0, fast: 0 },
+    enemyPathLength = 4,
+    playerPathLength = Infinity,
+    wallLifetime = Infinity,
+    enemyCountsFn,
+    wallLifetimeFn,
+    showAdjacentWalls = false,
+    showAdjacentWallsFn,
+    biasedSpawn = true,
+    biasedGoal = true,
+    levelId,
+    stagePerMap = 3,
+    respawnMax = 3,
+  } = options;
   const maze = prepMaze(m);
-  const enemies = createEnemies(enemyCounts, maze, biasedSpawn);
+  const enemies = createEnemies(counts, maze, biasedSpawn);
   const enemyBehavior = selectEnemyBehavior(m.size, finalStage);
   const life = wallLifetimeFn ? wallLifetimeFn(stage) : wallLifetime;
   // 周囲表示が有効なら開始時点で周囲の壁を記録する
@@ -140,7 +144,7 @@ export function initState(
     visitedGoals,
     finalStage,
     enemyBehavior,
-    enemyCounts,
+    enemyCounts: counts,
     enemyCountsFn,
     enemyPathLength,
     playerPathLength,

--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -1,6 +1,6 @@
 import { handleMoveAction } from './moveHandlers';
 import type { Dir, MazeData } from '@/src/types/maze';
-import type { EnemyCounts } from '@/src/types/enemy';
+import type { NewGameOptions } from '@/src/types/game';
 import { initState, State } from './core';
 import { createFirstStage, nextStageState, restartRun } from './stage';
 import { createEnemies } from './enemy';
@@ -10,23 +10,7 @@ export type Action =
   | { type: 'reset' }
   | { type: 'move'; dir: Dir }
   | { type: 'load'; state: State }
-  | {
-      type: 'newMaze';
-      maze: MazeData;
-      counts?: EnemyCounts;
-      enemyPathLength?: number;
-      playerPathLength?: number;
-      wallLifetime?: number;
-      enemyCountsFn?: (stage: number) => EnemyCounts;
-      wallLifetimeFn?: (stage: number) => number;
-      showAdjacentWalls?: boolean;
-      showAdjacentWallsFn?: (stage: number) => boolean;
-      biasedSpawn?: boolean;
-      biasedGoal?: boolean;
-      levelId?: string;
-      stagePerMap?: number;
-      respawnMax?: number;
-    }
+  | ({ type: 'newMaze'; maze: MazeData } & NewGameOptions)
   | { type: 'nextStage' }
   | { type: 'resetRun' }
   | { type: 'respawnEnemies'; playerPos: { x: number; y: number } };
@@ -39,42 +23,43 @@ export function reducer(state: State, action: Action): State {
         state.stage,
         new Set(state.visitedGoals),
         state.finalStage,
+        {
+          counts: state.enemyCounts,
+          enemyPathLength: state.enemyPathLength,
+          playerPathLength: state.playerPathLength,
+          wallLifetime: state.wallLifetime,
+          enemyCountsFn: state.enemyCountsFn,
+          wallLifetimeFn: state.wallLifetimeFn,
+          showAdjacentWalls: state.showAdjacentWalls,
+          showAdjacentWallsFn: state.showAdjacentWallsFn,
+          biasedSpawn: state.biasedSpawn,
+          biasedGoal: state.biasedGoal,
+          levelId: state.levelId,
+          stagePerMap: state.stagePerMap,
+          respawnMax: state.respawnMax,
+        },
         undefined,
         undefined,
-        state.enemyCounts,
-        state.enemyPathLength,
-        state.playerPathLength,
-        state.wallLifetime,
-        state.enemyCountsFn,
-        state.wallLifetimeFn,
-        state.showAdjacentWalls,
-        state.showAdjacentWallsFn,
-        state.biasedSpawn,
-        state.biasedGoal,
-        state.levelId,
-        state.stagePerMap,
-        state.respawnMax,
         state.respawnStock,
         state.totalSteps,
         state.totalBumps,
       );
     case 'newMaze':
-      return createFirstStage(
-        action.maze,
-        action.counts ?? state.enemyCounts,
-        action.enemyPathLength ?? state.enemyPathLength,
-        action.playerPathLength ?? state.playerPathLength,
-        action.wallLifetime ?? state.wallLifetime,
-        action.enemyCountsFn,
-        action.wallLifetimeFn,
-        action.biasedSpawn ?? state.biasedSpawn,
-        action.levelId,
-        action.stagePerMap ?? state.stagePerMap,
-        action.respawnMax ?? state.respawnMax,
-        action.biasedGoal ?? state.biasedGoal,
-        action.showAdjacentWalls ?? state.showAdjacentWalls,
-        action.showAdjacentWallsFn,
-      );
+      return createFirstStage(action.maze, {
+        counts: action.counts ?? state.enemyCounts,
+        enemyPathLength: action.enemyPathLength ?? state.enemyPathLength,
+        playerPathLength: action.playerPathLength ?? state.playerPathLength,
+        wallLifetime: action.wallLifetime ?? state.wallLifetime,
+        enemyCountsFn: action.enemyCountsFn,
+        wallLifetimeFn: action.wallLifetimeFn,
+        biasedSpawn: action.biasedSpawn ?? state.biasedSpawn,
+        levelId: action.levelId,
+        stagePerMap: action.stagePerMap ?? state.stagePerMap,
+        respawnMax: action.respawnMax ?? state.respawnMax,
+        biasedGoal: action.biasedGoal ?? state.biasedGoal,
+        showAdjacentWalls: action.showAdjacentWalls ?? state.showAdjacentWalls,
+        showAdjacentWallsFn: action.showAdjacentWallsFn,
+      });
     case 'nextStage':
       return nextStageState(state);
     case 'resetRun':

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -4,7 +4,7 @@ import { canMove } from './maze';
 import { loadMaze } from './loadMaze';
 import { saveGame } from './saveGame';
 import type { MazeData, Dir } from '@/src/types/maze';
-import type { EnemyCounts } from '@/src/types/enemy';
+import type { NewGameOptions } from '@/src/types/game';
 import {
   reducer,
   createFirstStage,
@@ -22,22 +22,7 @@ const GameContext = createContext<
       state: GameState;
       move: (dir: Dir) => boolean;
       reset: () => void;
-      newGame: (
-        size: number,
-        counts?: EnemyCounts,
-        enemyPathLength?: number,
-        playerPathLength?: number,
-        wallLifetime?: number,
-        enemyCountsFn?: (stage: number) => EnemyCounts,
-        wallLifetimeFn?: (stage: number) => number,
-        showAdjacentWalls?: boolean,
-        showAdjacentWallsFn?: (stage: number) => boolean,
-        biasedSpawn?: boolean,
-        biasedGoal?: boolean,
-        levelId?: string,
-        stagePerMap?: number,
-        respawnMax?: number,
-      ) => void;
+      newGame: (options?: NewGameOptions) => void;
       nextStage: () => void;
       resetRun: () => void;
       respawnEnemies: () => void;
@@ -63,22 +48,23 @@ export function GameProvider({ children }: { children: ReactNode }) {
   const send = (action: Action) => dispatch(action);
 
   const reset = () => send({ type: 'reset' });
-  const newGame = (
-    size: number = 10,
-    counts?: EnemyCounts,
-    enemyPathLength?: number,
-    playerPathLength?: number,
-    wallLifetime?: number,
-    enemyCountsFn?: (stage: number) => EnemyCounts,
-    wallLifetimeFn?: (stage: number) => number,
-    showAdjacentWalls?: boolean,
-    showAdjacentWallsFn?: (stage: number) => boolean,
-    biasedSpawn?: boolean,
-    biasedGoal?: boolean,
-    levelId?: string,
-    stagePerMap?: number,
-    respawnMax?: number,
-  ) => {
+  const newGame = (options: NewGameOptions = {}) => {
+    const {
+      size = 10,
+      counts,
+      enemyPathLength,
+      playerPathLength,
+      wallLifetime,
+      enemyCountsFn,
+      wallLifetimeFn,
+      showAdjacentWalls,
+      showAdjacentWallsFn,
+      biasedSpawn,
+      biasedGoal,
+      levelId,
+      stagePerMap,
+      respawnMax,
+    } = options;
     send({
       type: 'newMaze',
       maze: loadMaze(size),

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,30 @@
+export interface NewGameOptions {
+  /** 迷路サイズ。未指定なら10 */
+  size?: number;
+  /** 敵の出現数 */
+  counts?: import('./enemy').EnemyCounts;
+  /** 敵の軌跡を何マス残すか */
+  enemyPathLength?: number;
+  /** プレイヤーの軌跡長 */
+  playerPathLength?: number;
+  /** 壁表示を維持するターン数 */
+  wallLifetime?: number;
+  /** ステージ番号から敵数を計算する関数 */
+  enemyCountsFn?: (stage: number) => import('./enemy').EnemyCounts;
+  /** ステージ番号から壁寿命を計算する関数 */
+  wallLifetimeFn?: (stage: number) => number;
+  /** 周囲の壁を常に表示するか */
+  showAdjacentWalls?: boolean;
+  /** ステージ番号から周囲表示の有無を決める関数 */
+  showAdjacentWallsFn?: (stage: number) => boolean;
+  /** 敵のスポーン位置をスタートから遠くするか */
+  biasedSpawn?: boolean;
+  /** ゴールをスタートから遠ざけるかどうか */
+  biasedGoal?: boolean;
+  /** レベル識別子。練習モードでは undefined */
+  levelId?: string;
+  /** 何ステージごとに新しい迷路へ切り替えるか */
+  stagePerMap?: number;
+  /** 敵をリスポーンできる最大回数 */
+  respawnMax?: number;
+}


### PR DESCRIPTION
## Summary
- introduce `NewGameOptions` interface
- refactor `newGame` and state initializers to take option objects
- update stage logic and reducer
- adapt call sites in app screens

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6872085c8db8832c85fd7dc0aae576c9