### PR TITLE
fix: ATT 許可ダイアログが表示されない問題を修正

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -9,16 +9,8 @@ export default ({ config }) => ({
     ...(appJson.expo.ios ?? {}),
     bundleIdentifier: "com.kokisato.mazesense", // ⾃由に決定（Apple Dev 上でも登録）
     supportsTablet: true,
-    // 広告トラッキング許可ダイアログの文言を追加
-    // ↳ iOS の ATT ダイアログで表示されるデフォルト文言（英語）
-    infoPlist: {
-      ...(appJson.expo.ios?.infoPlist ?? {}),
-      // デフォルトは英語。日本語など他言語は app.json の locales で上書きする
-      NSUserTrackingUsageDescription:
-        "We use your device identifier to serve ads",
-      // 将来的に音声録音機能を追加する場合は以下も定義する
-      // NSMicrophoneUsageDescription: "マイクを使用して音声を録音します"
-    },
+    // NSUserTrackingUsageDescription は app.json で定義し
+    // locales ディレクトリの JSON で多言語化する
   },
   android: {
     ...(appJson.expo.android ?? {}),
@@ -49,9 +41,7 @@ export default ({ config }) => ({
         androidAppId: process.env.EXPO_PUBLIC_ANDROID_ADMOB_APP_ID,
         iosAppId: process.env.EXPO_PUBLIC_IOS_ADMOB_APP_ID,
         delayAppMeasurementInit: true,
-        // ATT ダイアログの文言（英語）。日本語は locales で定義
-        userTrackingUsageDescription:
-          "We use your device identifier to serve ads",
+        // ATT ダイアログの文言は app.json の locales で管理する
       },
     ],
   ],

--- a/app.json
+++ b/app.json
@@ -19,7 +19,8 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "CFBundleDevelopmentRegion": "en",
-        "CFBundleLocalizations": ["en", "ja"]
+        "CFBundleLocalizations": ["en", "ja"],
+        "NSUserTrackingUsageDescription": "We use your device identifier to serve ads"
       }
     },
     "android": {


### PR DESCRIPTION
## Summary
- Info.plist に `NSUserTrackingUsageDescription` を追加
- ATT ダイアログの文言管理を `app.json` と `locales` に移行

## Testing
- `pnpm lint`
- `pnpm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8d877e10832cb2673918407535df