### PR TITLE
Add tsx runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ mazesense/
 ## 迷路データの更新手順
 
 `assets/mazes` フォルダに迷路 JSON を配置した状態で `pnpm start` などの起動
-コマンドを実行すると、`scripts/update-maze-import.js` が自動的に走り
+コマンドを実行すると、`scripts/update-maze-import.ts` が自動的に走り
 `src/game/mazeAsset.ts` が生成されます。これにより迷路セットが最新の内容に
 置き換わります。手動で更新したい場合は以下を実行してください。
 
 ```bash
-pnpm exec node scripts/update-maze-import.js
+pnpm exec tsx scripts/update-maze-import.ts
 ```
 
 ## デバッグ用オプション

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "prestart": "node ./scripts/update-maze-import.ts",
+    "prestart": "npx tsx ./scripts/update-maze-import.ts",
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "preandroid": "node ./scripts/update-maze-import.ts",
+    "preandroid": "npx tsx ./scripts/update-maze-import.ts",
     "android": "expo start --android",
-    "preios": "node ./scripts/update-maze-import.ts",
+    "preios": "npx tsx ./scripts/update-maze-import.ts",
     "ios": "expo start --ios",
-    "preweb": "node ./scripts/update-maze-import.ts",
+    "preweb": "npx tsx ./scripts/update-maze-import.ts",
     "web": "expo start --web",
     "lint": "expo lint",
     "test": "jest"
@@ -55,7 +55,8 @@
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "tsx": "^4.7.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- npm scriptsでtsxを実行するよう変更
- devDependenciesに`tsx`を追加
- READMEのコマンド例を`.ts`版に修正

## Testing
- `pnpm lint` *(fail: expo not found)*
- `pnpm exec tsx scripts/update-maze-import.ts` *(fail: Command "tsx" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68721b0e8404832cb18d0c10aa21389c