### PR TITLE
Add debug info for removeAds

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -24,7 +24,8 @@ import { useResultState } from "@/src/hooks/useResultState";
 import { useRunRecords } from "@/src/hooks/useRunRecords";
 import { useHandleError } from "@/src/utils/handleError";
 // 広告削除課金機能
-import { useRemoveAds } from "@/src/iap/removeAds";
+import { useRemoveAds, isAdsRemoved } from "@/src/iap/removeAds";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 // EXPO_PUBLIC_UNLOCK_ALL_LEVELS が 'true' のとき
 // クリア状況に関わらず全難易度を選択可能にする
@@ -45,6 +46,8 @@ export default function TitleScreen() {
 
   const [showLang, setShowLang] = React.useState(false);
   const [hasSave, setHasSave] = React.useState(false);
+  // AsyncStorage に保存されている購入済みフラグを確認するための状態
+  const [storedAdsFlag, setStoredAdsFlag] = React.useState<string | null>(null);
 
   // 広告削除購入処理を提供するフック
   // 広告削除購入済みフラグと購入処理
@@ -94,6 +97,19 @@ export default function TitleScreen() {
       setHasSave(!!data);
     })();
   }, [showSnackbar]);
+
+  // 起動直後に AsyncStorage に保存された広告削除フラグを取得
+  // ホーム画面に表示するデバッグ情報用
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem("adsRemoved");
+        setStoredAdsFlag(stored);
+      } catch {
+        // 読み込み失敗時は null のままとする
+      }
+    })();
+  }, []);
 
   const select = (lang: Lang) => {
     changeLang(lang);
@@ -271,6 +287,18 @@ export default function TitleScreen() {
           />
         )}
 
+        {/* 購入フラグのデバッグ表示。完了後に削除する予定 */}
+        <ThemedText
+          lightColor="#fff"
+          darkColor="#fff"
+          style={styles.debug}
+          accessibilityLabel="debug-purchase-state"
+        >
+          {`adsRemoved: ${String(adsRemoved)} / isAdsRemoved: ${String(
+            isAdsRemoved()
+          )} / stored: ${String(storedAdsFlag)}`}
+        </ThemedText>
+
         {/* デバッグ用に表示していた広告IDは本番では不要なため削除 */}
       </ScrollView>
 
@@ -349,5 +377,9 @@ const styles = StyleSheet.create({
   },
   volBtn: {
     padding: 4,
+  },
+  // デバッグ用テキストスタイル
+  debug: {
+    marginTop: 8,
   },
 });


### PR DESCRIPTION
## Summary
- show ads purchase flags on home screen for debugging

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6889ebfe9110832c93eb7fa1cd78f06d