### PR TITLE
Switch to expo-iap for purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Expo のビルドサービスを利用する場合は `eas.json` の `env` セ�
 
 ## 課金機能の追加
 
-広告削除アイテムは `expo-in-app-purchases` を用いて実装しています。以下の手順で設定してください。
+広告削除アイテムは `expo-iap` を用いて実装しています。以下の手順で設定してください。
 
-1. 依存パッケージをインストール後、`pnpm add expo-in-app-purchases` を実行します。
+1. 依存パッケージをインストール後、`pnpm add expo-iap` を実行します。
 2. App Store Connect または Google Play Console で **non-consumable** アイテム `remove_ads` を登録します。
 3. ビルド後にストア審査を通過させると、アプリ内から購入や復元が行えます。
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
     "expo-web-browser": "~14.2.0",
-    "expo-in-app-purchases": "~14.6.0",
+    "expo-iap": "~1.0.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",

--- a/src/iap/removeAds.ts
+++ b/src/iap/removeAds.ts
@@ -1,4 +1,5 @@
-import type * as IAPType from 'expo-in-app-purchases';
+// expo-in-app-purchases から expo-iap へ変更
+import type * as IAPType from 'expo-iap';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 
@@ -21,7 +22,8 @@ let connected = false;
 function ensureModule(): IAPType | null {
   if (!IAP && isNative) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    IAP = require('expo-in-app-purchases');
+    // expo-iap は必要なときのみ読み込む
+    IAP = require('expo-iap');
   }
   return IAP;
 }


### PR DESCRIPTION
## Summary
- switch from expo-in-app-purchases to expo-iap
- update docs for new library

## Testing
- `pnpm lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688039f230dc832ca86714bdd06d22af