### PR TITLE
Improve purchase messages

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -54,7 +54,8 @@ export default function TitleScreen() {
   const handlePurchase = async () => {
     try {
       await purchase();
-      showSnackbar(t("removeAds"));
+      // 購入成功を通知するメッセージを表示
+      showSnackbar(t("purchaseSuccess"));
     } catch (e) {
       // ユーザーが購入処理を途中でキャンセルした場合はエラー扱いしない
       if ((e as { code?: string }).code === ErrorCode.E_USER_CANCELLED) {

--- a/app/options.tsx
+++ b/app/options.tsx
@@ -41,7 +41,8 @@ export default function OptionsScreen() {
   const handleRestore = async () => {
     try {
       await restore();
-      showSnackbar(t('restorePurchase'));
+      // 復元成功を通知するメッセージを表示
+      showSnackbar(t('restoreSuccess'));
     } catch (e) {
       handleError('復元に失敗しました', e);
     }

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -63,6 +63,10 @@ const messages = {
     watchAdForReveal: "広告を見るともう一度全表示できます",
     removeAds: "広告を削除する",
     restorePurchase: "購入を復元する",
+    // 購入完了時に表示するメッセージ
+    purchaseSuccess: "広告削除を購入しました",
+    // 復元完了時に表示するメッセージ
+    restoreSuccess: "購入情報を復元しました",
     // 購入をキャンセルしたときのメッセージ
     purchaseCancelled: "購入をキャンセルしました",
     // BGM 再生に失敗したときのエラーメッセージ
@@ -156,6 +160,10 @@ const messages = {
     watchAdForReveal: "Watch an ad to reveal again",
     removeAds: "Remove Ads",
     restorePurchase: "Restore Purchase",
+    // Message shown when purchase completes successfully
+    purchaseSuccess: "Ad removal purchased",
+    // Message shown when restore completes successfully
+    restoreSuccess: "Purchase restored",
     // Message shown when user cancels the purchase flow
     purchaseCancelled: "Purchase cancelled",
     // Message shown when BGM playback fails


### PR DESCRIPTION
## Summary
- add success messages for ad removal purchase/restore
- show the new messages after user purchases or restores

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68898dae475c832cba153a7cee26dbfb