### PR TITLE
Fix banner showing after clearing

### DIFF
--- a/src/hooks/useResultActions.ts
+++ b/src/hooks/useResultActions.ts
@@ -218,6 +218,9 @@ export function useResultActions({
       // ゲームクリア時はリザルト一覧へ遷移
       addRecord(state.stage, state.steps, state.bumps);
       resetRun();
+      // ゲームクリア後はステージ1バナーを再度出さないように
+      // bannerShown フラグを true に更新する
+      setBannerShown(true);
       // ゲームオーバーと同じく中断データを削除する
       await clearGame(showSnackbar ? { showError: showSnackbar } : undefined);
       setShowResult(false);


### PR DESCRIPTION
## Summary
- avoid stage1 banner after game clear by setting `bannerShown` to true

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687414e509fc832c81cfdc3a726d73a9