### PR TITLE
Add simple line charts to game results

### DIFF
--- a/app/game-result.tsx
+++ b/app/game-result.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { PlainButton } from '@/components/PlainButton';
+import { ScoreChart } from '@/components/ScoreChart';
 import { useRunRecords } from '@/src/hooks/useRunRecords';
 import { useLocale } from '@/src/locale/LocaleContext';
 import { useBgm } from '@/src/hooks/useBgm';
@@ -53,6 +54,12 @@ export default function GameResultScreen() {
     { steps: 0, bumps: 0, respawns: 0, reveals: 0 },
   );
 
+  // 各ステージごとのスコアを配列化してグラフ用に整形
+  const stepData = records.map((r) => r.steps);
+  const bumpData = records.map((r) => r.bumps);
+  const respawnData = records.map((r) => r.respawns);
+  const revealData = records.map((r) => r.reveals);
+
   return (
     <ThemedView
       lightColor="#000"
@@ -65,17 +72,38 @@ export default function GameResultScreen() {
         <ThemedText type="title" lightColor="#fff" darkColor="#fff">
           {t('gameResults')}
         </ThemedText>
-        {records.map((r) => (
-          <ThemedText key={r.stage} lightColor="#fff" darkColor="#fff">
-            {t('stageRecord', {
-              stage: r.stage,
-              steps: r.steps,
-              bumps: r.bumps,
-              respawns: r.respawns,
-              reveals: r.reveals,
-            })}
-          </ThemedText>
-        ))}
+        <ThemedText lightColor="#fff" darkColor="#fff">
+          {t('stepsGraph')}
+        </ThemedText>
+        <ScoreChart
+          data={stepData}
+          color="#00f"
+          accessibilityLabel={t('stepsGraph')}
+        />
+        <ThemedText lightColor="#fff" darkColor="#fff">
+          {t('bumpsGraph')}
+        </ThemedText>
+        <ScoreChart
+          data={bumpData}
+          color="#f33"
+          accessibilityLabel={t('bumpsGraph')}
+        />
+        <ThemedText lightColor="#fff" darkColor="#fff">
+          {t('respawnsGraph')}
+        </ThemedText>
+        <ScoreChart
+          data={respawnData}
+          color="#3c3"
+          accessibilityLabel={t('respawnsGraph')}
+        />
+        <ThemedText lightColor="#fff" darkColor="#fff">
+          {t('revealsGraph')}
+        </ThemedText>
+        <ScoreChart
+          data={revealData}
+          color="#ff0"
+          accessibilityLabel={t('revealsGraph')}
+        />
         <ThemedText lightColor="#fff" darkColor="#fff">
           {t('totalStats', totals)}
         </ThemedText>

--- a/components/ScoreChart.tsx
+++ b/components/ScoreChart.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Svg, { Polyline } from 'react-native-svg';
+import { UI } from '@/constants/ui';
+
+/**
+ * 折れ線グラフを描画するシンプルなコンポーネント
+ * data 配列の長さに合わせて自動的に点を配置する
+ */
+export interface ScoreChartProps {
+  data: number[];
+  color: string;
+  width?: number;
+  height?: number;
+  /** 画面読み上げ用のラベル */
+  accessibilityLabel?: string;
+}
+
+export function ScoreChart({
+  data,
+  color,
+  width = UI.resultModalWidth,
+  height = UI.miniMapSize / 3,
+  accessibilityLabel,
+}: ScoreChartProps) {
+  // 最大値が 0 だと計算できないので 1 を下限とする
+  const max = Math.max(...data, 1);
+  const stepX = data.length > 1 ? width / (data.length - 1) : 0;
+
+  // SVG Polyline 用の文字列 "x,y x,y ..." を作成
+  const points = data
+    .map((v, i) => {
+      const x = i * stepX;
+      const y = height - (v / max) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <Svg
+      width={width}
+      height={height}
+      accessibilityLabel={accessibilityLabel}
+    >
+      <Polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth={2}
+      />
+    </Svg>
+  );
+}

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -72,6 +72,10 @@ const messages = {
       "ステージ{{stage}}: {{steps}}ターン {{bumps}}衝突 リスポーン{{respawns}}回 可視化{{reveals}}回",
     totalStats:
       "合計 {{steps}}ターン {{bumps}}衝突 リスポーン{{respawns}}回 可視化{{reveals}}回",
+    stepsGraph: "ステージごとのターン数",
+    bumpsGraph: "ステージごとの壁衝突数",
+    respawnsGraph: "ステージごとのリスポーン回数",
+    revealsGraph: "ステージごとの可視化回数",
     changeLang: "Language",
     selectLang: "言語を選択してください",
     japanese: "日本語",
@@ -152,6 +156,10 @@ const messages = {
       "Stage {{stage}}: {{steps}} steps {{bumps}} bumps respawns {{respawns}} reveals {{reveals}}",
     totalStats:
       "Total {{steps}} steps {{bumps}} bumps respawns {{respawns}} reveals {{reveals}}",
+    stepsGraph: "Steps per stage",
+    bumpsGraph: "Bumps per stage",
+    respawnsGraph: "Respawns per stage",
+    revealsGraph: "Reveals per stage",
     changeLang: "Language",
     selectLang: "Select language",
     japanese: "Japanese",


### PR DESCRIPTION
## Summary
- show stage scores with simple polyline charts
- support chart titles in locale messages

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6872cc095734832cbf168c1a6d4d7e89