### PR TITLE
Add ScrollView to main screens

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Modal, StyleSheet, View } from "react-native";
+import { Modal, StyleSheet, View, ScrollView } from "react-native";
 import { PlainButton } from "@/components/PlainButton";
 import { useRouter } from "expo-router";
 import { useGame } from "@/src/game/useGame";
@@ -158,7 +158,9 @@ export default function TitleScreen() {
   };
 
   return (
-    <ThemedView lightColor="#000" darkColor="#000" style={styles.container}>
+    <ThemedView lightColor="#000" darkColor="#000" style={{ flex: 1 }}>
+      {/* 小さい画面でも内容をスクロールして閲覧できるように */}
+      <ScrollView contentContainerStyle={styles.container}>
       {/* タイトルの文字サイズを定数から調整できるように */}
       <ThemedText
         type="title"
@@ -221,6 +223,8 @@ export default function TitleScreen() {
         accessibilityLabel={t("openHowToPlay")}
       />
 
+      </ScrollView>
+
       {/* ───── 言語選択モーダル ───── */}
       <Modal transparent visible={showLang} animationType="fade">
         <View style={styles.modalWrapper} accessible accessibilityLabel="言語選択オーバーレイ">
@@ -234,17 +238,18 @@ export default function TitleScreen() {
         </View>
       </Modal>
 
-      </ThemedView>
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     // 選択肢間の余白をホーム画面用定数から参照
     gap: UI.titleScreen.optionGap,
+    paddingVertical: UI.screenGap,
   },
   // タイトル文字のサイズを変更しやすくするためのスタイル
   title: {

--- a/app/options.tsx
+++ b/app/options.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, StyleSheet, View } from 'react-native';
+import { Modal, StyleSheet, View, ScrollView } from 'react-native';
 import { useRouter } from 'expo-router';
 
 import { PlainButton } from '@/components/PlainButton';
@@ -28,10 +28,12 @@ export default function OptionsScreen() {
   };
 
   return (
-    <ThemedView lightColor="#000" darkColor="#000" style={styles.container}>
-      <ThemedText type="title" lightColor="#fff" darkColor="#fff">
-        {t('options')}
-      </ThemedText>
+    <ThemedView lightColor="#000" darkColor="#000" style={{ flex: 1 }}>
+      {/* 中央揃えを保ったままスクロールできるようにする */}
+      <ScrollView contentContainerStyle={styles.container}>
+        <ThemedText type="title" lightColor="#fff" darkColor="#fff">
+          {t('options')}
+        </ThemedText>
 
       <PlainButton
         title={t('volumeSettings')}
@@ -48,6 +50,7 @@ export default function OptionsScreen() {
         onPress={() => router.replace('/')}
         accessibilityLabel={t('backToTitle')}
       />
+      </ScrollView>
 
       {/* 言語選択モーダル */}
       <Modal transparent visible={showLang} animationType="fade">
@@ -123,10 +126,11 @@ export default function OptionsScreen() {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    flexGrow: 1,
     justifyContent: 'center',
     alignItems: 'center',
     gap: UI.screenGap,
+    paddingVertical: UI.screenGap,
   },
   modalWrapper: {
     flex: 1,

--- a/app/rules.tsx
+++ b/app/rules.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, ScrollView, View } from 'react-native';
 import { useRouter } from 'expo-router';
 
 import { PlainButton } from '@/components/PlainButton';
@@ -12,7 +12,6 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 
 import Svg, { Circle, Line, Rect , Polygon } from 'react-native-svg';
-import { View } from 'react-native';
 
 /* ─────────  EnemyIcon  ───────── */
 interface EnemyIconProps {
@@ -94,11 +93,13 @@ export default function RulesScreen() {
   const router = useRouter();
   const { t } = useLocale();
   return (
-    <ThemedView lightColor="#000" darkColor="#000" style={styles.container}>
-      {/* 画面タイトル */}
-      <ThemedText type="title" lightColor="#fff" darkColor="#fff">
-        {t('howToPlay')}
-      </ThemedText>
+    <ThemedView lightColor="#000" darkColor="#000" style={{ flex: 1 }}>
+      {/* 小さな画面でもスクロールできるようにする */}
+      <ScrollView contentContainerStyle={styles.container}>
+        {/* 画面タイトル */}
+        <ThemedText type="title" lightColor="#fff" darkColor="#fff">
+          {t('howToPlay')}
+        </ThemedText>
       {/* ゲームの概要説明 */}
       <ThemedText lightColor="#fff" darkColor="#fff" style={styles.text}>
         {t('ruleIntro')}
@@ -142,22 +143,24 @@ export default function RulesScreen() {
       <ThemedText lightColor="#fff" darkColor="#fff" style={styles.text}>
         {t('enermys')}
       </ThemedText>
-      <PlainButton
-        title={t('backToTitle')}
-        onPress={() => router.replace('/')}
-        accessibilityLabel={t('backToTitle')}
-      />
+        <PlainButton
+          title={t('backToTitle')}
+          onPress={() => router.replace('/')}
+          accessibilityLabel={t('backToTitle')}
+        />
+      </ScrollView>
     </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    flexGrow: 1,
     justifyContent: 'center',
     alignItems: 'center',
     gap: UI.screenGap /2,
     paddingHorizontal: 10,
+    paddingVertical: UI.screenGap,
   },
   // 説明文の幅が広くなりすぎないよう中央揃えに
   text: {


### PR DESCRIPTION
## Summary
- make Title, Options, and Rules screens scrollable
- keep contents centered even on small displays

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68741bc2f20c832c9c965c874d0aa505