### PR TITLE
Fix run record reset timing

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -19,6 +19,7 @@ import { useLevelUnlock } from "@/src/hooks/useLevelUnlock";
 import { UI } from "@/constants/ui";
 import { devLog } from "@/src/utils/logger";
 import { useResultState } from "@/src/hooks/useResultState";
+import { useRunRecords } from "@/src/hooks/useRunRecords";
 
 // EXPO_PUBLIC_UNLOCK_ALL_LEVELS が 'true' のとき
 // クリア状況に関わらず全難易度を選択可能にする
@@ -33,6 +34,8 @@ export default function TitleScreen() {
   const { isCleared } = useLevelUnlock();
   // 可視化フラグのリセット用フックを取得
   const { setDebugAll } = useResultState();
+  // ステージ記録を管理するフック
+  const { reset } = useRunRecords();
 
   const [showLang, setShowLang] = React.useState(false);
   const [hasSave, setHasSave] = React.useState(false);
@@ -82,8 +85,9 @@ export default function TitleScreen() {
     } else {
       audio.changeBgm(require('../assets/sounds/降りしきる、白_調整.mp3'));
     }
-    // 前回の可視化状態を引き継がないよう初期化する
+    // 前回の可視化状態とステージ記録を初期化する
     setDebugAll(false);
+    reset();
     newGame({
       size: level.size,
       counts: level.enemies,

--- a/app/practice.tsx
+++ b/app/practice.tsx
@@ -8,11 +8,13 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { EnemyCounter } from '@/components/EnemyCounter';
 import { UI } from '@/constants/ui';
+import { useRunRecords } from '@/src/hooks/useRunRecords';
 
 export default function PracticeScreen() {
   const router = useRouter();
   const { newGame } = useGame();
   const { t } = useLocale();
+  const { reset } = useRunRecords();
   // 各敵タイプの数を状態として管理
   const [random, setRandom] = React.useState(0);
   const [slow, setSlow] = React.useState(0);
@@ -25,6 +27,8 @@ export default function PracticeScreen() {
   const [wallLife, setWallLife] = React.useState<number>(Infinity);
 
   const start = (size: number) => {
+    // 前回ゲームの記録をリセット
+    reset();
     newGame({
       size,
       counts: { random, slow, sight, fast: 0 },

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -13,6 +13,7 @@ import { useLocale, type MessageKey } from '@/src/locale/LocaleContext';
 import { useBgm } from '@/src/hooks/useBgm';
 import { UI } from '@/constants/ui';
 import { useResultState } from '@/src/hooks/useResultState';
+import { useRunRecords } from '@/src/hooks/useRunRecords';
 
 export default function ResetConfirmScreen() {
   const router = useRouter();
@@ -24,6 +25,7 @@ export default function ResetConfirmScreen() {
   const { show: showSnackbar } = useSnackbar();
   // 可視化フラグのリセット用フックを取得
   const { setDebugAll } = useResultState();
+  const { reset } = useRunRecords();
   // 中断データの難易度とステージを保持する
   const [suspendInfo, setSuspendInfo] = React.useState<{
     levelId?: string;
@@ -73,8 +75,9 @@ export default function ResetConfirmScreen() {
     } else {
       setPendingBgm(bgmFile);
     }
-    // 前回の可視化状態を引き継がないよう初期化
+    // 前回の可視化状態とステージ記録を初期化
     setDebugAll(false);
+    reset();
     newGame({
       size: level.size,
       counts: level.enemies,

--- a/src/hooks/useBannerControl.ts
+++ b/src/hooks/useBannerControl.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useResultState } from '@/src/hooks/useResultState';
-import { useRunRecords } from '@/src/hooks/useRunRecords';
 
 interface Options {
   stage: number;
@@ -21,8 +20,6 @@ export function useBannerControl({ stage, steps, totalSteps }: Options) {
     bannerShown,
     setBannerShown,
   } = useResultState();
-  // 記録リセット用の関数だけ取得
-  const { reset } = useRunRecords();
 
   // バナー表示中かどうかのフラグ
   const bannerActiveRef = useRef(false);
@@ -48,12 +45,6 @@ export function useBannerControl({ stage, steps, totalSteps }: Options) {
     }
   }, [stage, steps, showBanner, bannerStage, bannerShown, setBannerStage, setShowBanner, setBannerShown]);
 
-  // ステージ1を読み込んだら記録を初期化する
-  useEffect(() => {
-    if (stage === 1 && steps === 0 && totalSteps === 0) {
-      reset();
-    }
-  }, [stage, steps, totalSteps, reset]);
 
   /** バナーの終了処理 */
   const handleBannerFinish = useCallback(() => {


### PR DESCRIPTION
## Summary
- reset run records when starting a new game
- remove auto reset from banner control

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872cd812c08832c80cda26d3a5b6b71