### PR TITLE
feat: SE 音量エラーメッセージを多言語化

### DIFF
--- a/src/audio/SeVolumeProvider.tsx
+++ b/src/audio/SeVolumeProvider.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useHandleError } from '@/src/utils/handleError';
+import { useLocale } from '@/src/locale/LocaleContext';
 
 interface SeVolumeContextValue {
   volume: number;
@@ -21,6 +22,8 @@ export function SeVolumeProvider({ children }: { children: ReactNode }) {
   // デフォルト音量は 5(0.5) に設定
   const [volume, setVolume] = useState(0.5);
   const handleError = useHandleError();
+  // 翻訳関数 t を取得
+  const { t } = useLocale();
 
   // 初期表示時に保存済みの音量を読み込む
   useEffect(() => {
@@ -29,10 +32,11 @@ export function SeVolumeProvider({ children }: { children: ReactNode }) {
         const stored = await AsyncStorage.getItem(STORAGE_KEY);
         if (stored !== null) setVolume(Number(stored));
       } catch (e) {
-        handleError('SE 音量を読み込めませんでした', e);
+        // SE 音量の読み込みに失敗した場合は翻訳メッセージを表示
+        handleError(t('loadSeVolumeFailure'), e);
       }
     })();
-  }, [handleError]);
+  }, [handleError, t]);
 
   // 音量変更時は値を保存する
   useEffect(() => {
@@ -40,10 +44,11 @@ export function SeVolumeProvider({ children }: { children: ReactNode }) {
       try {
         await AsyncStorage.setItem(STORAGE_KEY, String(volume));
       } catch (e) {
-        handleError('SE 音量を保存できませんでした', e);
+        // SE 音量の保存に失敗した場合は翻訳メッセージを表示
+        handleError(t('saveSeVolumeFailure'), e);
       }
     })();
-  }, [volume, handleError]);
+  }, [volume, handleError, t]);
 
   return (
     <SeVolumeContext.Provider value={{ volume, setVolume }}>

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -83,6 +83,10 @@ const ja = {
     adInitFailure: "広告初期化に失敗しました",
     // 追跡許可の再取得に失敗したときのエラーメッセージ
     trackingPermissionFailure: "追跡許可の再取得に失敗しました",
+    // SE 音量読込に失敗したときのエラーメッセージ
+    loadSeVolumeFailure: "SE 音量を読み込めませんでした",
+    // SE 音量保存に失敗したときのエラーメッセージ
+    saveSeVolumeFailure: "SE 音量を保存できませんでした",
     // ハイスコア読込に失敗したときのエラーメッセージ
     loadHighScoreFailure: "ハイスコアを読み込めませんでした",
     // ハイスコア保存に失敗したときのエラーメッセージ
@@ -230,6 +234,10 @@ const en = {
     adInitFailure: "Failed to initialize ads",
     // Message shown when re-checking tracking permission fails
     trackingPermissionFailure: "Failed to re-check tracking permission",
+    // SE 音量読込に失敗したときのエラーメッセージ
+    loadSeVolumeFailure: "Failed to load SE volume",
+    // SE 音量保存に失敗したときのエラーメッセージ
+    saveSeVolumeFailure: "Failed to save SE volume",
     // Error message when loading high scores fails
     loadHighScoreFailure: "Failed to load high score",
     // Error message when saving high scores fails


### PR DESCRIPTION
## Summary
- add translation keys for SE volume load/save errors
- replace hard-coded SE volume error messages with localized versions

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68ba5ef0b6f0832ca16cdc7319573413