### PR TITLE
Fix IAP loading on web

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -42,9 +42,12 @@ export default function RootLayout() {
 
   // 課金情報を初期化し、購入済みかを確認する
   useEffect(() => {
-    removeAds
-      .init()
-      .catch((e) => handleError('購入情報を取得できませんでした', e));
+    // Web 環境では IAP モジュールが存在しないためスキップする
+    if (Platform.OS !== 'web') {
+      removeAds
+        .init()
+        .catch((e) => handleError('購入情報を取得できませんでした', e));
+    }
   }, [handleError]);
 
   // Google Mobile Ads SDK を初期化する。web 環境や広告無効化時はスキップ

--- a/src/iap/removeAds.ts
+++ b/src/iap/removeAds.ts
@@ -1,5 +1,11 @@
-import * as IAP from 'expo-in-app-purchases';
+import type * as IAPType from 'expo-in-app-purchases';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+
+// Expo の IAP モジュールを動的に読み込むための変数
+let IAP: IAPType | null = null;
+// iOS/Android 以外では IAP を利用しない
+const isNative = Platform.OS === 'ios' || Platform.OS === 'android';
 
 // 永続化に利用するキー名
 const STORAGE_KEY = 'adsRemoved';
@@ -11,6 +17,15 @@ let adsRemoved = false;
 // IAP 接続状態を示すフラグ
 let connected = false;
 
+// 必要なときにだけ IAP モジュールを読み込む
+function ensureModule(): IAPType | null {
+  if (!IAP && isNative) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    IAP = require('expo-in-app-purchases');
+  }
+  return IAP;
+}
+
 /** 現在の購入状態を返す */
 export function isAdsRemoved() {
   return adsRemoved;
@@ -18,14 +33,18 @@ export function isAdsRemoved() {
 
 // ストアへ接続する共通処理
 async function ensureConnection() {
+  const mod = ensureModule();
+  if (!mod) return; // Web 環境などでは何もしない
   if (!connected) {
-    await IAP.connectAsync();
+    await mod.connectAsync();
     connected = true;
   }
 }
 
 /** 購入情報の初期化と履歴確認 */
 export async function init() {
+  // Web など非対応環境では処理をスキップ
+  if (!ensureModule()) return;
   await ensureConnection();
   const stored = await AsyncStorage.getItem(STORAGE_KEY);
   if (stored === 'true') {
@@ -37,17 +56,21 @@ export async function init() {
 
 /** 広告削除を購入する */
 export async function purchase() {
+  const mod = ensureModule();
+  if (!mod) return; // 非対応環境では何もしない
   await ensureConnection();
-  await IAP.getProductsAsync([PRODUCT_ID]);
-  await IAP.purchaseItemAsync(PRODUCT_ID);
+  await mod.getProductsAsync([PRODUCT_ID]);
+  await mod.purchaseItemAsync(PRODUCT_ID);
   adsRemoved = true;
   await AsyncStorage.setItem(STORAGE_KEY, 'true');
 }
 
 /** 購入済みか履歴を確認し、フラグを復元する */
 export async function restore() {
+  const mod = ensureModule();
+  if (!mod) return; // 非対応環境では処理なし
   await ensureConnection();
-  const { results } = await IAP.getPurchaseHistoryAsync();
+  const { results } = await mod.getPurchaseHistoryAsync();
   const bought = results?.some((r) => r.productId === PRODUCT_ID);
   if (bought) {
     adsRemoved = true;


### PR DESCRIPTION
## Summary
- avoid loading expo-in-app-purchases on non-native platforms
- skip `removeAds.init()` on web

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687ee4641934832cb844050aa6669b16