### PR TITLE
fix: 英語メッセージの誤りを修正

### DIFF
--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -120,15 +120,17 @@ const messages = {
     practiceMode: "Practice Mode",
     openPractice: "Open Practice",
     tutorial: "Tutorial",
-    easy: "Easy ★☆☆ updatetest",
+    // 難易度の名称（Easy）
+    easy: "Easy ★☆☆",
     normal: "Normal ★★☆",
     hard: "Hard ★★★",
     startLevel: "Start {{name}}",
     enemyRandom: "Normal Random",
     enemySlow: "Slow Vision",
     enemySight: "Normal Vision",
-    enemyPathLen: "Enemy Path",
-    playerPathLen: "Player Path",
+    // 軌跡長関連
+    enemyPathLen: "Enemy Path Length",
+    playerPathLen: "Player Path Length",
     wallDuration: "Wall Lifetime",
     startMazeSize: "Start {{size}} maze",
     increase: "Increase {{label}}",
@@ -138,8 +140,9 @@ const messages = {
     resetMaze: "Reset Maze",
     resetMazeLabel: "Reset maze",
     showAll: "Show All",
-    showMazeAll: "Show whole maze",
-    hideMazeAll: "Hide whole maze",
+    // 迷路全体の表示切替
+    showMazeAll: "Show entire maze",
+    hideMazeAll: "Hide entire maze",
     gameClear: "Game Clear",
     gameOver: "Game Over",
     goal: "Goal!",
@@ -151,7 +154,8 @@ const messages = {
     highScores: "High Scores",
     openHighScores: "View High Scores",
     options: "Options",
-    openOptions: "Open settings",
+    // 設定画面を開くボタン
+    openOptions: "Open Settings",
     volumeSettings: "Volume Settings",
     noRecord: "No record",
     // Message shown when a new high score is achieved
@@ -192,9 +196,9 @@ const messages = {
     backToTitle: "Back to title",
     continue: "Continue",
     startFromBegin: "{{name}}",
-    needClearEasy: "Easy not cleared",
-    needClearNormal: "Normal not cleared",
-    confirmReset: "Delete saved game and start new?",
+    needClearEasy: "Easy level not cleared",
+    needClearNormal: "Normal level not cleared",
+    confirmReset: "Delete saved game and start a new one?",
     confirmResetHighScores: "Delete all high scores?",
     resetHighScores: "Reset High Scores",
     suspendInfo: "Level: {{level}} / Stage: {{stage}}",
@@ -205,8 +209,9 @@ const messages = {
     openHowToPlay: "Open How to Play",
     ruleIntro:
       "The icons below have the following meanings.",
+    // リスポーン機能の説明
     respawnUsage:
-      "Respawns enemy positions\nUse when you're in a pinch",
+      "Respawn enemy positions\nUse when you're in a pinch",
     revealUsage:
       "Reveals the entire maze\nBe careful, this makes the stage much easier",
     // Enemies の説明


### PR DESCRIPTION
## Summary
- remove leftover text from Easy mode label
- fix typos in English messages and add Japanese comments

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba435be094832c843a25ccaaaa5cec