### PR TITLE
Remove debug AdMob info

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -13,7 +13,6 @@ import {
 
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
-import { AdInfo } from "@/components/AdInfo";
 import { LEVELS } from "@/constants/levels";
 import { useAudioControls } from "@/src/hooks/useAudioControls";
 import { useLevelUnlock } from "@/src/hooks/useLevelUnlock";
@@ -226,8 +225,7 @@ export default function TitleScreen() {
         accessibilityLabel={t("openHowToPlay")}
       />
 
-      {/* AdMob 設定値を確認するための表示 */}
-      <AdInfo />
+      {/* デバッグ用に表示していた広告IDは本番では不要なため削除 */}
 
       </ScrollView>
 


### PR DESCRIPTION
## Summary
- clean up home screen by removing `AdInfo`
- comment in Japanese about debug display removal

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b42f4fca0832c95bdb24eeab675e6