### PR TITLE
stagePerMap のデフォルト値追加

### DIFF
--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -82,6 +82,8 @@ export const LEVELS: LevelConfig[] = [
     biasedSpawn: true,
     biasedGoal: false,
     showAdjacentWallsFn: (stage) => stage <= 30,
+    // チュートリアル以外は3ステージごとに迷路更新
+    stagePerMap: 3,
     respawnMax: 3,
   },
   {
@@ -97,6 +99,8 @@ export const LEVELS: LevelConfig[] = [
     enemyCountsFn: level1EnemyCounts,
     biasedSpawn: true,
     biasedGoal: false,
+    // こちらも3ステージで切り替える
+    stagePerMap: 3,
     respawnMax: 2,
   },
   {
@@ -112,6 +116,8 @@ export const LEVELS: LevelConfig[] = [
     enemyCountsFn: level1EnemyCounts,
     biasedSpawn: false,
     biasedGoal: true,
+    // ハードも同様に3ステージごと
+    stagePerMap: 3,
     respawnMax: 1,
   },
 ];


### PR DESCRIPTION
## Summary
- イージー以降のレベルに `stagePerMap: 3` を明示
  - チュートリアルから他レベルへ移った際に前回の値が残るのを防止

## Testing
- `pnpm lint` *(failed: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c7e1a4d4832c85bb09a0260ab3af