### PR TITLE
BGM音量関連エラー文言のローカライズ対応

### DIFF
--- a/src/audio/BgmProvider.tsx
+++ b/src/audio/BgmProvider.tsx
@@ -46,10 +46,11 @@ export function BgmProvider({ children }: { children: ReactNode }) {
         const stored = await AsyncStorage.getItem(STORAGE_KEY);
         if (stored !== null) setVolume(Number(stored));
       } catch (e) {
-        handleError('BGM 音量を読み込めませんでした', e);
+        // 読み込みに失敗した場合はローカライズされたエラーメッセージを表示
+        handleError(t('loadBgmVolumeFailure'), e);
       }
     })();
-  }, [handleError]);
+  }, [handleError, t]);
 
   // 音量が変わったら保存する
   useEffect(() => {
@@ -57,10 +58,11 @@ export function BgmProvider({ children }: { children: ReactNode }) {
       try {
         await AsyncStorage.setItem(STORAGE_KEY, String(volume));
       } catch (e) {
-        handleError('BGM 音量を保存できませんでした', e);
+        // 保存に失敗した場合はローカライズされたエラーメッセージを表示
+        handleError(t('saveBgmVolumeFailure'), e);
       }
     })();
-  }, [volume, handleError]);
+  }, [volume, handleError, t]);
 
   // 一定時間待つためのユーティリティ
   const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -92,8 +94,8 @@ export function BgmProvider({ children }: { children: ReactNode }) {
       try {
         await setAudioModeAsync({ playsInSilentMode: true });
       } catch (e) {
-        // 設定に失敗した場合はユーザーへ通知し詳細をログ出力
-        handleError("オーディオ設定に失敗しました", e);
+        // オーディオ設定に失敗した場合はローカライズされたメッセージで通知
+        handleError(t('audioModeFailure'), e);
       } finally {
         setReady(true);
       }
@@ -101,7 +103,7 @@ export function BgmProvider({ children }: { children: ReactNode }) {
     return () => {
       playerRef.current?.remove();
     };
-  }, [handleError]);
+  }, [handleError, t]);
 
   useEffect(() => {
     if (playerRef.current) playerRef.current.volume = volume;

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -75,6 +75,12 @@ const ja = {
     purchaseFailure: "購入に失敗しました",
     // 復元処理に失敗したときのエラーメッセージ
     restoreFailure: "復元に失敗しました",
+    // BGM 音量の読み込みに失敗したときのエラーメッセージ
+    loadBgmVolumeFailure: "BGM 音量を読み込めませんでした",
+    // BGM 音量の保存に失敗したときのエラーメッセージ
+    saveBgmVolumeFailure: "BGM 音量を保存できませんでした",
+    // オーディオモードの設定に失敗したときのエラーメッセージ
+    audioModeFailure: "オーディオ設定に失敗しました",
     // BGM 再生に失敗したときのエラーメッセージ
     playbackFailure: "BGM の再生に失敗しました",
     // 広告表示に失敗したときのエラーメッセージ
@@ -220,9 +226,15 @@ const en = {
     purchaseCancelled: "Purchase cancelled",
     // Message shown when purchase fails
     purchaseFailure: "Failed to complete purchase",
-    // Message shown when restore fails
+    // 復元処理に失敗したときのエラーメッセージ
     restoreFailure: "Failed to restore purchase",
-    // Message shown when BGM playback fails
+    // BGM 音量の読み込みに失敗したときのエラーメッセージ
+    loadBgmVolumeFailure: "Failed to load BGM volume",
+    // BGM 音量の保存に失敗したときのエラーメッセージ
+    saveBgmVolumeFailure: "Failed to save BGM volume",
+    // オーディオモードの設定に失敗したときのエラーメッセージ
+    audioModeFailure: "Failed to configure audio mode",
+    // BGM 再生に失敗したときのエラーメッセージ
     playbackFailure: "Failed to play BGM",
     // Message shown when ad display fails
     adDisplayFailure: "Failed to show ad",


### PR DESCRIPTION
## Summary
- add localized messages for BGM volume load/save failures and audio mode failure
- use new locale keys in `BgmProvider`

## Testing
- `pnpm lint`
- `pnpm test` *(jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5eecd040832cbc5c05ae7b587370