### PR TITLE
予期せぬエラー文言の追加とハンドラの翻訳対応

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -57,9 +57,10 @@ function RootLayoutInner() {
 
   // アプリ全体のエラーハンドラを設定
   useEffect(() => {
-    initGlobalErrorHandler(showSnackbar);
-    initUnhandledRejectionHandler(showSnackbar);
-  }, [showSnackbar]);
+    // グローバルなエラーハンドラを設定し、翻訳関数を渡す
+    initGlobalErrorHandler(showSnackbar, t);
+    initUnhandledRejectionHandler(showSnackbar, t);
+  }, [showSnackbar, t]);
 
   // ATT 許可を確認してから広告 SDK を初期化
   useEffect(() => {
@@ -135,7 +136,8 @@ function RootLayoutInner() {
   if (!loaded) return null;
 
   return (
-    <ErrorBoundary onError={showSnackbar}>
+    // エラーバウンダリにも翻訳関数を渡して文言を統一
+    <ErrorBoundary onError={showSnackbar} t={t}>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <RemoveAdsProvider>
           <BgmProvider>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import type { MessageKey } from '@/src/locale/LocaleContext';
 import { IS_TESTFLIGHT } from '@/src/utils/appEnv';
 
 interface ErrorBoundaryProps {
   /** エラー発生時に呼び出されるコールバック */
   onError: (msg: string) => void;
+  /** 翻訳関数。エラーメッセージ表示に利用 */
+  t: (key: MessageKey) => string;
   children?: React.ReactNode;
 }
 
@@ -27,9 +30,9 @@ export class ErrorBoundary extends React.Component<
     // 詳細をコンソールに出力しデバッグしやすくする
     console.error(error, info);
     // TestFlight ではエラー詳細を通知
-    const msg = IS_TESTFLIGHT
-      ? String(error)
-      : '予期せぬエラーが発生しました';
+      const msg = IS_TESTFLIGHT
+        ? String(error)
+        : this.props.t('unexpectedError');
     this.props.onError(msg);
     // フォールバック UI を表示するためフラグを立てる
     this.setState({ hasError: true });
@@ -40,7 +43,7 @@ export class ErrorBoundary extends React.Component<
       // シンプルなエラーメッセージだけを表示
       return (
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-          <Text>エラーが発生しました</Text>
+          <Text>{this.props.t('unexpectedError')}</Text>
         </View>
       );
     }

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -75,6 +75,8 @@ const ja = {
     purchaseFailure: "購入に失敗しました",
     // 復元処理に失敗したときのエラーメッセージ
     restoreFailure: "復元に失敗しました",
+    // 予期せぬエラー全般のメッセージ
+    unexpectedError: "予期せぬエラーが発生しました",
     // BGM 再生に失敗したときのエラーメッセージ
     playbackFailure: "BGM の再生に失敗しました",
     // 広告表示に失敗したときのエラーメッセージ
@@ -222,6 +224,8 @@ const en = {
     purchaseFailure: "Failed to complete purchase",
     // Message shown when restore fails
     restoreFailure: "Failed to restore purchase",
+    // Generic unexpected error message
+    unexpectedError: "An unexpected error occurred",
     // Message shown when BGM playback fails
     playbackFailure: "Failed to play BGM",
     // Message shown when ad display fails

--- a/src/utils/initGlobalErrorHandler.ts
+++ b/src/utils/initGlobalErrorHandler.ts
@@ -1,4 +1,5 @@
 import type { ErrorUtils as ErrorUtilsType } from 'react-native/Libraries/vendor/core/ErrorUtils';
+import type { MessageKey } from '@/src/locale/LocaleContext';
 import { logError } from './errorLogger';
 import { IS_TESTFLIGHT } from './appEnv';
 
@@ -8,8 +9,12 @@ import { IS_TESTFLIGHT } from './appEnv';
  * ユーザーへ簡易的なメッセージを表示します。
  *
  * @param showSnackbar スナックバー表示用の関数
+ * @param t            翻訳関数。unexpectedError などの文言取得に使用
  */
-export function initGlobalErrorHandler(showSnackbar: (msg: string) => void) {
+export function initGlobalErrorHandler(
+  showSnackbar: (msg: string) => void,
+  t: (key: MessageKey) => string,
+) {
   // React Native が提供するグローバル ErrorUtils を取得
   const ErrorUtils = global.ErrorUtils as ErrorUtilsType;
   const defaultHandler = ErrorUtils.getGlobalHandler();
@@ -18,7 +23,7 @@ export function initGlobalErrorHandler(showSnackbar: (msg: string) => void) {
     console.error('Unhandled Error', error);
     void logError('Unhandled Error', error);
     // テストフライトでは詳細を表示してデバッグを容易にする
-    const msg = IS_TESTFLIGHT ? String(error) : '予期せぬエラーが発生しました';
+    const msg = IS_TESTFLIGHT ? String(error) : t('unexpectedError');
     showSnackbar(msg);
     defaultHandler(error, isFatal);
   });

--- a/src/utils/initUnhandledRejectionHandler.ts
+++ b/src/utils/initUnhandledRejectionHandler.ts
@@ -1,3 +1,4 @@
+import type { MessageKey } from '@/src/locale/LocaleContext';
 import { logError } from './errorLogger';
 import { IS_TESTFLIGHT } from './appEnv';
 
@@ -5,8 +6,12 @@ import { IS_TESTFLIGHT } from './appEnv';
  * Promise の未処理拒否を捕捉するハンドラを登録します。
  *
  * @param showSnackbar ユーザーへ通知するための関数
+ * @param t            翻訳関数。unexpectedError などの文言取得に使用
  */
-export function initUnhandledRejectionHandler(showSnackbar: (msg: string) => void) {
+export function initUnhandledRejectionHandler(
+  showSnackbar: (msg: string) => void,
+  t: (key: MessageKey) => string,
+) {
   // onunhandledrejection を持つグローバルオブジェクトとして型付け
   const g: typeof globalThis & {
     onunhandledrejection?: (event: PromiseRejectionEvent) => void;
@@ -17,10 +22,10 @@ export function initUnhandledRejectionHandler(showSnackbar: (msg: string) => voi
     // 未処理の Promise 拒否を記録しておく
     console.error('Unhandled Promise Rejection', event.reason);
     void logError('Unhandled Promise Rejection', event.reason);
-    // TestFlight では詳細も通知する
-    const msg = IS_TESTFLIGHT
-      ? String(event.reason)
-      : '予期せぬエラーが発生しました';
+      // TestFlight では詳細も通知する
+      const msg = IS_TESTFLIGHT
+        ? String(event.reason)
+        : t('unexpectedError');
     showSnackbar(msg);
     if (typeof original === 'function') {
       original(event);


### PR DESCRIPTION
## 概要
- unexpectedError を多言語化
- ErrorBoundary などのハンドラで t('unexpectedError') を利用可能に

## テスト
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f1245d0832c90ad54c507f64722