### PR TITLE
feat: add translations for score load/save errors

### DIFF
--- a/src/hooks/useRunRecords.ts
+++ b/src/hooks/useRunRecords.ts
@@ -8,6 +8,8 @@ import React, {
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useHandleError } from '@/src/utils/handleError';
+// 翻訳関数を利用するため LocaleContext から取得
+import { useLocale } from '@/src/locale/LocaleContext';
 
 /**
  * 1 ステージ分の記録を表すインターフェース
@@ -54,6 +56,8 @@ export function RunRecordProvider({ children }: { children: ReactNode }) {
   const [reveals, setReveals] = useState(0);
   // 例外表示用の共通ハンドラ
   const handleError = useHandleError();
+  // ローカライズされた文言を取得する関数
+  const { t } = useLocale();
 
   // 初回マウント時に保存済みのデータを読み込む
   useEffect(() => {
@@ -67,10 +71,11 @@ export function RunRecordProvider({ children }: { children: ReactNode }) {
           setReveals(data.reveals ?? 0);
         }
       } catch (e) {
-        handleError('スコアデータを読み込めませんでした', e);
+        // スコアデータの読込に失敗した場合の処理
+        handleError(t('loadScoreFailure'), e);
       }
     })();
-  }, [handleError]);
+  }, [handleError, t]);
 
   // データが変化するたびに保存する
   useEffect(() => {
@@ -79,10 +84,11 @@ export function RunRecordProvider({ children }: { children: ReactNode }) {
         const data: StoredData = { records, respawns, reveals };
         await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
       } catch (e) {
-        handleError('スコアデータを保存できませんでした', e);
+        // スコアデータの保存に失敗した場合の処理
+        handleError(t('saveScoreFailure'), e);
       }
     })();
-  }, [records, respawns, reveals, handleError]);
+  }, [records, respawns, reveals, handleError, t]);
 
   /**
    * ステージクリア時に記録を追加する処理

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -83,6 +83,10 @@ const ja = {
     adInitFailure: "広告初期化に失敗しました",
     // 追跡許可の再取得に失敗したときのエラーメッセージ
     trackingPermissionFailure: "追跡許可の再取得に失敗しました",
+    // スコアデータ読込に失敗したときのエラーメッセージ
+    loadScoreFailure: "スコアデータを読み込めませんでした",
+    // スコアデータ保存に失敗したときのエラーメッセージ
+    saveScoreFailure: "スコアデータを保存できませんでした",
     // ハイスコア読込に失敗したときのエラーメッセージ
     loadHighScoreFailure: "ハイスコアを読み込めませんでした",
     // ハイスコア保存に失敗したときのエラーメッセージ
@@ -230,6 +234,10 @@ const en = {
     adInitFailure: "Failed to initialize ads",
     // Message shown when re-checking tracking permission fails
     trackingPermissionFailure: "Failed to re-check tracking permission",
+    // スコアデータ読込に失敗したときのエラーメッセージ
+    loadScoreFailure: "Failed to load score data",
+    // スコアデータ保存に失敗したときのエラーメッセージ
+    saveScoreFailure: "Failed to save score data",
     // Error message when loading high scores fails
     loadHighScoreFailure: "Failed to load high score",
     // Error message when saving high scores fails


### PR DESCRIPTION
## Summary
- add `loadScoreFailure` and `saveScoreFailure` translations
- use translations in `useRunRecords` error handling

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba5efb71c0832cac7c16ba5363a5cc