### PR TITLE
feat: loadMaze のエラー文言を翻訳対応

### DIFF
--- a/src/game/__tests__/loadMaze.test.ts
+++ b/src/game/__tests__/loadMaze.test.ts
@@ -28,10 +28,15 @@ describe('loadMaze', () => {
   test('無効なサイズはエラーを出して 10 を返す', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation();
     const showError = jest.fn();
+    // エラーメッセージ取得用のダミー関数
+    const t = jest
+      .fn()
+      .mockReturnValue('迷路サイズは 5 または 10 を指定してください');
 
-    const maze = loadMaze(7, { showError });
+    const maze = loadMaze(7, { showError, t });
 
     expect(spy).toHaveBeenCalled();
+    expect(t).toHaveBeenCalledWith('invalidMazeSize');
     expect(showError).toHaveBeenCalledWith('迷路サイズは 5 または 10 を指定してください');
     expect(maze.size).toBe(10);
 

--- a/src/game/loadMaze.ts
+++ b/src/game/loadMaze.ts
@@ -1,10 +1,13 @@
 // mazeAsset.ts から迷路セットを読み込む
 import { mazeSet5, mazeSet10 } from './mazeAsset';
 import type { MazeData } from '@/src/types/maze';
+import type { MessageKey } from '@/src/locale/LocaleContext';
 
 export interface LoadMazeOptions {
   /** エラー時に呼び出されるコールバック */
   showError?: (msg: string) => void;
+  /** 現在の言語に応じた文言を取得するための関数 */
+  t?: (key: MessageKey) => string;
 }
 
 // IIFE でプール配列と操作関数を閉じ込める
@@ -21,7 +24,11 @@ const { loadMaze, resetMazePools } = (() => {
     // 5 でも 10 でもない場合はエラー扱い
     if (size !== 5 && size !== 10) {
       console.error('loadMaze: invalid size', size);
-      opts.showError?.('迷路サイズは 5 または 10 を指定してください');
+      // 翻訳関数が渡されていればキーから文言を取得する
+      const msg = opts.t
+        ? opts.t('invalidMazeSize')
+        : '迷路サイズは 5 または 10 を指定してください';
+      opts.showError?.(msg);
       // 初心者向け: 不正な値はデフォルトの10に置き換える
       size = 10;
     }

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -115,6 +115,8 @@ const messages = {
     player: "プレイヤーの現在位置",
     Goal: "挑戦中ステージのゴール地点",
     visitedGoals: "過去に到達したゴール地点",
+    // loadMaze でサイズが不正なときのエラーメッセージ
+    invalidMazeSize: "迷路サイズは 5 または 10 を指定してください",
   },
   en: {
     practiceMode: "Practice Mode",
@@ -214,6 +216,8 @@ const messages = {
     player: "Your current position",
     Goal: "Goal position for the current stage",
     visitedGoals: "Previously reached goal positions",
+    // Error when an invalid maze size is specified in loadMaze
+    invalidMazeSize: "Maze size must be 5 or 10",
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- loadMaze の迷路サイズエラーを翻訳キー化し、翻訳関数に対応
- ロケール定義へ invalidMazeSize を追加
- テストを翻訳対応の仕様に合わせて更新

## Testing
- `pnpm lint`
- `pnpm test` *(jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba435a4960832ca5cf8c53eab01615