### PR TITLE
Handle purchase cancel

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Modal, StyleSheet, View, ScrollView } from "react-native";
 import { PlainButton } from "@/components/PlainButton";
 import { useRouter } from "expo-router";
+// expo-iap からエラーコード定数を取得
+import { ErrorCode } from "expo-iap";
 import { useGame } from "@/src/game/useGame";
 import { loadGame, clearGame } from "@/src/game/saveGame";
 import { useSnackbar } from "@/src/hooks/useSnackbar";
@@ -53,6 +55,12 @@ export default function TitleScreen() {
       await purchase();
       showSnackbar(t("removeAds"));
     } catch (e) {
+      // ユーザーが購入処理を途中でキャンセルした場合はエラー扱いしない
+      if ((e as { code?: string }).code === ErrorCode.E_USER_CANCELLED) {
+        showSnackbar(t("purchaseCancelled"));
+        return;
+      }
+      // それ以外は共通エラーハンドラへ
       handleError("購入に失敗しました", e);
     }
   };

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -63,6 +63,8 @@ const messages = {
     watchAdForReveal: "広告を見るともう一度全表示できます",
     removeAds: "広告を削除する",
     restorePurchase: "購入を復元する",
+    // 購入をキャンセルしたときのメッセージ
+    purchaseCancelled: "購入をキャンセルしました",
     // BGM 再生に失敗したときのエラーメッセージ
     playbackFailure: "BGM の再生に失敗しました",
     // 広告表示に失敗したときのエラーメッセージ
@@ -154,6 +156,8 @@ const messages = {
     watchAdForReveal: "Watch an ad to reveal again",
     removeAds: "Remove Ads",
     restorePurchase: "Restore Purchase",
+    // Message shown when user cancels the purchase flow
+    purchaseCancelled: "Purchase cancelled",
     // Message shown when BGM playback fails
     playbackFailure: "Failed to play BGM",
     // Message shown when ad display fails


### PR DESCRIPTION
## Summary
- show snackbar when purchase cancelled
- add purchaseCancelled translation in ja/en

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68895a5b2be8832c9fffde4680b5c9a8