### PR TITLE
feat: ATT ダイアログの英語対応

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -10,9 +10,12 @@ export default ({ config }) => ({
     bundleIdentifier: "com.kokisato.mazesense", // ⾃由に決定（Apple Dev 上でも登録）
     supportsTablet: true,
     // 広告トラッキング許可ダイアログの文言を追加
+    // ↳ iOS の ATT ダイアログで表示されるデフォルト文言（英語）
     infoPlist: {
       ...(appJson.expo.ios?.infoPlist ?? {}),
-      NSUserTrackingUsageDescription: "広告配信のために端末識別子を利用します",
+      // デフォルトは英語。日本語など他言語は app.json の locales で上書きする
+      NSUserTrackingUsageDescription:
+        "We use your device identifier to serve ads",
       // 将来的に音声録音機能を追加する場合は以下も定義する
       // NSMicrophoneUsageDescription: "マイクを使用して音声を録音します"
     },
@@ -46,8 +49,9 @@ export default ({ config }) => ({
         androidAppId: process.env.EXPO_PUBLIC_ANDROID_ADMOB_APP_ID,
         iosAppId: process.env.EXPO_PUBLIC_IOS_ADMOB_APP_ID,
         delayAppMeasurementInit: true,
+        // ATT ダイアログの文言（英語）。日本語は locales で定義
         userTrackingUsageDescription:
-          "広告の最適化のためにデバイスIDを使用します",
+          "We use your device identifier to serve ads",
       },
     ],
   ],

--- a/app.json
+++ b/app.json
@@ -52,6 +52,10 @@
     "experiments": {
       "typedRoutes": true
     },
+    "locales": {
+      "en": "./locales/en.json",
+      "ja": "./locales/ja.json"
+    },
     "extra": {
       "router": {},
       "eas": {}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,3 @@
+{
+  "NSUserTrackingUsageDescription": "We use your device identifier to serve ads"
+}

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,0 +1,3 @@
+{
+  "NSUserTrackingUsageDescription": "広告配信のために端末識別子を利用します"
+}


### PR DESCRIPTION
## Summary
- ATTダイアログの文言を英語と日本語に対応
- ローカライズファイルを追加し`locales`を設定

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba2d887374832c81a8688d07b0ee8b