### PR TITLE
広告関連ログを拡充

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -8,3 +8,15 @@ export function devLog(...params: unknown[]) {
     console.log(...params);
   }
 }
+
+/**
+ * 広告関連の詳細ログを出力するための関数
+ * EXPO_PUBLIC_DEBUG_ADS が 'true' のときと開発ビルドでのみ表示される
+ */
+const DEBUG_ADS = process.env.EXPO_PUBLIC_DEBUG_ADS === 'true';
+
+export function adLog(...params: unknown[]) {
+  if (__DEV__ || DEBUG_ADS) {
+    console.log(...params);
+  }
+}


### PR DESCRIPTION
## Summary
- ad用ログ関数 `adLog` を追加
- インタースティシャル広告の各処理で詳細なログを出力

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687ac29b2d8c832cb16f237bcc226f68