### PR TITLE
feat: エラーログ未存在時の文言を追加

### DIFF
--- a/app/error-logs.tsx
+++ b/app/error-logs.tsx
@@ -41,8 +41,9 @@ export default function ErrorLogsScreen() {
           </ThemedText>
         ))}
         {logs.length === 0 && (
+          // ログが一件も存在しない場合に表示するテキスト
           <ThemedText lightColor="#fff" darkColor="#fff">
-            ログはありません
+            {t('noLogs')}
           </ThemedText>
         )}
         <PlainButton

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -148,6 +148,8 @@ const ja = {
     visitedGoalIcon: "訪問済みゴール",
     resetConfirmOverlay: "リセット確認オーバーレイ",
     errorLogs: "エラーログ一覧",
+    // エラーログが存在しない場合に表示するメッセージ
+    noLogs: "ログはありません",
     // loadMaze でサイズが不正なときのエラーメッセージ
     invalidMazeSize: "迷路サイズは 5 または 10 を指定してください",
   } as const;
@@ -296,6 +298,8 @@ const en = {
     visitedGoalIcon: "Visited goal",
     resetConfirmOverlay: "Reset confirmation overlay",
     errorLogs: "Error logs",
+    // エラーログが存在しない場合に表示するテキスト
+    noLogs: "No logs",
     // Error when an invalid maze size is specified in loadMaze
     invalidMazeSize: "Maze size must be 5 or 10",
   } as const satisfies Messages;


### PR DESCRIPTION
## Summary
- add noLogs translation for Japanese and English
- show translation when no error logs are available

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba5ee78eb8832cb6f2e8e412229f8c