### PR TITLE
fix: finishTransaction 成功後にフラグ更新

### DIFF
--- a/src/iap/removeAds.tsx
+++ b/src/iap/removeAds.tsx
@@ -110,11 +110,12 @@ export function RemoveAdsProvider({ children }: { children: ReactNode }) {
         try {
           // 購入が完了したらトランザクションを終了
           await finishTransaction({ purchase: currentPurchase });
+          // 正常終了したらフラグを更新
+          setAdsRemoved(true);
+          await AsyncStorage.setItem(STORAGE_KEY, "true").catch(() => {});
         } catch {
-          // 失敗してもエラーにはしない
+          // ログに残すなど (UI は落とさない)
         }
-        setAdsRemoved(true);
-        await AsyncStorage.setItem(STORAGE_KEY, "true").catch(() => {});
       })();
     }
   }, [currentPurchase, finishTransaction]);


### PR DESCRIPTION
## Summary
- `RemoveAdsProvider` の購入処理を更新
- `finishTransaction` 成功時のみ `adsRemoved` を更新するよう変更

## Testing
- `pnpm lint` *(failed: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_6889c65c9874832c9ec8fde07926a486