### PR TITLE
進行状況保存・読込エラーの翻訳対応

### DIFF
--- a/src/hooks/useLevelUnlock.ts
+++ b/src/hooks/useLevelUnlock.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useHandleError } from '@/src/utils/handleError';
+// 多言語対応のための翻訳フック
+import { useLocale } from '@/src/locale/LocaleContext';
 
 /**
  * レベルクリア状況を管理するフック。
@@ -14,6 +16,8 @@ const STORAGE_KEY = 'clearedLevels';
 
 export function useLevelUnlock() {
   const handleError = useHandleError();
+  // 文言取得用の関数 t を利用
+  const { t } = useLocale();
   const [unlocked, setUnlocked] = useState<UnlockMap>({});
 
   // 初回読み込み時に保存データを取得する
@@ -23,10 +27,11 @@ export function useLevelUnlock() {
         const json = await AsyncStorage.getItem(STORAGE_KEY);
         if (json) setUnlocked(JSON.parse(json) as UnlockMap);
       } catch (e) {
-        handleError('進行状況を読み込めませんでした', e);
+        // 進行状況を読めなかった場合は多言語メッセージを表示
+        handleError(t('loadProgressFailure'), e);
       }
     })();
-  }, [handleError]);
+  }, [handleError, t]);
 
   /**
    * レベルクリアを記録して永続化する。
@@ -38,10 +43,11 @@ export function useLevelUnlock() {
       try {
         await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
       } catch (e) {
-        handleError('進行状況を保存できませんでした', e);
+        // 進行状況の保存に失敗した場合の通知
+        handleError(t('saveProgressFailure'), e);
       }
     },
-    [unlocked, handleError],
+    [unlocked, handleError, t],
   );
 
   /**

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -89,6 +89,10 @@ const ja = {
     saveHighScoreFailure: "ハイスコアを保存できませんでした",
     // ハイスコア削除に失敗したときのエラーメッセージ
     clearHighScoresFailure: "ハイスコアを削除できませんでした",
+    // 進行状況読込に失敗したときのエラーメッセージ
+    loadProgressFailure: "進行状況を読み込めませんでした",
+    // 進行状況保存に失敗したときのエラーメッセージ
+    saveProgressFailure: "進行状況を保存できませんでした",
     nextStage: "次のステージへ",
     goGameResult: "ゲームリザルトへ進む",
     gameResults: "ゲームリザルト",
@@ -236,6 +240,10 @@ const en = {
     saveHighScoreFailure: "Failed to save high score",
     // Error message when clearing high scores fails
     clearHighScoresFailure: "Failed to clear high scores",
+    // Error message when loading progress fails
+    loadProgressFailure: "Failed to load progress",
+    // Error message when saving progress fails
+    saveProgressFailure: "Failed to save progress",
     nextStage: "Next stage",
     goGameResult: "View Game Results",
     gameResults: "Game Results",


### PR DESCRIPTION
## 概要
- 進行状況の保存/読込失敗メッセージを多言語化
- レベル解放処理で翻訳メッセージを利用

## テスト
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba5ef468e0832c96b04a154eb7a418