### PR TITLE
Set default volumes to 5

### DIFF
--- a/src/audio/BgmProvider.tsx
+++ b/src/audio/BgmProvider.tsx
@@ -33,7 +33,8 @@ export function BgmProvider({ children }: { children: ReactNode }) {
   const playerRef = useRef<AudioPlayer | null>(null);
   // 現在再生中の BGM ファイル番号を保持
   const currentFileRef = useRef<number | null>(null);
-  const [volume, setVolume] = useState(1);
+  // デフォルト音量は 5(0.5) とする
+  const [volume, setVolume] = useState(0.5);
   const [ready, setReady] = useState(false);
   const handleError = useHandleError();
   const { t } = useLocale();

--- a/src/audio/SeVolumeProvider.tsx
+++ b/src/audio/SeVolumeProvider.tsx
@@ -18,7 +18,8 @@ const SeVolumeContext = createContext<SeVolumeContextValue | undefined>(undefine
 const STORAGE_KEY = 'seVolume';
 
 export function SeVolumeProvider({ children }: { children: ReactNode }) {
-  const [volume, setVolume] = useState(1);
+  // デフォルト音量は 5(0.5) に設定
+  const [volume, setVolume] = useState(0.5);
   const handleError = useHandleError();
 
   // 初期表示時に保存済みの音量を読み込む


### PR DESCRIPTION
## Summary
- set BGM default volume to 5
- set SE default volume to 5

## Testing
- `pnpm lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68896d2ef758832c8f5baa263d1ce7a6