### PR TITLE
Fix provider hierarchy for locale hook

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -58,9 +58,9 @@ export default function RootLayout() {
   return (
     <ErrorBoundary onError={showSnackbar}>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <BgmProvider>
-          <SeVolumeProvider>
-            <LocaleProvider>
+        <LocaleProvider>
+          <BgmProvider>
+            <SeVolumeProvider>
               <ResultStateProvider>
                 <RunRecordProvider>
                 <GameProvider>
@@ -79,10 +79,10 @@ export default function RootLayout() {
               </GameProvider>
               </RunRecordProvider>
               </ResultStateProvider>
-            </LocaleProvider>
-            <StatusBar style="auto" />
-          </SeVolumeProvider>
-        </BgmProvider>
+              <StatusBar style="auto" />
+            </SeVolumeProvider>
+          </BgmProvider>
+        </LocaleProvider>
       </ThemeProvider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary
- wrap `BgmProvider` with `LocaleProvider`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c07769b8832cac54cde57b2b907e