### PR TITLE
Update tracking permission and remove audio permissions

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -9,6 +9,13 @@ export default ({ config }) => ({
     ...(appJson.expo.ios ?? {}),
     bundleIdentifier: "com.kokisato.mazesense", // ⾃由に決定（Apple Dev 上でも登録）
     supportsTablet: true,
+    // 広告トラッキング許可ダイアログの文言を追加
+    infoPlist: {
+      ...(appJson.expo.ios?.infoPlist ?? {}),
+      NSUserTrackingUsageDescription: "広告配信のために端末識別子を利用します",
+      // 将来的に音声録音機能を追加する場合は以下も定義する
+      // NSMicrophoneUsageDescription: "マイクを使用して音声を録音します"
+    },
   },
   android: {
     ...(appJson.expo.android ?? {}),

--- a/app.json
+++ b/app.json
@@ -27,10 +27,7 @@
       },
       "edgeToEdgeEnabled": true,
       "package": "com.kokisato.mazesense",
-      "permissions": [
-        "android.permission.RECORD_AUDIO",
-        "android.permission.MODIFY_AUDIO_SETTINGS"
-      ]
+      "permissions": []
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
## Summary
- add tracking usage description to iOS infoPlist via app.config.js
- remove unused audio permissions on Android

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6879fefce2d8832c9a9e8b3f6ee6aa73