### PR TITLE
Fix showAdjacentWalls reset when starting new game

### DIFF
--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -57,7 +57,9 @@ export function reducer(state: State, action: Action): State {
         stagePerMap: action.stagePerMap ?? state.stagePerMap,
         respawnMax: action.respawnMax ?? state.respawnMax,
         biasedGoal: action.biasedGoal ?? state.biasedGoal,
-        showAdjacentWalls: action.showAdjacentWalls ?? state.showAdjacentWalls,
+        // レベル設定に無い場合は周囲表示フラグをリセットする
+        // undefined だと前回の値を引き継いでしまうため false を入れて初期化
+        showAdjacentWalls: action.showAdjacentWalls ?? false,
         showAdjacentWallsFn: action.showAdjacentWallsFn,
       });
     case 'nextStage':

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -70,7 +70,8 @@ export function GameProvider({ children }: { children: ReactNode }) {
         wallLifetime,
         enemyCountsFn,
         wallLifetimeFn,
-        showAdjacentWalls,
+        // 新しいゲームを始めるときは前回の周囲表示設定を引き継がない
+        showAdjacentWalls = false,
         showAdjacentWallsFn,
         biasedSpawn,
         biasedGoal,


### PR DESCRIPTION
## Summary
- 新しいゲームを始める際、前回の周囲壁表示設定を引き継がないよう修正
- `useGame` と reducer で `showAdjacentWalls` を `false` 初期化

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6872c699d6d4832caf8167605a5449ec