### PR TITLE
広告削除復元処理の改善

### DIFF
--- a/app/options.tsx
+++ b/app/options.tsx
@@ -11,7 +11,7 @@ import { UI } from '@/constants/ui';
 import { useHandleError } from '@/src/utils/handleError';
 import { useSnackbar } from '@/src/hooks/useSnackbar';
 // 広告削除機能
-import { useRemoveAds } from '@/src/iap/removeAds';
+import { useRemoveAds, isAdsRemoved } from '@/src/iap/removeAds';
 
 export default function OptionsScreen() {
   const router = useRouter();
@@ -40,9 +40,18 @@ export default function OptionsScreen() {
   // 購入済み情報を復元する処理
   const handleRestore = async () => {
     try {
-      await restore();
-      // 復元成功を通知するメッセージを表示
-      showSnackbar(t('restoreSuccess'));
+      // 購入履歴の取得結果を受け取る
+      const result = await restore();
+      // 復元後のフラグを参照してメッセージを切り替え
+      if (result && isAdsRemoved()) {
+        showSnackbar(t('restoreSuccess'));
+      } else if (isAdsRemoved()) {
+        // result が false でもフラグが立っていれば成功扱い
+        showSnackbar(t('restoreSuccess'));
+      } else {
+        // 購入情報が見つからない場合はこちら
+        showSnackbar(t('purchaseNotFound'));
+      }
     } catch (e) {
       handleError('復元に失敗しました', e);
     }

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -67,6 +67,8 @@ const messages = {
     purchaseSuccess: "広告削除を購入しました",
     // 復元完了時に表示するメッセージ
     restoreSuccess: "購入情報を復元しました",
+    // 復元対象が見つからなかったときのメッセージ
+    purchaseNotFound: "購入履歴が見つかりませんでした",
     // 購入をキャンセルしたときのメッセージ
     purchaseCancelled: "購入をキャンセルしました",
     // BGM 再生に失敗したときのエラーメッセージ
@@ -164,6 +166,8 @@ const messages = {
     purchaseSuccess: "Ad removal purchased",
     // Message shown when restore completes successfully
     restoreSuccess: "Purchase restored",
+    // Shown when no purchases were found to restore
+    purchaseNotFound: "No purchases to restore",
     // Message shown when user cancels the purchase flow
     purchaseCancelled: "Purchase cancelled",
     // Message shown when BGM playback fails


### PR DESCRIPTION
## Summary
- 購入復元後の状態確認を追加
- 復元対象が無い場合のメッセージを追加
- restore() で復元有無を boolean 返却

## Testing
- `npx expo lint --max-warnings=0`


------
https://chatgpt.com/codex/tasks/task_e_6889b4db3304832cb35b6f677a95f670