### PR TITLE
Load IAP product info on connection

### DIFF
--- a/src/iap/removeAds.tsx
+++ b/src/iap/removeAds.tsx
@@ -38,11 +38,24 @@ export function RemoveAdsProvider({ children }: { children: ReactNode }) {
     currentPurchase,
     availablePurchases,
     getAvailablePurchases,
+    getProducts,
     requestPurchase,
     finishTransaction,
   } = useIAP();
 
   const [adsRemoved, setAdsRemoved] = useState(false);
+
+  // 接続されたら商品情報を取得
+  useEffect(() => {
+    if (!isNative || !connected) return;
+    (async () => {
+      try {
+        await getProducts({ skus: [PRODUCT_ID] });
+      } catch {
+        // エラーは無視して UI を維持する
+      }
+    })();
+  }, [connected, getProducts]);
 
   // 初回接続後に保存済みフラグを確認し、未保存なら購入履歴を取得
   useEffect(() => {


### PR DESCRIPTION
## Summary
- retrieve `getProducts` from `useIAP`
- when connection is established, call `getProducts` to fetch product data
- ignore any errors to prevent UI breakage

## Testing
- `pnpm lint` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68844dc0ad70832cb94aa3b7daae93c6