### PR TITLE
Add enemy adjacent wall display

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -98,6 +98,8 @@ export default function TitleScreen() {
       wallLifetimeFn: level.wallLifetimeFn,
       showAdjacentWalls: level.showAdjacentWalls,
       showAdjacentWallsFn: level.showAdjacentWallsFn,
+      playerAdjacentLife: level.playerAdjacentLife,
+      enemyAdjacentLife: level.enemyAdjacentLife,
       biasedSpawn: level.biasedSpawn,
       biasedGoal: level.biasedGoal,
       levelId: level.id,

--- a/app/reset.tsx
+++ b/app/reset.tsx
@@ -88,6 +88,8 @@ export default function ResetConfirmScreen() {
       wallLifetimeFn: level.wallLifetimeFn,
       showAdjacentWalls: level.showAdjacentWalls,
       showAdjacentWallsFn: level.showAdjacentWallsFn,
+      playerAdjacentLife: level.playerAdjacentLife,
+      enemyAdjacentLife: level.enemyAdjacentLife,
       biasedSpawn: level.biasedSpawn,
       biasedGoal: level.biasedGoal,
       levelId: level.id,

--- a/constants/levels.ts
+++ b/constants/levels.ts
@@ -34,6 +34,10 @@ export interface LevelConfig {
   showAdjacentWalls?: boolean;
   /** ステージごとに周囲表示の有無を決める関数 */
   showAdjacentWallsFn?: (stage: number) => boolean;
+  /** プレイヤー周囲壁の寿命。未指定なら衝突壁と同じ */
+  playerAdjacentLife?: number;
+  /** 敵周囲壁の寿命。未指定なら衝突壁と同じ */
+  enemyAdjacentLife?: number;
   /** 何ステージごとに迷路を更新するか */
   stagePerMap?: number;
   /** 敵をリスポーンできる最大回数 */
@@ -63,6 +67,9 @@ export const LEVELS: LevelConfig[] = [
     // チュートリアルでは常に周囲の壁を表示する
     // showAdjacentWalls を true にすることで全ステージに適用される
     showAdjacentWalls: true,
+    // 周囲壁寿命は衝突壁と同じ
+    playerAdjacentLife: undefined,
+    enemyAdjacentLife: undefined,
     stagePerMap: 5,
     respawnMax: 3,
   },
@@ -84,6 +91,8 @@ export const LEVELS: LevelConfig[] = [
     // イージーは常に周囲の壁を表示する。true は「はい/いいえ」を表す
     // ブール値 (boolean) と呼ばれる型で、true のとき機能が有効になる
     showAdjacentWalls: true,
+    playerAdjacentLife: undefined,
+    enemyAdjacentLife: undefined,
     // チュートリアル以外は3ステージごとに迷路更新
     stagePerMap: 3,
     respawnMax: 3,
@@ -104,6 +113,9 @@ export const LEVELS: LevelConfig[] = [
     // こちらも3ステージで切り替える
     stagePerMap: 3,
     respawnMax: 2,
+    // プレイヤーのみ2ターン固定
+    playerAdjacentLife: 2,
+    enemyAdjacentLife: undefined,
   },
   {
     id: 'hard',
@@ -121,5 +133,8 @@ export const LEVELS: LevelConfig[] = [
     // ハードも同様に3ステージごと
     stagePerMap: 3,
     respawnMax: 1,
+    // プレイヤー・敵とも2ターン固定
+    playerAdjacentLife: 2,
+    enemyAdjacentLife: 2,
   },
 ];

--- a/src/game/__tests__/adjacentWalls.test.ts
+++ b/src/game/__tests__/adjacentWalls.test.ts
@@ -1,0 +1,31 @@
+import { addAdjacentWalls } from '../state/utils';
+import { wallSet } from '../maze';
+import type { MazeSets } from '../state/core';
+
+const maze: MazeSets = {
+  id: 'test',
+  size: 5,
+  start: [0, 0],
+  goal: [4, 4],
+  v_walls: wallSet([]),
+  h_walls: wallSet([]),
+};
+
+describe('addAdjacentWalls', () => {
+  test('指定寿命で周囲壁を追加する', () => {
+    const res = addAdjacentWalls({ x: 0, y: 0 }, maze, new Map(), new Map(), 2);
+    expect(res.hitV.get('-1,0')).toBe(2);
+    expect(res.hitH.get('0,-1')).toBe(2);
+  });
+
+  test('既存より短い寿命では上書きしない', () => {
+    const res = addAdjacentWalls(
+      { x: 0, y: 4 },
+      maze,
+      new Map([['0,4', 5]]),
+      new Map(),
+      2,
+    );
+    expect(res.hitV.get('0,4')).toBe(5);
+  });
+});

--- a/src/game/saveGame.ts
+++ b/src/game/saveGame.ts
@@ -36,6 +36,8 @@ export interface StoredState {
   respawnStock: number;
   respawnMax: number;
   stagePerMap: number;
+  playerAdjacentLife: number;
+  enemyAdjacentLife: number;
 }
 
 // State から保存用データへ変換
@@ -69,6 +71,8 @@ export function encodeState(state: State): StoredState {
     respawnStock: state.respawnStock,
     respawnMax: state.respawnMax,
     stagePerMap: state.stagePerMap,
+    playerAdjacentLife: state.playerAdjacentLife,
+    enemyAdjacentLife: state.enemyAdjacentLife,
   };
 }
 
@@ -114,6 +118,8 @@ export function decodeState(data: StoredState): State {
     respawnStock: data.respawnStock,
     respawnMax: level?.respawnMax ?? data.respawnMax,
     stagePerMap: level?.stagePerMap ?? 3,
+    playerAdjacentLife: data.playerAdjacentLife,
+    enemyAdjacentLife: data.enemyAdjacentLife,
   };
 }
 

--- a/src/game/state/moveHandlers.ts
+++ b/src/game/state/moveHandlers.ts
@@ -123,8 +123,29 @@ export function handleMoveAction(state: State, dir: Dir): State {
   const bumpDiff = player.bumps - state.bumps;
   // 周囲表示が有効なら現在位置の壁を記録する
   const adj = state.showAdjacentWalls
-    ? addAdjacentWalls(player.pos, state.maze, player.hitV, player.hitH)
+    ? addAdjacentWalls(
+        player.pos,
+        state.maze,
+        player.hitV,
+        player.hitH,
+        state.playerAdjacentLife,
+      )
     : { hitV: player.hitV, hitH: player.hitH };
+
+  // 敵周囲の壁も同様に記録する
+  const enemyAdj = state.showAdjacentWalls
+    ? enemyResult.enemies.reduce(
+        (acc, e) =>
+          addAdjacentWalls(
+            e.pos,
+            state.maze,
+            acc.hitV,
+            acc.hitH,
+            state.enemyAdjacentLife,
+          ),
+        { hitV: adj.hitV, hitH: adj.hitH },
+      )
+    : adj;
 
   return {
     ...state,
@@ -134,8 +155,8 @@ export function handleMoveAction(state: State, dir: Dir): State {
     totalSteps: state.totalSteps + stepDiff,
     totalBumps: state.totalBumps + bumpDiff,
     path: updatePlayerPathIfMoved(state, player.pos, player.steps),
-    hitV: adj.hitV,
-    hitH: adj.hitH,
+    hitV: enemyAdj.hitV,
+    hitH: enemyAdj.hitH,
     enemies: enemyResult.enemies,
     enemyVisited: enemyResult.enemyVisited,
     enemyPaths: enemyResult.enemyPaths,

--- a/src/game/state/reducer.ts
+++ b/src/game/state/reducer.ts
@@ -34,10 +34,12 @@ export function reducer(state: State, action: Action): State {
           showAdjacentWallsFn: state.showAdjacentWallsFn,
           biasedSpawn: state.biasedSpawn,
           biasedGoal: state.biasedGoal,
-          levelId: state.levelId,
-          stagePerMap: state.stagePerMap,
-          respawnMax: state.respawnMax,
-        },
+        levelId: state.levelId,
+        stagePerMap: state.stagePerMap,
+        respawnMax: state.respawnMax,
+        playerAdjacentLife: state.playerAdjacentLife,
+        enemyAdjacentLife: state.enemyAdjacentLife,
+      },
         undefined,
         undefined,
         state.respawnStock,
@@ -61,6 +63,8 @@ export function reducer(state: State, action: Action): State {
         // undefined だと前回の値を引き継いでしまうため false を入れて初期化
         showAdjacentWalls: action.showAdjacentWalls ?? false,
         showAdjacentWallsFn: action.showAdjacentWallsFn,
+        playerAdjacentLife: action.playerAdjacentLife,
+        enemyAdjacentLife: action.enemyAdjacentLife,
       });
     case 'nextStage':
       return nextStageState(state);

--- a/src/game/state/stage.ts
+++ b/src/game/state/stage.ts
@@ -28,6 +28,8 @@ export function createFirstStage(
     biasedGoal = true,
     showAdjacentWalls = false,
     showAdjacentWallsFn,
+    playerAdjacentLife,
+    enemyAdjacentLife,
   } = options;
   const visited = new Set<string>();
   const start = randomCell(base.size);
@@ -64,6 +66,8 @@ export function createFirstStage(
       levelId,
       stagePerMap,
       respawnMax,
+      playerAdjacentLife,
+      enemyAdjacentLife,
     },
     undefined,
     undefined,
@@ -123,6 +127,8 @@ export function nextStageState(state: State): State {
       levelId: state.levelId,
       stagePerMap: state.stagePerMap,
       respawnMax: state.respawnMax,
+      playerAdjacentLife: state.playerAdjacentLife,
+      enemyAdjacentLife: state.enemyAdjacentLife,
     },
     hitV,
     hitH,
@@ -148,5 +154,7 @@ export function restartRun(state: State): State {
     biasedGoal: state.biasedGoal,
     showAdjacentWalls: state.showAdjacentWalls,
     showAdjacentWallsFn: state.showAdjacentWallsFn,
+    playerAdjacentLife: state.playerAdjacentLife,
+    enemyAdjacentLife: state.enemyAdjacentLife,
   });
 }

--- a/src/game/state/utils.ts
+++ b/src/game/state/utils.ts
@@ -1,7 +1,9 @@
 /**
  * プレイヤーの周囲に存在する壁を記録するヘルパー。
- * 座標と迷路情報を受け取り、見つかった壁を無限寿命(永続)で
+ * 座標と迷路情報を受け取り、見つかった壁を指定ターン分
  * hitV と hitH に追加して返す。
+ * 既に登録済みの壁寿命より長い値を指定した場合は
+ * その値で上書きする。
  *
  * Map は元の状態を変更しないよう新しいインスタンスを作成する点に注意。
  */
@@ -12,16 +14,23 @@ export function addAdjacentWalls(
   maze: MazeSets,
   hitV: Map<string, number>,
   hitH: Map<string, number>,
+  life: number = Infinity,
 ): { hitV: Map<string, number>; hitH: Map<string, number> } {
   const { x, y } = pos;
   const last = maze.size - 1;
   const nextV = new Map(hitV);
   const nextH = new Map(hitH);
 
-  if (x <= 0 || maze.v_walls.has(`${x - 1},${y}`)) nextV.set(`${x - 1},${y}`, Infinity);
-  if (x >= last || maze.v_walls.has(`${x},${y}`)) nextV.set(`${x},${y}`, Infinity);
-  if (y <= 0 || maze.h_walls.has(`${x},${y - 1}`)) nextH.set(`${x},${y - 1}`, Infinity);
-  if (y >= last || maze.h_walls.has(`${x},${y}`)) nextH.set(`${x},${y}`, Infinity);
+  const add = (map: Map<string, number>, key: string) => {
+    const current = map.get(key);
+    const nextLife = life === Infinity || current === Infinity ? Infinity : Math.max(current ?? 0, life);
+    map.set(key, nextLife);
+  };
+
+  if (x <= 0 || maze.v_walls.has(`${x - 1},${y}`)) add(nextV, `${x - 1},${y}`);
+  if (x >= last || maze.v_walls.has(`${x},${y}`)) add(nextV, `${x},${y}`);
+  if (y <= 0 || maze.h_walls.has(`${x},${y - 1}`)) add(nextH, `${x},${y - 1}`);
+  if (y >= last || maze.h_walls.has(`${x},${y}`)) add(nextH, `${x},${y}`);
 
   return { hitV: nextV, hitH: nextH };
 }

--- a/src/game/useGame.tsx
+++ b/src/game/useGame.tsx
@@ -73,6 +73,8 @@ export function GameProvider({ children }: { children: ReactNode }) {
         // 新しいゲームを始めるときは前回の周囲表示設定を引き継がない
         showAdjacentWalls = false,
         showAdjacentWallsFn,
+        playerAdjacentLife,
+        enemyAdjacentLife,
         biasedSpawn,
         biasedGoal,
         levelId,
@@ -95,6 +97,8 @@ export function GameProvider({ children }: { children: ReactNode }) {
         levelId,
         stagePerMap,
         respawnMax,
+        playerAdjacentLife,
+        enemyAdjacentLife,
       });
       // フラグが有効なら最終ステージまで進める
       if (START_FINAL) {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -17,6 +17,10 @@ export interface NewGameOptions {
   showAdjacentWalls?: boolean;
   /** ステージ番号から周囲表示の有無を決める関数 */
   showAdjacentWallsFn?: (stage: number) => boolean;
+  /** プレイヤー周囲壁の寿命。未指定なら衝突壁と同じ */
+  playerAdjacentLife?: number;
+  /** 敵周囲壁の寿命。未指定なら衝突壁と同じ */
+  enemyAdjacentLife?: number;
   /** 敵のスポーン位置をスタートから遠くするか */
   biasedSpawn?: boolean;
   /** ゴールをスタートから遠ざけるかどうか */


### PR DESCRIPTION
## Summary
- handle new player/enemy adjacent wall lifetimes per level
- track walls around enemies as well as the player
- persist adjacent wall settings in save data
- test wall lifetime helper

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c673e2c8832caf8aaf8fe78eeac7