### PR TITLE
fix: usePlayLogicの広告表示エラーを翻訳キーへ変更

### DIFF
--- a/src/hooks/usePlayLogic.ts
+++ b/src/hooks/usePlayLogic.ts
@@ -7,6 +7,8 @@ import { showInterstitial, DISABLE_ADS } from '@/src/ads/interstitial';
 // 広告削除購入済みか判定するユーティリティ
 import { useRemoveAds } from '@/src/iap/removeAds';
 import { useHandleError } from '@/src/utils/handleError';
+// 国際化された文字列を取得するフック
+import { useLocale } from '@/src/locale/LocaleContext';
 
 import { useGame } from '@/src/game/useGame';
 import { useSnackbar } from '@/src/hooks/useSnackbar';
@@ -25,6 +27,8 @@ export function usePlayLogic() {
   const { show: showSnackbar } = useSnackbar();
   // 広告削除状態を取得
   const { adsRemoved } = useRemoveAds();
+  // 翻訳用の関数を取得
+  const { t } = useLocale();
 
   // BGM・SE 操作は専用フックに委譲
   const audio = useAudioControls(
@@ -75,7 +79,8 @@ export function usePlayLogic() {
           if (needMute) audio.pauseBgm();
           await showInterstitial();
         } catch (e) {
-          handleError('広告を表示できませんでした', e);
+          // 翻訳キーからエラーメッセージを取得して通知
+          handleError(t('adDisplayFailure'), e);
         } finally {
           if (needMute) audio.resumeBgm();
         }


### PR DESCRIPTION
## Summary
- `handleRespawn` 内の広告表示失敗メッセージを翻訳キー `t('adDisplayFailure')` に統一
- `useLocale` を導入して国際化メッセージを取得

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f0659f8832ca0ca061e506926e8