### PR TITLE
広告初期化を一フレーム遅らせるよう修正

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -71,7 +71,14 @@ export default function RootLayout() {
         handleError('広告初期化に失敗しました', e);
       }
     }
-    void initAds();
+    // 初回レンダー直後だとダイアログが無視されることがあるため一フレーム遅らせる
+    // requestAnimationFrame で次フレームに処理を移す
+    const id = requestAnimationFrame(() => {
+      // この時点でアプリがアクティブになっているので安全に広告初期化を行える
+      void initAds();
+    });
+    // コンポーネントがアンマウントされた場合に備えてキャンセルを行う
+    return () => cancelAnimationFrame(id);
   }, [handleError]);
 
   if (!loaded) {


### PR DESCRIPTION
## 概要
- requestAnimationFrame を利用して initAds の実行を初回レンダーの次フレームまで遅延
- 初回レンダー直後だとダイアログが無視されることがある旨のコメントを追加

## テスト
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b52f1e4f80832cb60fdf8c4c459e8b