### PR TITLE
ハイスコアエラーメッセージの多言語対応

### DIFF
--- a/app/scores.tsx
+++ b/app/scores.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Modal, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 
@@ -19,6 +19,14 @@ export default function ScoresScreen() {
   const router = useRouter();
   const { t } = useLocale();
   const { show: showSnackbar } = useSnackbar();
+  // 翻訳キーを受け取りスナックバーに表示するヘルパー
+  const showError = useCallback(
+    (key: MessageKey) => {
+      // useLocale で取得した文言を表示
+      showSnackbar(t(key));
+    },
+    [showSnackbar, t],
+  );
   // レベルIDごとのハイスコアを保持
   const [scores, setScores] = useState<Record<string, HighScore | null>>({});
   // リセット確認モーダルの表示状態
@@ -28,7 +36,7 @@ export default function ScoresScreen() {
   const loadScores = async () => {
     const result: Record<string, HighScore | null> = {};
     for (const lv of LEVELS) {
-      result[lv.id] = await loadHighScore(lv.id, { showError: showSnackbar });
+      result[lv.id] = await loadHighScore(lv.id, { showError });
     }
     setScores(result);
   };
@@ -83,7 +91,7 @@ export default function ScoresScreen() {
               onPress={async () => {
                 await clearAllHighScores(
                   LEVELS.map((l) => l.id),
-                  { showError: showSnackbar },
+                  { showError },
                 );
                 await loadScores();
                 setShowConfirm(false);

--- a/src/game/highScore.ts
+++ b/src/game/highScore.ts
@@ -1,4 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+// ロケール用の型をインポート
+import { type MessageKey } from '@/src/locale/LocaleContext';
 
 export interface HighScore {
   stage: number;
@@ -6,14 +8,16 @@ export interface HighScore {
   bumps: number;
 }
 
+// AsyncStorage に保存する際のキーの接頭辞
 const PREFIX = 'highscore:';
 
 /**
- * ハイスコアを取得する非同期関数。
- * データが無い場合は null を返す。
+ * 各関数で共通的に利用するオプション
+ * エラー表示用に翻訳キーを渡すコールバックを受け取る
  */
 export interface HighScoreOptions {
-  showError?: (msg: string) => void;
+  // `MessageKey` を受け取り呼び出し元で翻訳して表示する
+  showError?: (key: MessageKey) => void;
 }
 
 export async function loadHighScore(
@@ -25,7 +29,8 @@ export async function loadHighScore(
     return json ? (JSON.parse(json) as HighScore) : null;
   } catch (e) {
     console.error('loadHighScore error', e);
-    opts?.showError?.('ハイスコアを読み込めませんでした');
+    // 翻訳キーを渡してエラーメッセージを表示
+    opts?.showError?.('loadHighScoreFailure');
     return null;
   }
 }
@@ -42,7 +47,8 @@ export async function saveHighScore(
     await AsyncStorage.setItem(PREFIX + levelId, JSON.stringify(score));
   } catch (e) {
     console.error('saveHighScore error', e);
-    opts?.showError?.('ハイスコアを保存できませんでした');
+    // 保存に失敗した場合も翻訳キーを返す
+    opts?.showError?.('saveHighScoreFailure');
   }
 }
 
@@ -71,6 +77,7 @@ export async function clearAllHighScores(
     await AsyncStorage.multiRemove(keys);
   } catch (e) {
     console.error('clearAllHighScores error', e);
-    opts?.showError?.('ハイスコアを削除できませんでした');
+    // 削除失敗時のエラーも翻訳キーで通知
+    opts?.showError?.('clearHighScoresFailure');
   }
 }

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -75,6 +75,12 @@ const messages = {
     playbackFailure: "BGM の再生に失敗しました",
     // 広告表示に失敗したときのエラーメッセージ
     adDisplayFailure: "広告を表示できませんでした",
+    // ハイスコア読込に失敗したときのエラーメッセージ
+    loadHighScoreFailure: "ハイスコアを読み込めませんでした",
+    // ハイスコア保存に失敗したときのエラーメッセージ
+    saveHighScoreFailure: "ハイスコアを保存できませんでした",
+    // ハイスコア削除に失敗したときのエラーメッセージ
+    clearHighScoresFailure: "ハイスコアを削除できませんでした",
     nextStage: "次のステージへ",
     goGameResult: "ゲームリザルトへ進む",
     gameResults: "ゲームリザルト",
@@ -174,6 +180,12 @@ const messages = {
     playbackFailure: "Failed to play BGM",
     // Message shown when ad display fails
     adDisplayFailure: "Failed to show ad",
+    // Error message when loading high scores fails
+    loadHighScoreFailure: "Failed to load high score",
+    // Error message when saving high scores fails
+    saveHighScoreFailure: "Failed to save high score",
+    // Error message when clearing high scores fails
+    clearHighScoresFailure: "Failed to clear high scores",
     nextStage: "Next stage",
     goGameResult: "View Game Results",
     gameResults: "Game Results",


### PR DESCRIPTION
## Summary
- ハイスコア処理のエラーメッセージを翻訳キー化
- ロケール定義にハイスコア関連のエラー文言を追加
- `useLocale` 経由でエラーメッセージを取得しスナックバー表示に対応

## Testing
- `pnpm lint`
- `pnpm test` *(jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba43595138832cb186dcac45da8301