### PR TITLE
fix reveal flag persistence

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -18,6 +18,7 @@ import { useAudioControls } from "@/src/hooks/useAudioControls";
 import { useLevelUnlock } from "@/src/hooks/useLevelUnlock";
 import { UI } from "@/constants/ui";
 import { devLog } from "@/src/utils/logger";
+import { useResultState } from "@/src/hooks/useResultState";
 
 // EXPO_PUBLIC_UNLOCK_ALL_LEVELS が 'true' のとき
 // クリア状況に関わらず全難易度を選択可能にする
@@ -30,6 +31,8 @@ export default function TitleScreen() {
   const { t, firstLaunch, changeLang } = useLocale();
   const { show: showSnackbar } = useSnackbar();
   const { isCleared } = useLevelUnlock();
+  // 可視化フラグのリセット用フックを取得
+  const { setDebugAll } = useResultState();
 
   const [showLang, setShowLang] = React.useState(false);
   const [hasSave, setHasSave] = React.useState(false);
@@ -79,6 +82,8 @@ export default function TitleScreen() {
     } else {
       audio.changeBgm(require('../assets/sounds/降りしきる、白_調整.mp3'));
     }
+    // 前回の可視化状態を引き継がないよう初期化する
+    setDebugAll(false);
     newGame({
       size: level.size,
       counts: level.enemies,

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -12,6 +12,7 @@ import { useGame } from '@/src/game/useGame';
 import { useLocale, type MessageKey } from '@/src/locale/LocaleContext';
 import { useBgm } from '@/src/hooks/useBgm';
 import { UI } from '@/constants/ui';
+import { useResultState } from '@/src/hooks/useResultState';
 
 export default function ResetConfirmScreen() {
   const router = useRouter();
@@ -21,6 +22,8 @@ export default function ResetConfirmScreen() {
   const { t } = useLocale();
   const { change, bgmReady } = useBgm();
   const { show: showSnackbar } = useSnackbar();
+  // 可視化フラグのリセット用フックを取得
+  const { setDebugAll } = useResultState();
   // 中断データの難易度とステージを保持する
   const [suspendInfo, setSuspendInfo] = React.useState<{
     levelId?: string;
@@ -70,6 +73,8 @@ export default function ResetConfirmScreen() {
     } else {
       setPendingBgm(bgmFile);
     }
+    // 前回の可視化状態を引き継がないよう初期化
+    setDebugAll(false);
     newGame({
       size: level.size,
       counts: level.enemies,


### PR DESCRIPTION
## Summary
- reset debugAll (全表示状態) when starting a new game

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c500384c832c85ddebd2122d2af2