### PR TITLE
fix: clamp を worklet 化

### DIFF
--- a/src/game/math.ts
+++ b/src/game/math.ts
@@ -21,7 +21,9 @@ export function lerp(start: number, end: number, t: number): number {
 
 /**
  * 値を最小値と最大値の範囲に収める clamp 関数
+ * Reanimated から呼び出すことを想定し `worklet` を付与
  */
 export function clamp(v: number, min: number, max: number): number {
+  'worklet';
   return Math.min(max, Math.max(min, v));
 }


### PR DESCRIPTION
## Summary
- `src/game/math.ts` の `clamp` 関数を Reanimated 対応で worklet 化
- コメントを日本語で整理し、他の関数と統一

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6879964860a4832c9cc15fe86717efcf