### PR TITLE
Fix remove ads restore

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -47,7 +47,8 @@ export default function TitleScreen() {
   const [hasSave, setHasSave] = React.useState(false);
 
   // 広告削除購入処理を提供するフック
-  const { purchase } = useRemoveAds();
+  // 広告削除購入済みフラグと購入処理
+  const { adsRemoved, purchase } = useRemoveAds();
 
   // 広告削除を購入する処理
   const handlePurchase = async () => {
@@ -258,11 +259,14 @@ export default function TitleScreen() {
           accessibilityLabel={t("openHowToPlay")}
         />
         {/* ホーム画面にも広告削除オプションを表示 */}
-        <PlainButton
-          title={t("removeAds")}
-          onPress={handlePurchase}
-          accessibilityLabel={t("removeAds")}
-        />
+        {/* 購入済みならボタンを非表示にする */}
+        {!adsRemoved && (
+          <PlainButton
+            title={t("removeAds")}
+            onPress={handlePurchase}
+            accessibilityLabel={t("removeAds")}
+          />
+        )}
 
         {/* デバッグ用に表示していた広告IDは本番では不要なため削除 */}
       </ScrollView>


### PR DESCRIPTION
## Summary
- load purchase flag from AsyncStorage at app launch
- fetch previous purchases only when IAP is connected

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68897130244c832cb72c0c2947e0db5b