### PR TITLE
Refactor result actions into smaller hooks

### DIFF
--- a/src/hooks/useAdManager.ts
+++ b/src/hooks/useAdManager.ts
@@ -1,0 +1,68 @@
+import { useRef, useState, useCallback } from 'react';
+import type { InterstitialAd } from 'react-native-google-mobile-ads';
+import { useStageEffects } from '@/src/hooks/useStageEffects';
+import { useLocale } from '@/src/locale/LocaleContext';
+import { useResultState } from '@/src/hooks/useResultState';
+
+interface Options {
+  stage: number;
+  finalStage: boolean;
+  levelId?: string | null;
+  pauseBgm: () => void;
+  resumeBgm: () => void;
+}
+
+/**
+ * インタースティシャル広告の管理を行うフック。
+ * 読み込みと表示、OK ボタンラベル制御をまとめています。
+ */
+export function useAdManager({ stage, finalStage, levelId, pauseBgm, resumeBgm }: Options) {
+  const { t } = useLocale();
+  const { loadAdIfNeeded, showAd } = useStageEffects({ pauseBgm, resumeBgm, levelId: levelId ?? undefined });
+
+  const loadedAdRef = useRef<InterstitialAd | null>(null);
+  const { okLocked, setOkLocked } = useResultState();
+  const [okLabel, setOkLabel] = useState(t('ok'));
+  const okLockedRef = useRef(false);
+
+  /** ステージクリア時に広告を読み込む */
+  const preloadAd = useCallback(() => {
+    okLockedRef.current = true;
+    setOkLocked(true);
+    setOkLabel(t('loadingAd'));
+    loadAdIfNeeded(stage).then((ad) => {
+      loadedAdRef.current = ad;
+      if (finalStage) {
+        setOkLabel(t('goGameResult'));
+      } else {
+        setOkLabel(ad ? t('showAd') : t('nextStage'));
+      }
+      okLockedRef.current = false;
+      setOkLocked(false);
+    });
+  }, [loadAdIfNeeded, stage, finalStage, t, setOkLocked]);
+
+  /** 広告を表示し、表示されたらラベルを更新 */
+  const showLoadedAd = useCallback(async () => {
+    const shown = await showAd(loadedAdRef.current);
+    loadedAdRef.current = null;
+    if (shown) setOkLabel(t('nextStage'));
+    return shown;
+  }, [showAd, t]);
+
+  /** ラベルとロックを初期状態へ戻す */
+  const resetLabel = useCallback(() => {
+    setOkLabel(t('ok'));
+    okLockedRef.current = false;
+    setOkLocked(false);
+  }, [t, setOkLocked]);
+
+  return {
+    okLabel,
+    okLocked,
+    okLockedRef,
+    preloadAd,
+    showLoadedAd,
+    resetLabel,
+  } as const;
+}

--- a/src/hooks/useBannerControl.ts
+++ b/src/hooks/useBannerControl.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useResultState } from '@/src/hooks/useResultState';
+import { useRunRecords } from '@/src/hooks/useRunRecords';
+
+interface Options {
+  stage: number;
+  steps: number;
+  totalSteps: number;
+}
+
+/**
+ * ステージバナー表示と記録リセットを管理するフック。
+ * ゲーム開始直後のバナー表示やバナー終了処理を担当します。
+ */
+export function useBannerControl({ stage, steps, totalSteps }: Options) {
+  const {
+    showBanner,
+    setShowBanner,
+    bannerStage,
+    setBannerStage,
+    bannerShown,
+    setBannerShown,
+  } = useResultState();
+  const { records, reset } = useRunRecords();
+
+  // バナー表示中かどうかのフラグ
+  const bannerActiveRef = useRef(false);
+
+  // バナー非表示時はフラグも戻す
+  useEffect(() => {
+    if (!showBanner) bannerActiveRef.current = false;
+  }, [showBanner]);
+
+  // ステージ1開始時に一度だけバナーを出す
+  useEffect(() => {
+    if (
+      stage === 1 &&
+      steps === 0 &&
+      !showBanner &&
+      bannerStage === 0 &&
+      !bannerShown
+    ) {
+      setBannerStage(1);
+      setShowBanner(true);
+      bannerActiveRef.current = true;
+      setBannerShown(true);
+    }
+  }, [stage, steps, showBanner, bannerStage, bannerShown, setBannerStage, setShowBanner, setBannerShown]);
+
+  // ステージ1開始時は前回の記録をリセット
+  useEffect(() => {
+    if (
+      stage === 1 &&
+      steps === 0 &&
+      totalSteps === 0 &&
+      records.length === 0
+    ) {
+      reset();
+    }
+  }, [stage, steps, totalSteps, records.length, reset]);
+
+  /** バナーの終了処理 */
+  const handleBannerFinish = useCallback(() => {
+    setShowBanner(false);
+    bannerActiveRef.current = false;
+  }, [setShowBanner]);
+
+  /** フェードアウト後に番号をリセット */
+  const handleBannerDismiss = useCallback(() => {
+    setBannerStage(0);
+  }, [setBannerStage]);
+
+  /** 次ステージ番号を設定してバナーを表示 */
+  const startBanner = useCallback(
+    (nextStage: number) => {
+      setBannerStage(nextStage);
+      setShowBanner(true);
+      bannerActiveRef.current = true;
+    },
+    [setBannerStage, setShowBanner],
+  );
+
+  return {
+    showBanner,
+    bannerStage,
+    bannerActiveRef,
+    handleBannerFinish,
+    handleBannerDismiss,
+    startBanner,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- 押下処理などが長くなっていた `useResultActions` を整理
- ステージバナー管理を `useBannerControl` として分離
- 広告読み込み・表示周りを `useAdManager` として独立
- それぞれ簡単な日本語コメントを追加

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68721b113d2c832c9ecf1f03b29f11a8