### PR TITLE
feat: 404画面の多言語化対応

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -4,15 +4,23 @@ import { StyleSheet } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+// 多言語化のために Locale コンテキストを利用
+import { useLocale } from '@/src/locale/LocaleContext';
 
 export default function NotFoundScreen() {
+  // t 関数で翻訳済みの文言を取得
+  const { t } = useLocale();
+
   return (
     <>
-      <Stack.Screen options={{ title: 'Oops!' }} />
+      {/* 画面タイトルも翻訳キーから取得 */}
+      <Stack.Screen options={{ title: t('notFoundTitle') }} />
       <ThemedView style={styles.container}>
-        <ThemedText type="title">This screen does not exist.</ThemedText>
+        {/* ユーザーに存在しない画面であることを説明 */}
+        <ThemedText type="title">{t('notFoundMessage')}</ThemedText>
         <Link href="/" style={styles.link}>
-          <ThemedText type="link">Go to home screen!</ThemedText>
+          {/* ホーム画面へ戻るリンク */}
+          <ThemedText type="link">{t('goHome')}</ThemedText>
         </Link>
       </ThemedView>
     </>

--- a/src/locale/LocaleContext.tsx
+++ b/src/locale/LocaleContext.tsx
@@ -17,6 +17,12 @@ const STORAGE_KEY = "lang";
 // 画面で表示する文言の定義
 // ja を原文として定義し、この型を基準に他言語をチェックする
 const ja = {
+    // 404 画面で表示するタイトル
+    notFoundTitle: "ページが見つかりません",
+    // 存在しない画面であることを説明する文言
+    notFoundMessage: "この画面は存在しません",
+    // ホーム画面へ戻るリンクのラベル
+    goHome: "ホーム画面に戻る",
     practiceMode: "練習モード",
     openPractice: "練習モードを開く",
     tutorial: "Tutorial",
@@ -194,6 +200,12 @@ export type MessageKey = keyof Messages;
 
 // en は ja と同じキーを持つ必要があるので satisfies を利用
 const en = {
+    // 404 画面で表示するタイトル
+    notFoundTitle: "Oops!",
+    // 画面が見つからない場合のメッセージ
+    notFoundMessage: "This screen does not exist.",
+    // ホーム画面へ戻るリンクのラベル
+    goHome: "Go to home screen!",
     practiceMode: "Practice Mode",
     openPractice: "Open Practice",
     tutorial: "Tutorial",


### PR DESCRIPTION
## Summary
- 404画面の文言をLocaleContext経由で多言語化
- ja/enの翻訳キーを追加

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba6567f318832c88c225acccd1c7ed