### PR TITLE
Fix localization key enemies

### DIFF
--- a/app/rules.tsx
+++ b/app/rules.tsx
@@ -141,7 +141,8 @@ export default function RulesScreen() {
         <EnemyIcon spokes={24} />
       </View>
       <ThemedText lightColor="#fff" darkColor="#fff" style={styles.text}>
-        {t('enermys')}
+        {/* 敵の説明を表示 */}
+        {t('enemies')}
       </ThemedText>
         <PlainButton
           title={t('backToTitle')}

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -100,7 +100,8 @@ const messages = {
       "敵の位置をリスポーン\nピンチの時に使用",
     revealUsage:
       "迷路全体を表示\n簡単になりすぎるので注意",
-    enermys: "敵\nプレイヤーを追跡中は色が変化する",
+    // 敵の説明
+    enemies: "敵\nプレイヤーを追跡中は色が変化する",
     player: "プレイヤーの現在位置",
     Goal: "挑戦中ステージのゴール地点",
     visitedGoals: "過去に到達したゴール地点",
@@ -188,7 +189,8 @@ const messages = {
       "Respawns enemy positions\nUse when you're in a pinch",
     revealUsage:
       "Reveals the entire maze\nBe careful, this makes the stage much easier",
-    enermys: "Enemies. Their color changes while chasing the player",
+    // Enemies の説明
+    enemies: "Enemies. Their color changes while chasing the player",
     player: "Your current position",
     Goal: "Goal position for the current stage",
     visitedGoals: "Previously reached goal positions",


### PR DESCRIPTION
## Summary
- fix the typo `enermys` to `enemies`
- update Japanese and English messages
- update Rule screen to use the new key

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6874408818b4832cafda0d757eba4e82