### PR TITLE
Add worklet error handling

### DIFF
--- a/src/game/feedback.ts
+++ b/src/game/feedback.ts
@@ -1,7 +1,13 @@
 // 振動フィードバックに関する処理をまとめたモジュール
 
 import * as Haptics from 'expo-haptics';
-import { withSequence, withTiming, type SharedValue } from 'react-native-reanimated';
+import {
+  withSequence,
+  withTiming,
+  runOnJS,
+  type SharedValue,
+} from 'react-native-reanimated';
+import { logError } from '@/src/utils/errorLogger';
 import { UI } from '@/constants/ui';
 import type { Vec2 } from '@/src/types/maze';
 import { distance } from './math';
@@ -105,10 +111,15 @@ export function applyBumpFeedback(
   }, 50);
   setTimeout(() => clearInterval(id), showTime);
 
-  borderW.value = withSequence(
-    withTiming(width, { duration: showTime / 2 }),
-    withTiming(0, { duration: showTime / 2 }),
-  );
+  try {
+    borderW.value = withSequence(
+      withTiming(width, { duration: showTime / 2 }),
+      withTiming(0, { duration: showTime / 2 }),
+    );
+  } catch (e) {
+    // UI スレッドで発生したエラーをログへ送る
+    runOnJS(logError)('Worklet error', e);
+  }
 
   return showTime;
 }

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -18,7 +18,8 @@ const MAX_LOGS = 50;
 /**
  * エラーログを追記する関数
  */
-export async function logError(message: string, error: unknown) {
+// runOnJS から呼び出せるよう関数式で定義
+export const logError = async (message: string, error: unknown) => {
   try {
     const json = await AsyncStorage.getItem(LOG_KEY);
     const logs: ErrorLog[] = json ? JSON.parse(json) : [];
@@ -28,7 +29,7 @@ export async function logError(message: string, error: unknown) {
   } catch (e) {
     console.error('logError error', e);
   }
-}
+};
 
 /**
  * 全エラーログを取得する


### PR DESCRIPTION
## Summary
- log errors from Reanimated worklets
- log `applyBumpFeedback` animation errors
- expose `logError` for use with `runOnJS`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687f1176c050832c903d96cb0d46403d