### PR TITLE
Refactor level1 enemy count table

### DIFF
--- a/src/game/level1.ts
+++ b/src/game/level1.ts
@@ -1,5 +1,122 @@
 import type { EnemyCounts } from '@/src/types/enemy';
 
+/** ステージ範囲ごとの敵出現数テーブル */
+interface StageRow {
+  /**
+   * この行が適用される最終ステージ番号
+   * 例: end が 9 の場合、1〜9 ステージに適用
+   */
+  end: number;
+  /**
+   * 余り(mod)ごとの敵数を格納
+   * index0: mod=0, index1: mod=1, index2: mod=2
+   */
+  mods: [EnemyCounts, EnemyCounts, EnemyCounts];
+}
+
+/**
+ * 下記配列は `doc/level.md` の表をそのまま写したものです。
+ * ステージ範囲と mod の組み合わせから敵数を参照します。
+ */
+const STAGE_TABLE: StageRow[] = [
+  {
+    end: 9,
+    mods: [
+      { random: 0, slow: 1, sight: 0, fast: 0 }, // mod 0
+      { random: 1, slow: 0, sight: 0, fast: 0 }, // mod 1
+      { random: 1, slow: 0, sight: 0, fast: 0 }, // mod 2
+    ],
+  },
+  {
+    end: 18,
+    mods: [
+      { random: 1, slow: 0, sight: 0, fast: 0 }, // mod 0
+      { random: 1, slow: 0, sight: 0, fast: 0 }, // mod 1
+      { random: 1, slow: 0, sight: 0, fast: 0 }, // mod 2
+    ],
+  },
+  {
+    end: 27,
+    mods: [
+      { random: 0, slow: 2, sight: 0, fast: 0 },
+      { random: 1, slow: 0, sight: 0, fast: 0 },
+      { random: 1, slow: 0, sight: 0, fast: 0 },
+    ],
+  },
+  {
+    end: 36,
+    mods: [
+      { random: 0, slow: 2, sight: 0, fast: 0 },
+      { random: 1, slow: 0, sight: 0, fast: 0 },
+      { random: 2, slow: 0, sight: 0, fast: 0 },
+    ],
+  },
+  {
+    end: 45,
+    mods: [
+      { random: 1, slow: 2, sight: 0, fast: 0 },
+      { random: 2, slow: 0, sight: 0, fast: 0 },
+      { random: 2, slow: 0, sight: 0, fast: 0 },
+    ],
+  },
+  {
+    end: 54,
+    mods: [
+      { random: 1, slow: 2, sight: 0, fast: 0 },
+      { random: 2, slow: 0, sight: 0, fast: 0 },
+      { random: 0, slow: 3, sight: 0, fast: 0 },
+    ],
+  },
+  {
+    end: 63,
+    mods: [
+      { random: 1, slow: 2, sight: 0, fast: 0 },
+      { random: 2, slow: 0, sight: 0, fast: 0 },
+      { random: 0, slow: 3, sight: 0, fast: 0 },
+    ],
+  },
+  {
+    end: 72,
+    mods: [
+      { random: 2, slow: 1, sight: 0, fast: 0 },
+      { random: 2, slow: 0, sight: 0, fast: 0 },
+      { random: 1, slow: 2, sight: 0, fast: 0 },
+    ],
+  },
+  {
+    end: 81,
+    mods: [
+      { random: 2, slow: 0, sight: 1, fast: 0 },
+      { random: 2, slow: 0, sight: 0, fast: 0 },
+      { random: 1, slow: 2, sight: 0, fast: 0 },
+    ],
+  },
+  {
+    end: 90,
+    mods: [
+      { random: 1, slow: 3, sight: 0, fast: 0 },
+      { random: 1, slow: 2, sight: 0, fast: 0 },
+      { random: 3, slow: 0, sight: 0, fast: 0 },
+    ],
+  },
+  {
+    end: 99,
+    mods: [
+      { random: 1, slow: 2, sight: 1, fast: 0 },
+      { random: 1, slow: 2, sight: 1, fast: 0 },
+      { random: 1, slow: 2, sight: 1, fast: 0 },
+    ],
+  },
+  {
+    end: Infinity,
+    mods: [
+      { random: 1, slow: 2, sight: 2, fast: 0 },
+      { random: 1, slow: 2, sight: 2, fast: 0 },
+      { random: 1, slow: 2, sight: 2, fast: 0 },
+    ],
+  },
+];
+
 /**
  * レベル1・2共通の敵出現数を返す関数です。
  *
@@ -8,88 +125,16 @@ import type { EnemyCounts } from '@/src/types/enemy';
  * この関数も同じ内容になるよう実装しています。
  */
 export function level1EnemyCounts(stage: number): EnemyCounts {
-  // 100 ステージ以降は表の最終行(ステージ100)と同じ扱い
-  if (stage >= 100) {
-    return { random: 1, slow: 2, sight: 2, fast: 0 };
+  const mod = stage % 3 as 0 | 1 | 2;
+
+  for (const row of STAGE_TABLE) {
+    if (stage <= row.end) {
+      return row.mods[mod];
+    }
   }
 
-  const mod = stage % 3;
-
-  // --- ステージ 1〜9 ---------------------------------
-  if (stage <= 9) {
-    // mod が 0 のときだけ鈍足視認 1 体
-    if (mod === 0) return { random: 0, slow: 1, sight: 0, fast: 0 };
-    return { random: 1, slow: 0, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 10〜18 ---------------------------------
-  if (stage <= 18) {
-    // すべてランダム 1 体
-    return { random: 1, slow: 0, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 19〜27 ---------------------------------
-  if (stage <= 27) {
-    if (mod === 0) return { random: 0, slow: 2, sight: 0, fast: 0 };
-    return { random: 1, slow: 0, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 28〜36 ---------------------------------
-  if (stage <= 36) {
-    if (mod === 0) return { random: 0, slow: 2, sight: 0, fast: 0 };
-    if (mod === 2) return { random: 2, slow: 0, sight: 0, fast: 0 };
-    return { random: 1, slow: 0, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 37〜45 ---------------------------------
-  if (stage <= 45) {
-    if (mod === 0) return { random: 1, slow: 2, sight: 0, fast: 0 };
-    return { random: 2, slow: 0, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 46〜54 ---------------------------------
-  if (stage <= 54) {
-    if (mod === 1) return { random: 2, slow: 0, sight: 0, fast: 0 };
-    if (mod === 2) return { random: 0, slow: 3, sight: 0, fast: 0 };
-    return { random: 1, slow: 2, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 55〜63 ---------------------------------
-  if (stage <= 63) {
-    if (mod === 1) return { random: 2, slow: 0, sight: 0, fast: 0 };
-    if (mod === 2) return { random: 0, slow: 3, sight: 0, fast: 0 };
-    return { random: 1, slow: 2, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 64〜72 ---------------------------------
-  if (stage <= 72) {
-    if (mod === 1) return { random: 2, slow: 0, sight: 0, fast: 0 };
-    if (mod === 2) return { random: 1, slow: 2, sight: 0, fast: 0 };
-    return { random: 2, slow: 1, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 73〜81 ---------------------------------
-  if (stage <= 81) {
-    if (mod === 1) return { random: 2, slow: 0, sight: 0, fast: 0 };
-    if (mod === 2) return { random: 1, slow: 2, sight: 0, fast: 0 };
-    return { random: 2, slow: 0, sight: 1, fast: 0 };
-  }
-
-  // --- ステージ 82〜90 ---------------------------------
-  if (stage <= 90) {
-    if (mod === 1) return { random: 1, slow: 2, sight: 0, fast: 0 };
-    if (mod === 2) return { random: 3, slow: 0, sight: 0, fast: 0 };
-    return { random: 1, slow: 3, sight: 0, fast: 0 };
-  }
-
-  // --- ステージ 91〜99 ---------------------------------
-  if (stage <= 99) {
-    // mod に関係なく同じ数
-    return { random: 1, slow: 2, sight: 1, fast: 0 };
-  }
-
-  // 理論上ここには来ないが型安全のため
-  return { random: 1, slow: 2, sight: 1, fast: 0 };
+  // ここには来ない想定だが、型安全のため最後の行を返す
+  return STAGE_TABLE[STAGE_TABLE.length - 1].mods[mod];
 }
 
 /**


### PR DESCRIPTION
## Summary
- use a stage table to look up level1 enemy counts
- greatly reduce if statements in `level1EnemyCounts`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872087cfc50832c8c90d0a2fe26a909