### PR TITLE
Add axis ticks and monochrome charts

### DIFF
--- a/app/game-result.tsx
+++ b/app/game-result.tsx
@@ -77,7 +77,7 @@ export default function GameResultScreen() {
         </ThemedText>
         <ScoreChart
           data={stepData}
-          color="#00f"
+          color="#fff"
           accessibilityLabel={t('stepsGraph')}
         />
         <ThemedText lightColor="#fff" darkColor="#fff">
@@ -85,7 +85,7 @@ export default function GameResultScreen() {
         </ThemedText>
         <ScoreChart
           data={bumpData}
-          color="#f33"
+          color="#fff"
           accessibilityLabel={t('bumpsGraph')}
         />
         <ThemedText lightColor="#fff" darkColor="#fff">
@@ -93,7 +93,7 @@ export default function GameResultScreen() {
         </ThemedText>
         <ScoreChart
           data={respawnData}
-          color="#3c3"
+          color="#fff"
           accessibilityLabel={t('respawnsGraph')}
         />
         <ThemedText lightColor="#fff" darkColor="#fff">
@@ -101,7 +101,7 @@ export default function GameResultScreen() {
         </ThemedText>
         <ScoreChart
           data={revealData}
-          color="#ff0"
+          color="#fff"
           accessibilityLabel={t('revealsGraph')}
         />
         <ThemedText lightColor="#fff" darkColor="#fff">


### PR DESCRIPTION
## Summary
- make `ScoreChart` draw black&white axes with tick labels
- adjust `GameResult` screen to use white charts

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6872d213a32c832ca31864a0c3f27f6e