### PR TITLE
音量設定の保存機能を追加

### DIFF
--- a/src/audio/SeVolumeProvider.tsx
+++ b/src/audio/SeVolumeProvider.tsx
@@ -1,4 +1,12 @@
-import React, { createContext, useContext, useState, type ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useHandleError } from '@/src/utils/handleError';
 
 interface SeVolumeContextValue {
   volume: number;
@@ -6,9 +14,36 @@ interface SeVolumeContextValue {
 }
 
 const SeVolumeContext = createContext<SeVolumeContextValue | undefined>(undefined);
+// 音量保存用のキー
+const STORAGE_KEY = 'seVolume';
 
 export function SeVolumeProvider({ children }: { children: ReactNode }) {
   const [volume, setVolume] = useState(1);
+  const handleError = useHandleError();
+
+  // 初期表示時に保存済みの音量を読み込む
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        if (stored !== null) setVolume(Number(stored));
+      } catch (e) {
+        handleError('SE 音量を読み込めませんでした', e);
+      }
+    })();
+  }, [handleError]);
+
+  // 音量変更時は値を保存する
+  useEffect(() => {
+    (async () => {
+      try {
+        await AsyncStorage.setItem(STORAGE_KEY, String(volume));
+      } catch (e) {
+        handleError('SE 音量を保存できませんでした', e);
+      }
+    })();
+  }, [volume, handleError]);
+
   return (
     <SeVolumeContext.Provider value={{ volume, setVolume }}>
       {children}


### PR DESCRIPTION
## Summary
- BgmProvider と SeVolumeProvider で音量を AsyncStorage に保存/読み込み
- 既存の音量をアプリ再起動後も保持できるようにする

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874159f637c832c862a5fe53af80a74