### PR TITLE
Improve TestFlight error logs

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ import 'react-native-reanimated';
 import mobileAds from 'react-native-google-mobile-ads';
 import { Platform } from 'react-native';
 import { DISABLE_ADS } from '@/src/ads/interstitial';
+import { useHandleError } from '@/src/utils/handleError';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { GameProvider } from '@/src/game/useGame';
@@ -26,6 +27,7 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
   // スナックバー表示用フック。エラー通知に利用する
   const { show: showSnackbar } = useSnackbar();
+  const handleError = useHandleError();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
@@ -43,12 +45,11 @@ export default function RootLayout() {
       try {
         mobileAds().initialize();
       } catch (e) {
-        // エラー内容をログに出し、ユーザーにも通知する
-        console.error(e);
-        showSnackbar('広告初期化に失敗しました');
+        // 共通エラーハンドラで詳細を通知
+        handleError('広告初期化に失敗しました', e);
       }
     }
-  }, [showSnackbar]);
+  }, [handleError]);
 
   if (!loaded) {
     // Async font loading only occurs in development.

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import { IS_TESTFLIGHT } from '@/src/utils/appEnv';
 
 interface ErrorBoundaryProps {
   /** エラー発生時に呼び出されるコールバック */
@@ -25,8 +26,11 @@ export class ErrorBoundary extends React.Component<
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     // 詳細をコンソールに出力しデバッグしやすくする
     console.error(error, info);
-    // 呼び出し元にエラーを通知する
-    this.props.onError('予期せぬエラーが発生しました');
+    // TestFlight ではエラー詳細を通知
+    const msg = IS_TESTFLIGHT
+      ? String(error)
+      : '予期せぬエラーが発生しました';
+    this.props.onError(msg);
     // フォールバック UI を表示するためフラグを立てる
     this.setState({ hasError: true });
   }

--- a/src/utils/appEnv.ts
+++ b/src/utils/appEnv.ts
@@ -1,0 +1,7 @@
+import * as Updates from 'expo-updates';
+
+/**
+ * TestFlight ビルドかどうか判定する定数
+ * expo-updates の channel 名が 'testflight' のとき true
+ */
+export const IS_TESTFLIGHT = Updates.channel === 'testflight';

--- a/src/utils/handleError.ts
+++ b/src/utils/handleError.ts
@@ -1,6 +1,7 @@
 import { useSnackbar } from '@/src/hooks/useSnackbar';
 import { useCallback } from 'react';
 import { logError } from './errorLogger';
+import { IS_TESTFLIGHT } from './appEnv';
 
 /**
  * 例外発生時の共通処理を提供するカスタムフック。
@@ -16,8 +17,9 @@ export function useHandleError() {
       console.error(message, error);
       // エラーログを保存して後から調査できるようにする
       void logError(message, error);
-      // ユーザーには簡潔なメッセージを表示
-      show(message);
+      // TestFlight では詳細なエラー内容も表示してデバッグしやすくする
+      const msg = IS_TESTFLIGHT ? `${message}: ${String(error)}` : message;
+      show(msg);
     },
     [show],
   );

--- a/src/utils/initGlobalErrorHandler.ts
+++ b/src/utils/initGlobalErrorHandler.ts
@@ -1,5 +1,6 @@
 import type { ErrorUtils as ErrorUtilsType } from 'react-native/Libraries/vendor/core/ErrorUtils';
 import { logError } from './errorLogger';
+import { IS_TESTFLIGHT } from './appEnv';
 
 /**
  * グローバルエラーハンドラを登録する関数。
@@ -16,7 +17,9 @@ export function initGlobalErrorHandler(showSnackbar: (msg: string) => void) {
     // 予期しないエラーをログに残す
     console.error('Unhandled Error', error);
     void logError('Unhandled Error', error);
-    showSnackbar('予期せぬエラーが発生しました');
+    // テストフライトでは詳細を表示してデバッグを容易にする
+    const msg = IS_TESTFLIGHT ? String(error) : '予期せぬエラーが発生しました';
+    showSnackbar(msg);
     defaultHandler(error, isFatal);
   });
 }

--- a/src/utils/initUnhandledRejectionHandler.ts
+++ b/src/utils/initUnhandledRejectionHandler.ts
@@ -1,4 +1,5 @@
 import { logError } from './errorLogger';
+import { IS_TESTFLIGHT } from './appEnv';
 
 /**
  * Promise の未処理拒否を捕捉するハンドラを登録します。
@@ -16,7 +17,11 @@ export function initUnhandledRejectionHandler(showSnackbar: (msg: string) => voi
     // 未処理の Promise 拒否を記録しておく
     console.error('Unhandled Promise Rejection', event.reason);
     void logError('Unhandled Promise Rejection', event.reason);
-    showSnackbar('予期せぬエラーが発生しました');
+    // TestFlight では詳細も通知する
+    const msg = IS_TESTFLIGHT
+      ? String(event.reason)
+      : '予期せぬエラーが発生しました';
+    showSnackbar(msg);
     if (typeof original === 'function') {
       original(event);
     }


### PR DESCRIPTION
## Summary
- show detailed errors when running TestFlight builds
- centralize environment detection in `IS_TESTFLIGHT`
- use `useHandleError` for ad initialization

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687aa45d82e4832cbe59dff762f83592