### PR TITLE
fix: loadMaze のエラーメッセージを英語化

### DIFF
--- a/src/game/__tests__/loadMaze.test.ts
+++ b/src/game/__tests__/loadMaze.test.ts
@@ -42,4 +42,18 @@ describe('loadMaze', () => {
 
     spy.mockRestore();
   });
+
+  test('翻訳関数が無い場合は英語メッセージで通知される', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+    const showError = jest.fn();
+
+    // t を渡さずに呼び出した場合、内部のデフォルト関数が英語メッセージを返す
+    const maze = loadMaze(8, { showError });
+
+    expect(spy).toHaveBeenCalled();
+    expect(showError).toHaveBeenCalledWith('Maze size must be 5 or 10');
+    expect(maze.size).toBe(10);
+
+    spy.mockRestore();
+  });
 });

--- a/src/game/loadMaze.ts
+++ b/src/game/loadMaze.ts
@@ -24,10 +24,17 @@ const { loadMaze, resetMazePools } = (() => {
     // 5 でも 10 でもない場合はエラー扱い
     if (size !== 5 && size !== 10) {
       console.error('loadMaze: invalid size', size);
-      // 翻訳関数が渡されていればキーから文言を取得する
-      const msg = opts.t
-        ? opts.t('invalidMazeSize')
-        : '迷路サイズは 5 または 10 を指定してください';
+      // 翻訳関数が渡されなくても必ず t('invalidMazeSize') を利用するため
+      // デフォルトの翻訳関数を用意して英語メッセージを返す
+      const t = opts.t ?? ((key: MessageKey) => {
+        // 想定しているキーは invalidMazeSize のみだが、他のキーが来た場合はそのまま返す
+        if (key === 'invalidMazeSize') {
+          return 'Maze size must be 5 or 10';
+        }
+        return key;
+      });
+      // 上記で用意した t を利用してエラーメッセージを取得する
+      const msg = t('invalidMazeSize');
       opts.showError?.(msg);
       // 初心者向け: 不正な値はデフォルトの10に置き換える
       size = 10;


### PR DESCRIPTION
## Summary
- loadMazeで翻訳関数が無い場合のエラー文言を英語に統一
- 英語フォールバックを検証するテストを追加

## Testing
- `pnpm lint`
- `pnpm test` *(fails: jest: not found)*
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f14987c832c94aa07b0dc174979