### PR TITLE
広告削除課金をホーム画面へ移動

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -20,6 +20,9 @@ import { UI } from "@/constants/ui";
 import { devLog } from "@/src/utils/logger";
 import { useResultState } from "@/src/hooks/useResultState";
 import { useRunRecords } from "@/src/hooks/useRunRecords";
+import { useHandleError } from "@/src/utils/handleError";
+// 広告削除課金機能
+import * as removeAds from "@/src/iap/removeAds";
 
 // EXPO_PUBLIC_UNLOCK_ALL_LEVELS が 'true' のとき
 // クリア状況に関わらず全難易度を選択可能にする
@@ -36,9 +39,22 @@ export default function TitleScreen() {
   const { setDebugAll } = useResultState();
   // ステージ記録を管理するフック
   const { reset } = useRunRecords();
+  // エラー処理共通化のためのハンドラ
+  const handleError = useHandleError();
 
   const [showLang, setShowLang] = React.useState(false);
   const [hasSave, setHasSave] = React.useState(false);
+
+  // 広告削除を購入する処理
+  const handlePurchase = async () => {
+    try {
+      await removeAds.purchase();
+      showSnackbar(t('removeAds'));
+    } catch (e) {
+      handleError('購入に失敗しました', e);
+    }
+  };
+
 
   // BGM/SE を制御
   const audio = useAudioControls(
@@ -210,6 +226,13 @@ export default function TitleScreen() {
         title={t("highScores")}
         onPress={() => router.push("/scores")}
         accessibilityLabel={t("openHighScores")}
+      />
+
+      {/* ホーム画面にも広告削除オプションを表示 */}
+      <PlainButton
+        title={t('removeAds')}
+        onPress={handlePurchase}
+        accessibilityLabel={t('removeAds')}
       />
 
       <PlainButton

--- a/app/options.tsx
+++ b/app/options.tsx
@@ -19,6 +19,7 @@ export default function OptionsScreen() {
 
   const [showLang, setShowLang] = React.useState(false);
   const [showVolume, setShowVolume] = React.useState(false);
+  // 共通エラー処理とスナックバー表示を利用
   const handleError = useHandleError();
   const { show: showSnackbar } = useSnackbar();
 
@@ -33,17 +34,7 @@ export default function OptionsScreen() {
     setShowLang(false);
   };
 
-  // 広告削除を購入する処理
-  const handlePurchase = async () => {
-    try {
-      await removeAds.purchase();
-      showSnackbar(t('removeAds'));
-    } catch (e) {
-      handleError('購入に失敗しました', e);
-    }
-  };
-
-  // 購入情報を復元する処理
+  // 購入済み情報を復元する処理
   const handleRestore = async () => {
     try {
       await removeAds.restore();
@@ -52,6 +43,7 @@ export default function OptionsScreen() {
       handleError('復元に失敗しました', e);
     }
   };
+
 
   return (
     <ThemedView lightColor="#000" darkColor="#000" style={{ flex: 1 }}>
@@ -71,11 +63,7 @@ export default function OptionsScreen() {
         onPress={() => setShowLang(true)}
         accessibilityLabel={t('changeLang')}
       />
-      <PlainButton
-        title={t('removeAds')}
-        onPress={handlePurchase}
-        accessibilityLabel={t('removeAds')}
-      />
+      {/* 購入済みの復元ボタン */}
       <PlainButton
         title={t('restorePurchase')}
         onPress={handleRestore}


### PR DESCRIPTION
## Summary
- 設定画面に購入復元ボタンを残したままに変更
- ホーム画面には広告削除ボタンのみ表示

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6880bf7fa4f0832cbeb534b08df59676