### PR TITLE
Add white border to player base

### DIFF
--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -108,7 +108,11 @@ export function MiniMap({
 
   // 外周円の色だけアニメーションさせる
   const outerProps = useAnimatedProps(() => ({
+    // 常に薄いグレーの塗りつぶしを維持
     fill: playerColor.value,
+    // 白色の細い枠線を追加
+    stroke: "white",
+    strokeWidth: 1,
     r: radius,
   }));
 


### PR DESCRIPTION
## Summary
- プレイヤーを表すグレー円に白色1pxの枠線を追加

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6880bcf980a8832c86291457270dfb2d