### PR TITLE
fix run record reset on new game

### DIFF
--- a/src/hooks/useBannerControl.ts
+++ b/src/hooks/useBannerControl.ts
@@ -21,7 +21,8 @@ export function useBannerControl({ stage, steps, totalSteps }: Options) {
     bannerShown,
     setBannerShown,
   } = useResultState();
-  const { records, reset } = useRunRecords();
+  // 記録リセット用の関数だけ取得
+  const { reset } = useRunRecords();
 
   // バナー表示中かどうかのフラグ
   const bannerActiveRef = useRef(false);
@@ -47,17 +48,12 @@ export function useBannerControl({ stage, steps, totalSteps }: Options) {
     }
   }, [stage, steps, showBanner, bannerStage, bannerShown, setBannerStage, setShowBanner, setBannerShown]);
 
-  // ステージ1開始時は前回の記録をリセット
+  // ステージ1を読み込んだら記録を初期化する
   useEffect(() => {
-    if (
-      stage === 1 &&
-      steps === 0 &&
-      totalSteps === 0 &&
-      records.length === 0
-    ) {
+    if (stage === 1 && steps === 0 && totalSteps === 0) {
       reset();
     }
-  }, [stage, steps, totalSteps, records.length, reset]);
+  }, [stage, steps, totalSteps, reset]);
 
   /** バナーの終了処理 */
   const handleBannerFinish = useCallback(() => {


### PR DESCRIPTION
## Summary
- reset run records when stage 1 is loaded to avoid merging previous results

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872cb4dff1c832cbb8497ae8c81ab25