### PR TITLE
修正: IAP購入フロー完了待ち & 復元ロジック改善

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -56,8 +56,9 @@ export default function TitleScreen() {
   // 広告削除を購入する処理
   const handlePurchase = async () => {
     try {
+      // purchase() は購入完了まで解決しない
       await purchase();
-      // 購入成功を通知するメッセージを表示
+      // 完了後に成功メッセージを表示
       showSnackbar(t("purchaseSuccess"));
     } catch (e) {
       // ユーザーが購入処理を途中でキャンセルした場合はエラー扱いしない


### PR DESCRIPTION
## Summary
- IAP購入フローの完了を待ってからメッセージを表示
- 購入復元処理でエラーを握りつぶさないよう変更
- `expo-iap` の購入エラーを検知してPromiseを解決/拒否する

## Testing
- `pnpm lint` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6889f32dcd60832cb13164378c9962a6